### PR TITLE
Basic commands

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+sudo: false
+cache: bundler
+before_install:
+  - gem update --system
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v 1.14.6
+script: 'bundle exec rake --trace'
+rvm:
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+  - jruby-9.1.8.0
+  - jruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'byebug', require: false
+unless ENV['TRAVIS']
+  gem 'byebug', require: false, platforms: :mri
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-
-# Specify your gem's dependencies in hanami-cli.gemspec
 gemspec
+
+gem 'byebug', require: false

--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/jodosha/hanami-cli.
+Bug reports and pull requests are welcome on GitHub at https://github.com/hanami/cli.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,19 @@
-require "bundler/gem_tasks"
-task :default => :spec
+require 'rake'
+require 'rake/testtask'
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+namespace :spec do
+  RSpec::Core::RakeTask.new(:unit) do |task|
+    file_list = FileList['spec/**/*_spec.rb']
+
+    task.pattern = file_list
+  end
+
+  task :coverage do
+    ENV['COVERAGE'] = 'true'
+    Rake::Task['spec:unit'].invoke
+  end
+end
+
+task default: 'spec:unit'

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Hanami::Cli::VERSION
   spec.authors       = ["Luca Guidi"]
   spec.email         = ["me@lucaguidi.com"]
+  spec.licenses      = ["MIT"]
 
   spec.summary       = "Hanami CLI"
   spec.description   = "Hanami framework to build command line interfaces with Ruby"
@@ -27,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.5"
 end

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "hanami-utils", "~> 1.0"
+  spec.add_dependency "hanami-utils",    "~> 1.0"
+  spec.add_dependency "concurrent-ruby", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "hanami-utils", "~> 1.0"
+
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec"
 end

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -4,8 +4,11 @@ module Hanami
   module Cli
     def self.included(base)
       mod = Module.new do
-        def self.call
-          puts "world"
+        def self.call(arguments: ARGV)
+          cmd     = arguments.first
+          command = const_get(constants.find { |c| c.to_s.downcase == cmd })
+
+          command.new.call
         end
       end
 

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -6,7 +6,10 @@ module Hanami
       mod = Module.new do
         def self.call(arguments: ARGV)
           cmd     = arguments.first
-          command = const_get(constants.find { |c| c.to_s.downcase == cmd })
+          command = constants.find { |c| c.to_s.downcase == cmd }
+          exit(1) if command.nil?
+
+          command = const_get(command)
 
           command.new.call
         end

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -5,37 +5,37 @@ module Hanami
     require "hanami/cli/version"
 
     def self.included(base)
-      mod = Module.new do
-        def self.call(arguments: ARGV)
-          cmd     = arguments.first
-          command = Hanami::Cli.command(cmd)
-          exit(1) if command.nil?
+      base.extend ClassMethods
+    end
 
-          command.new.call
-        end
+    module ClassMethods
+      def call(arguments: ARGV)
+        cmd     = arguments.first
+        command = Hanami::Cli.command(cmd)
+        exit(1) if command.nil?
 
-        # This is only for temporary integration with
-        # hanami gem
-        def self.run(arguments: ARGV)
-          cmd     = arguments.first
-          command = Hanami::Cli.command(cmd)
-          return false if command.nil?
-
-          command.new.call
-          true
-        end
-
-        def self.register_as(name, command)
-          Hanami::Cli.register_as(name, command)
-        end
+        command.new.call
       end
 
-      base.const_set(:Cli, mod)
+      # This is only for temporary integration with
+      # hanami gem
+      def run(arguments: ARGV)
+        cmd     = arguments.first
+        command = Hanami::Cli.command(cmd)
+        return false if command.nil?
+
+        command.new.call
+        true
+      end
+
+      def register(name, command)
+        Hanami::Cli.register(name, command)
+      end
     end
 
     @__commands = Concurrent::Hash.new
 
-    def self.register_as(name, command)
+    def self.register(name, command)
       @__commands[name] = command
     end
 

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -1,21 +1,35 @@
-require "hanami/cli/version"
+require "concurrent"
 
 module Hanami
   module Cli
+    require "hanami/cli/version"
+
     def self.included(base)
       mod = Module.new do
         def self.call(arguments: ARGV)
           cmd     = arguments.first
-          command = constants.find { |c| c.to_s.downcase == cmd }
+          command = Hanami::Cli.command(cmd)
           exit(1) if command.nil?
 
-          command = const_get(command)
-
           command.new.call
+        end
+
+        def self.register_as(name, command)
+          Hanami::Cli.register_as(name, command)
         end
       end
 
       base.const_set(:Cli, mod)
+    end
+
+    @__commands = Concurrent::Hash.new
+
+    def self.register_as(name, command)
+      @__commands[name] = command
+    end
+
+    def self.command(name)
+      @__commands.fetch(name, nil)
     end
   end
 end

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -2,6 +2,14 @@ require "hanami/cli/version"
 
 module Hanami
   module Cli
-    # Your code goes here...
+    def self.included(base)
+      mod = Module.new do
+        def self.call
+          puts "world"
+        end
+      end
+
+      base.const_set(:Cli, mod)
+    end
   end
 end

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -14,6 +14,17 @@ module Hanami
           command.new.call
         end
 
+        # This is only for temporary integration with
+        # hanami gem
+        def self.run(arguments: ARGV)
+          cmd     = arguments.first
+          command = Hanami::Cli.command(cmd)
+          return false if command.nil?
+
+          command.new.call
+          true
+        end
+
         def self.register_as(name, command)
           Hanami::Cli.register_as(name, command)
         end

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -10,8 +10,7 @@ module Hanami
 
     module ClassMethods
       def call(arguments: ARGV)
-        cmd     = arguments.first
-        command = Hanami::Cli.command(cmd)
+        command = Hanami::Cli.command(arguments)
         exit(1) if command.nil?
 
         command.new.call
@@ -20,8 +19,7 @@ module Hanami
       # This is only for temporary integration with
       # hanami gem
       def run(arguments: ARGV)
-        cmd     = arguments.first
-        command = Hanami::Cli.command(cmd)
+        command = Hanami::Cli.command(arguments)
         return false if command.nil?
 
         command.new.call
@@ -39,8 +37,9 @@ module Hanami
       @__commands[name] = command
     end
 
-    def self.command(name)
-      @__commands.fetch(name, nil)
+    def self.command(arguments)
+      command = arguments.join(" ")
+      @__commands.fetch(command, nil)
     end
   end
 end

--- a/lib/hanami/cli/version.rb
+++ b/lib/hanami/cli/version.rb
@@ -1,5 +1,5 @@
 module Hanami
   module Cli
-    VERSION = "0.0.0"
+    VERSION = "1.0.0".freeze
   end
 end

--- a/spec/integration/basic_command_spec.rb
+++ b/spec/integration/basic_command_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe "Basic command" do
     expect(output).to match("world")
   end
 
+  it "prints version" do
+    output = `foo version`
+    expect(output).to match("1.0.0 yay!")
+  end
+
   it "fails for unknown command" do
     result = system("foo unknown")
     expect(result).to be(false)

--- a/spec/integration/basic_command_spec.rb
+++ b/spec/integration/basic_command_spec.rb
@@ -3,4 +3,9 @@ RSpec.describe "Basic command" do
     output = `foo hello`
     expect(output).to match("world")
   end
+
+  it "fails for unknown command" do
+    result = system("foo unknown")
+    expect(result).to be(false)
+  end
 end

--- a/spec/integration/basic_command_spec.rb
+++ b/spec/integration/basic_command_spec.rb
@@ -1,16 +1,42 @@
 RSpec.describe "Basic command" do
-  it "prints world" do
-    output = `foo hello`
-    expect(output).to match("world")
+  context "commands" do
+    it "calls basic command" do
+      output = `foo hello`
+      expect(output).to match("world")
+    end
+
+    it "fails for unknown command" do
+      result = system("foo unknown")
+      expect(result).to be(false)
+    end
   end
 
-  it "prints version" do
-    output = `foo version`
-    expect(output).to match("1.0.0 yay!")
+  context "subcommands" do
+    it "calls subcommand" do
+      output = `foo generate model`
+      expect(output).to match("generated model")
+    end
+
+    it "fails for unknown subcommand" do
+      result = system("foo generate unknown")
+      expect(result).to be(false)
+    end
   end
 
-  it "fails for unknown command" do
-    result = system("foo unknown")
-    expect(result).to be(false)
+  context "third-party gems" do
+    it "allows to override basic commands" do
+      output = `foo version`
+      expect(output).to match("1.0.0 yay!")
+    end
+
+    it "allows to add a subcommand" do
+      output = `foo generate webpack`
+      expect(output).to match("generated configuration")
+    end
+
+    it "allows to override a subcommand" do
+      output = `foo generate action`
+      expect(output).to match("generated action")
+    end
   end
 end

--- a/spec/integration/basic_command_spec.rb
+++ b/spec/integration/basic_command_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe "Basic command" do
+  it "prints world" do
+    output = `foo hello`
+    expect(output).to match("world")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.filter_run_when_matching :focus
+
+  config.disable_monkey_patching!
+
+  config.warnings = true
+
+  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.profile_examples = 10
+
+  config.order = :random
+
+  Kernel.srand config.seed
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,3 +22,6 @@ RSpec.configure do |config|
 
   Kernel.srand config.seed
 end
+
+require 'hanami-utils'
+Hanami::Utils.require!("spec/support/**/*.rb")

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -1,3 +1,9 @@
 #!/usr/bin/env ruby
+$:.unshift __dir__ + '/../../lib'
+require 'hanami/cli'
 
-puts "world"
+module Foo
+  include Hanami::Cli
+end
+
+Foo::Cli.call

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -4,6 +4,14 @@ require 'hanami/cli'
 
 module Foo
   include Hanami::Cli
+
+  module Cli
+    class Hello
+      def call
+        puts "world"
+      end
+    end
+  end
 end
 
 Foo::Cli.call

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts "world"

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -3,9 +3,9 @@ $:.unshift __dir__ + '/../../lib'
 require 'hanami/cli'
 
 module Foo
-  include Hanami::Cli
+  module CLI
+    include Hanami::Cli
 
-  module Cli
     class Hi
       def call
         puts "world"
@@ -18,23 +18,23 @@ module Foo
       end
     end
 
-    register_as 'hello', Hi
-    register_as 'version', Version
+    register 'hello',   Hi
+    register 'version', Version
   end
 end
 
 module Webpack
-  include Hanami::Cli
+  module Commands
+    include Hanami::Cli
 
-  module Cli
     class Version
       def call
         puts "1.0.0 yay!"
       end
     end
 
-    register_as 'version', Version
+    register 'version', Version
   end
 end
 
-Foo::Cli.call
+Foo::CLI.call

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -14,12 +14,27 @@ module Foo
 
     class Version
       def call
-        puts "1.0.0"
+      end
+    end
+
+    module Generate
+      class Model
+        def call
+          puts "generated model"
+        end
+      end
+
+      class Action
+        def call
+        end
       end
     end
 
     register 'hello',   Hi
     register 'version', Version
+
+    register 'generate model',  Generate::Model
+    register 'generate action', Generate::Action
   end
 end
 
@@ -33,7 +48,23 @@ module Webpack
       end
     end
 
+    module Generate
+      class Configuration
+        def call
+          puts "generated configuration"
+        end
+      end
+
+      class Action
+        def call
+          puts "generated action"
+        end
+      end
+    end
+
     register 'version', Version
+    register 'generate webpack', Generate::Configuration
+    register 'generate action',  Generate::Action
   end
 end
 

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -6,11 +6,34 @@ module Foo
   include Hanami::Cli
 
   module Cli
-    class Hello
+    class Hi
       def call
         puts "world"
       end
     end
+
+    class Version
+      def call
+        puts "1.0.0"
+      end
+    end
+
+    register_as 'hello', Hi
+    register_as 'version', Version
+  end
+end
+
+module Webpack
+  include Hanami::Cli
+
+  module Cli
+    class Version
+      def call
+        puts "1.0.0 yay!"
+      end
+    end
+
+    register_as 'version', Version
   end
 end
 

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -1,0 +1,22 @@
+module RSpec
+  module Support
+    module Path
+      def self.included(base)
+        base.class_eval do
+          before do
+            @original_path = ENV['PATH']
+            ENV['PATH'] = __dir__ + '/fixtures:' + ENV['PATH']
+          end
+
+          after do
+            ENV['PATH'] = @original_path
+          end
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(RSpec::Support::Path)
+end


### PR DESCRIPTION
## Features

  * [x] Commands as classes
  * [x] Dispatch control to commands (eg `foo version`)
  * [x] Dispatch control to subcommands (eg `foo generate bar`)
  * [x] Exit on missing (sub)command
  * [x] Allow third-party gems to add (sub)commands
  * [x] Allow third-party gems to override (sub)commands

## Usage

Let's imagine we want to ship a CLI for our `my-cool-gem` gem. It ships with a `cool` command, placed at `bin/cool` in the gem codebase.

This is how `bin/cool` looks like:

```ruby
#!/usr/bin/env ruby
require 'my_cool_gem/cli'

MyCoolGem::CLI.call
```

This is the implementation of a basic CLI for our `my-cool-gem`

```ruby
# lib/my_cool_gem/cli.rb
require 'hanami/cli'

module MyCoolGem
  module CLI
    include Hanami::Cli

    class Hello
      def call
        puts "world"
      end
    end

    register "hello", Hello
  end
end
```

In the end we'll be able to run:

```shell
$ cool hello
world
```

---

Me & @oana-sipos paired on this.

@hanami/core for review