### PR TITLE
Support aliases

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -26,8 +26,8 @@ module Hanami
         true
       end
 
-      def register(name, command)
-        Hanami::Cli.register(name, command)
+      def register(*names, command)
+        names.each { |name| Hanami::Cli.register(name, command) }
       end
     end
 

--- a/spec/integration/basic_command_spec.rb
+++ b/spec/integration/basic_command_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe "Basic command" do
       expect(output).to match("v1.0.0")
     end
 
+    it "calls basic command with alias" do
+      output = `foo -v`
+      expect(output).to match("v1.0.0")
+
+      output = `foo --version`
+      expect(output).to match("v1.0.0")
+    end
+
     it "fails for unknown command" do
       result = system("foo unknown")
       expect(result).to be(false)
@@ -15,6 +23,11 @@ RSpec.describe "Basic command" do
     it "calls subcommand" do
       output = `foo generate model`
       expect(output).to match("generated model")
+    end
+
+    it "calls subcommand with alias" do
+      output = `foo generate --help`
+      expect(output).to match("help for generate")
     end
 
     it "fails for unknown subcommand" do

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -18,6 +18,12 @@ module Foo
     end
 
     module Generate
+      class Help
+        def call
+          puts "help for generate"
+        end
+      end
+
       class Model
         def call
           puts "generated model"
@@ -30,9 +36,10 @@ module Foo
       end
     end
 
-    register 'hello',     Hello
-    register 'version',   Version
+    register 'hello', Hello
+    register 'version', '-v', '--version', Version
 
+    register 'generate --help', Generate::Help
     register 'generate model',  Generate::Model
     register 'generate action', Generate::Action
   end


### PR DESCRIPTION
With this PR you can create several names for a command

Example
--
```ruby
module Foo
  module CLI
    include Hanami::Cli
 
    class Version
      def call
        puts "v1.0.0"
      end
    end

    register 'version', '-v', '--version', Version
  end
end
```
```shell
$ foo version
v1.0.0
$ foo -v
v1.0.0
$ foo --version
v1.0.0
```

I use this version for now, there is another alternative:
```ruby
register ['version', '-v', '--version'], Version
```
But I prefer the first one because we don't have to remember to write the bracket.

cc @jodosha @oana-sipos 