### PR TITLE
Register commands explicitly in dedicated command registries

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -1,72 +1,37 @@
-require "concurrent"
+require "hanami/cli/version"
+require "hanami/cli/renderer"
+require "hanami/cli/command/params_parser"
 
 module Hanami
-  module Cli
-    require "hanami/cli/version"
-    require "hanami/cli/command"
-    require "hanami/cli/renderer"
+  class Cli
+    attr_reader :commands
+    attr_reader :renderer
 
-    def self.included(base)
-      base.extend ClassMethods
+    def initialize(command_registry)
+      @commands = command_registry
+      @renderer = Hanami::Cli::Renderer.new(command_registry)
     end
 
-    module ClassMethods
-      # FIXME ignore_unknown_commands is a hack to help us to migrate Hanami commands.
-      # It MUST be removed once done
-      def call(arguments: ARGV, ignore_unknown_commands: false)
-        command, arguments = Hanami::Cli.command(arguments)
-        if command.nil? || command.subcommand?
-          command_name = command.name if command
-          return nil if ignore_unknown_commands
+    # FIXME ignore_unknown_commands is a hack to help us to migrate Hanami commands.
+    # It MUST be removed once done
+    def call(arguments: ARGV, ignore_unknown_commands: false)
+      command, arguments = commands.resolve_from_arguments(arguments)
 
-          Hanami::Cli::Renderer.new(command_name).render
-          exit(1)
-        end
+      if command.nil? || command.subcommand?
+        command_name = command.name if command
+        return nil if ignore_unknown_commands
 
-        required_params = command.parse_arguments(arguments)
-        if required_params
-          command.call(required_params)
-        else
-          command.call
-        end
+        renderer.render(command_name)
+        exit(1)
       end
-    end
 
-    @__commands = Concurrent::Hash.new
-
-    def self.register(command)
-      @__commands[command.name] ||= {}
-      @__commands[command.name] = command
-    end
-
-    def self.command(arguments)
-      command_names = arguments.take_while { |argument| !argument.start_with?('-') }
-      command = nil
-      command_names.size.times do |i|
-        splitted_names = command_names[0, command_names.size - i]
-        command = @__commands[splitted_names.join(' ')]
-        if command
-          arguments = arguments - splitted_names
-          break
-        end
+      parser = Command::ParamsParser.new(command)
+      params = parser.parse(arguments)
+      if params.any?
+        command.call(params)
+      else
+        command.call
       end
-      [command, arguments]
-
-      # command_by_alias(arguments.join(' '))
-    end
-
-    def self.commands
-      @__commands
-    end
-
-    private
-
-    def self.command_by_class(command_class)
-      @__commands.values.detect {|command_instance| command_instance.class == command_class}
-    end
-
-    def self.command_by_alias(command)
-      @__commands.values.detect {|command_instance| command_instance.aliases.to_a.include?(command)}
     end
   end
 end

--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -1,107 +1,44 @@
-require "hanami/cli/param"
-require "hanami/cli/command/params_parser"
+require "hanami/cli/command/class_interface"
 
 module Hanami
-  module Cli
-    module Command
-      def self.included(base)
-        base.include InstanceMethods
-        base.extend ClassMethods
+  class Cli
+    class Command
+      extend ClassInterface
+
+      attr_reader :name, :description, :params, :options
+
+      def initialize(name:, description:, params: [], **options)
+        @name = name
+        @description = description
+        @params = params
+        @options = options
       end
 
-      module InstanceMethods
-        attr_reader :options, :name, :parsed_options, :aliases
+      def subcommand?
+        options[:subcommand]
+      end
 
-        def initialize(name, options = {})
-          @name = name
-          @aliases = options[:aliases]
-          @options = options
-          @params_parser = ParamsParser.new(self)
-        end
+      def level
+        name.split(' ').size - 1
+      end
 
-        def subcommand?
-          options[:subcommand]
-        end
+      def arguments
+        params.select(&:argument?)
+      end
 
-        def level
-          name.split(' ').size - 1
-        end
+      def required_arguments
+        arguments.select(&:required?)
+      end
 
-        def description
-          options[:desc]
-        end
-
-        def params
-          options[:params]
-        end
-
-        def parse_arguments(arguments)
-          return unless options[:params]
-
-          @params_parser.parse(arguments)
-        end
-
-        def arguments
-          @arguments ||= options[:params].to_a.select(&:argument?)
-        end
-
-        def required_arguments
-          @required_arguments ||= arguments.select(&:required?)
-        end
-
-        def default_params
-          params.to_a.inject({}) do |list, param|
-            list[param.name] = param.default unless param.default.nil?
-            list
-          end
-        end
-
-        def command_of_subcommand?(key)
-          name.start_with?(key.to_s)
+      def default_params
+        params.inject({}) do |list, param|
+          list[param.name] = param.default unless param.default.nil?
+          list
         end
       end
 
-      module ClassMethods
-        def desc(description)
-          generate_new_command(desc: description)
-        end
-
-        def aliases(*names)
-          generate_new_command(aliases: names)
-        end
-
-        #
-        # FIXME: Use custom argument class instead Param class
-        #
-        def argument(name, options = {})
-          option(name, options.merge(argument: true))
-        end
-
-        #
-        # FIXME: Use custom option class instead Param class
-        #
-        def option(name, options = {})
-          param = Param.new(name, options)
-          command = current_command
-          command.options[:params] ||= []
-          command.options[:params] << param
-          generate_new_command(command: command, params: command.options[:params])
-        end
-
-        def register(name, options = {})
-          Hanami::Cli.register(new(name, options))
-        end
-
-        private
-
-        def generate_new_command(command: current_command, **options)
-          new_command = new(command.name, command.options.merge(options))
-          Hanami::Cli.commands[new_command.name] = new_command
-        end
-
-        def current_command
-          Hanami::Cli.command_by_class(self)
-        end
+      def command_of_subcommand?(key)
+        name.start_with?(key.to_s)
       end
     end
   end

--- a/lib/hanami/cli/command/class_interface.rb
+++ b/lib/hanami/cli/command/class_interface.rb
@@ -1,0 +1,41 @@
+require "hanami/cli/param"
+
+module Hanami
+  class Cli
+    class Command
+      module ClassInterface
+        UNDEFINED = Object.new.freeze
+
+        def new(**options)
+          super(options.merge(description: desc, params: params))
+        end
+
+        def desc(new_description = UNDEFINED)
+          if new_description == UNDEFINED
+            @desc if instance_variable_defined?(:@desc)
+          else
+            @desc = new_description
+          end
+        end
+
+        def params
+          @params ||= []
+        end
+
+        #
+        # FIXME: Use custom argument class instead Param class
+        #
+        def argument(name, **options)
+          option(name, options.merge(argument: true))
+        end
+
+        #
+        # FIXME: Use custom option class instead Param class
+        #
+        def option(name, **options)
+          params << Param.new(name, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/command/params_parser.rb
+++ b/lib/hanami/cli/command/params_parser.rb
@@ -1,8 +1,8 @@
 require "optparse"
 
 module Hanami
-  module Cli
-    module Command
+  class Cli
+    class Command
       class ParamsParser
         attr_reader :command
 

--- a/lib/hanami/cli/command_registry.rb
+++ b/lib/hanami/cli/command_registry.rb
@@ -1,0 +1,53 @@
+require "concurrent/hash"
+
+module Hanami
+  class Cli
+    module CommandRegistry
+      include Enumerable
+
+      def commands
+        @commands ||= Concurrent::Hash.new
+      end
+
+      def aliases
+        @aliases ||= Concurrent::Hash.new
+      end
+
+      def command_keys
+        commands.keys + aliases.keys
+      end
+
+      def each(&block)
+        commands.each(&block)
+      end
+
+      def register(name, command_class, aliases: [], **options)
+        commands[name] = command_class.new(name: name, **options)
+
+        aliases.each do |a|
+          self.aliases[a] = name
+        end
+
+        self
+      end
+
+      def resolve(name)
+        commands[name] || aliases[name]
+      end
+
+      def resolve_from_arguments(arguments)
+        command_names = arguments.take_while { |argument| !argument.start_with?('-') }
+        command = nil
+        command_names.size.times do |i|
+          splitted_names = command_names[0, command_names.size - i]
+          command = resolve(splitted_names.join(' '))
+          if command
+            arguments = arguments - splitted_names
+            break
+          end
+        end
+        [command, arguments]
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/param.rb
+++ b/lib/hanami/cli/param.rb
@@ -1,7 +1,7 @@
 require 'hanami/utils/string'
 
 module Hanami
-  module Cli
+  class Cli
     class Param
       attr_reader :name, :options
 

--- a/lib/hanami/cli/renderer.rb
+++ b/lib/hanami/cli/renderer.rb
@@ -1,19 +1,19 @@
 module Hanami
-  module Cli
+  class Cli
     class Renderer
-      attr_reader :command_name
+      attr_reader :commands
 
-      def initialize(command_name)
-        @command_name = command_name
+      def initialize(command_registry)
+        @commands = command_registry
       end
 
-      def render
+      def render(current_command)
         puts "Commands:"
-        longest_row = row_sizes.max
+        longest_row = row_sizes(current_command).max
 
-        Hanami::Cli.commands.sort.each do |key, command|
-          next if command_level != command.level
-          next unless command.command_of_subcommand?(command_name)
+        commands.sort.each do |key, command|
+          next if command_level(current_command) != command.level
+          next unless command.command_of_subcommand?(current_command)
           row = build_row(key, command)
           print_row(row, longest_row, command)
         end
@@ -21,14 +21,14 @@ module Hanami
 
       private
 
-      def command_level
-        @command_level ||= command_name.to_s.split(' ').size
+      def command_level(current_command)
+        current_command.to_s.split(' ').size
       end
 
-      def row_sizes
-        Hanami::Cli.commands.map do |key, command|
-          next 0 if command_level != command.level
-          next 0 unless command.command_of_subcommand?(command_name)
+      def row_sizes(current_command)
+        commands.map do |key, command|
+          next 0 if command_level(current_command) != command.level
+          next 0 unless command.command_of_subcommand?(current_command)
           build_row(key, command).size
         end
       end

--- a/lib/hanami/cli/version.rb
+++ b/lib/hanami/cli/version.rb
@@ -1,5 +1,5 @@
 module Hanami
-  module Cli
+  class Cli
     VERSION = "1.0.0".freeze
   end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -1,36 +1,31 @@
 #!/usr/bin/env ruby
 $:.unshift __dir__ + '/../../lib'
 require 'hanami/cli'
+require 'hanami/cli/command'
+require 'hanami/cli/command_registry'
+
+module MyCLI
+  class Commands
+    extend Hanami::Cli::CommandRegistry
+  end
+end
 
 module Foo
-  module CLI
-    include Hanami::Cli
-
-    class Hello
-      include Hanami::Cli::Command
-
-      register 'hello'
-
+  class Cli
+    class Hello < Hanami::Cli::Command
       def call
       end
     end
+    MyCLI::Commands.register "hello", Hello
 
-    class Version
-      include Hanami::Cli::Command
-
-      register 'version'
-      aliases '--version', '-v'
-
+    class Version < Hanami::Cli::Command
       def call
         puts "v1.0.0"
       end
     end
+    MyCLI::Commands.register "version", Version, aliases: ["--version", "-v"]
 
-    class Server
-      include Hanami::Cli::Command
-
-      register 'server'
-
+    class Server < Hanami::Cli::Command
       desc 'Starts a hanami server'
 
       option :port, alias: '-p', desc: 'The port to run the server on'
@@ -42,12 +37,9 @@ module Foo
         puts "Server: #{options}"
       end
     end
+    MyCLI::Commands.register "server", Server
 
-    class New
-      include Hanami::Cli::Command
-
-      register 'new'
-
+    class New < Hanami::Cli::Command
       desc 'Creates a new hanami project'
 
       argument :project_name, required: true
@@ -56,21 +48,15 @@ module Foo
         puts "New: #{options} - project_name: #{project_name}"
       end
     end
+    MyCLI::Commands.register "new", New
 
     module Destroy
-      class Subcommand
-        include Hanami::Cli::Command
-
-        register 'destroy', subcommand: true
-
+      class Subcommand < Hanami::Cli::Command
         desc 'Destroy hanami classes'
       end
+      MyCLI::Commands.register 'destroy', Subcommand, subcommand: true
 
-      class Action
-        include Hanami::Cli::Command
-
-        register 'destroy action'
-
+      class Action < Hanami::Cli::Command
         argument :application_name, required: true
         argument :controller_name__action_name, required: true, label: "CONTROLLER_NAME#ACTION_NAME"
         option :url
@@ -80,22 +66,16 @@ module Foo
           puts "destroy action: #{options} - application_name: #{application_name} - controller_name__action_name: #{controller_name__action_name}"
         end
       end
+      MyCLI::Commands.register "destroy action", Action
     end
 
     module Generate
-      class Subcommand
-        include Hanami::Cli::Command
-
-        register 'generate', subcommand: true
-
+      class Subcommand < Hanami::Cli::Command
         desc 'Generate hanami classes'
       end
+      MyCLI::Commands.register 'generate', Subcommand, subcommand: true
 
-      class Model
-        include Hanami::Cli::Command
-
-        register 'generate model'
-
+      class Model < Hanami::Cli::Command
         desc 'Generate an entity'
 
         argument :model_name, required: true
@@ -105,91 +85,70 @@ module Foo
           puts "generated model: #{options} - model_name: #{model_name}"
         end
       end
+      MyCLI::Commands.register "generate model", Model
 
-      class Secret
-        include Hanami::Cli::Command
-
-        register 'generate secret'
-
+      class Secret < Hanami::Cli::Command
         argument :app
 
         def call(app:, **options)
           puts "generate secret: - app: #{app}"
         end
       end
+      MyCLI::Commands.register "generate secret", Secret
 
-      class Action
-        include Hanami::Cli::Command
-
-        register 'generate action'
-
+      class Action < Hanami::Cli::Command
         def call
         end
       end
+      MyCLI::Commands.register "generate action", Action
     end
   end
 end
 
 module Webpack
   module Commands
-    include Hanami::Cli
-
-    class Hi
-      include Hanami::Cli::Command
-
-      register 'hello'
-
+    class Hi < Hanami::Cli::Command
       def call
         puts "world"
       end
     end
+    MyCLI::Commands.register "hello", Hi
 
     module Generate
-      class Configuration
-        include Hanami::Cli::Command
-
-        register 'generate webpack'
-
+      class Configuration < Hanami::Cli::Command
         def call
           puts "generated configuration"
         end
       end
+      MyCLI::Commands.register "generate webpack", Configuration
 
-      class Action
-        include Hanami::Cli::Command
-
-        register 'generate action'
-
+      class Action < Hanami::Cli::Command
         desc 'Generate an action'
 
         def call
           puts "generated action"
         end
       end
+      MyCLI::Commands.register "generate action", Action
 
       module Application
-        class Subcommand
-          include Hanami::Cli::Command
-
-          register 'generate application', subcommand: true
-
+        class Subcommand < Hanami::Cli::Command
           desc 'Generate hanami applications'
         end
+        MyCLI::Commands.register 'generate application', Subcommand, subcommand: true
 
-        class New
-          include Hanami::Cli::Command
-
-          register 'generate application new'
-
+        class New < Hanami::Cli::Command
           desc 'Generate an application'
 
           def call(options)
             puts "generated application new: #{options}"
           end
         end
+        MyCLI::Commands.register "generate application new", New
       end
     end
   end
 end
 
-Foo::CLI.call
+cli = Hanami::Cli.new(MyCLI::Commands)
+cli.call


### PR DESCRIPTION
This PR allows explicit command registries to be provided by projects offering an extensible CLI as part of their offerings. It moves registration outside of commands so it can be done against explicitly named command registries.

The reason for this change is to make it so that multiple, distinct sets of commands to be registered for different users of hanami-cli, all within the same Ruby runtime environment.

This would allow, for example, gems to target Hanami's CLI _as well as_ other CLIs, like the dry-web CLI I want to build using hanami-cli.

To support this broad change, a couple of other things have changed too:

- `Hanami::Cli::Command` is now a class, and commands should subclass it.
- A class method interface has been created for the Command class’ `desc` and `params`, with those methods setting class-level instance variables.
- `Hanami::Cli` is now a class, and it should be instantiated with a command registry object
- `Hanami::Cli::Renderer` is now instantiated with a command registry object, and `#call`-ede with the name of the command

My approach here was to try and make the smallest amount of change to support the new arrangement with the command registries.

There's a few other things I came across in doing this work, but I'd be happy to tackle them after we sort out this PR :)