### PR TITLE
Hanami::Cli => Hanami::CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ end
 Foo::CLI::Commands.register "hi", Foo::CLI::Commands::Hello
 Foo::CLI::Commands.register "v",  Version
 
-Hanami::Cli.new(Foo::CLI::Commands).call
+Hanami::CLI.new(Foo::CLI::Commands).call
 ```
 
 **Please note:** there is NOT a convention between the _command name_ and the _command object_ class.
@@ -74,7 +74,7 @@ end
 
 Foo::CLI::Commands.register "generate configuration", Foo::CLI::Commands::Generate::Configuration
 
-Hanami::Cli.new(Foo::CLI::Commands).call
+Hanami::CLI.new(Foo::CLI::Commands).call
 ```
 
 ### Arguments
@@ -203,7 +203,7 @@ Imagine to build a CLI executable `foo` for your Ruby project.
 require "bundler/setup"
 require "hanami/cli"
 
-Hanami::CLI = Hanami::Cli
+Hanami::CLI = Hanami::CLI
 
 module Foo
   module CLI
@@ -270,7 +270,7 @@ module Foo
           end
         end
 
-        class Test < Hanami::Cli::Command
+        class Test < Hanami::CLI::Command
           desc "Generate tests"
 
           option :framework, default: "minitest", values: %w[minitest rspec]
@@ -294,7 +294,7 @@ module Foo
   end
 end
 
-Hanami::Cli.new(Foo::CLI::Commands).call
+Hanami::CLI.new(Foo::CLI::Commands).call
 ```
 
 Let's have a look at the command line usage.

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -5,7 +5,7 @@ require 'hanami/cli/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "hanami-cli"
-  spec.version       = Hanami::Cli::VERSION
+  spec.version       = Hanami::CLI::VERSION
   spec.authors       = ["Luca Guidi"]
   spec.email         = ["me@lucaguidi.com"]
   spec.licenses      = ["MIT"]

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -1,5 +1,5 @@
 module Hanami
-  class Cli
+  class CLI
     require "hanami/cli/version"
     require "hanami/cli/command"
     require "hanami/cli/registry"
@@ -60,7 +60,7 @@ module Hanami
     end
 
     def command?(command)
-      Cli.command?(command)
+      CLI.command?(command)
     end
   end
 end

--- a/lib/hanami/cli/banner.rb
+++ b/lib/hanami/cli/banner.rb
@@ -1,7 +1,7 @@
 require "hanami/cli/program_name"
 
 module Hanami
-  class Cli
+  class CLI
     module Banner
       def self.call(command, out)
 

--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -3,7 +3,7 @@ require "hanami/cli/option"
 require "concurrent/array"
 
 module Hanami
-  class Cli
+  class CLI
     class Command
       def self.inherited(base)
         base.extend ClassMethods

--- a/lib/hanami/cli/command_registry.rb
+++ b/lib/hanami/cli/command_registry.rb
@@ -1,7 +1,7 @@
 require "concurrent/hash"
 
 module Hanami
-  class Cli
+  class CLI
     class CommandRegistry
       def initialize
         @root = Node.new

--- a/lib/hanami/cli/option.rb
+++ b/lib/hanami/cli/option.rb
@@ -1,7 +1,7 @@
 require "hanami/utils/string"
 
 module Hanami
-  class Cli
+  class CLI
     class Option
       attr_reader :name, :options
 

--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -2,7 +2,7 @@ require "optparse"
 require "hanami/cli/program_name"
 
 module Hanami
-  class Cli
+  class CLI
     module Parser
       def self.call(command, arguments, names)
         parsed_options = {}

--- a/lib/hanami/cli/program_name.rb
+++ b/lib/hanami/cli/program_name.rb
@@ -1,5 +1,5 @@
 module Hanami
-  class Cli
+  class CLI
     module ProgramName
       SEPARATOR = " ".freeze
 

--- a/lib/hanami/cli/registry.rb
+++ b/lib/hanami/cli/registry.rb
@@ -1,7 +1,7 @@
 require "hanami/cli/command_registry"
 
 module Hanami
-  class Cli
+  class CLI
     module Registry
       def self.extended(base)
         base.class_eval do

--- a/lib/hanami/cli/usage.rb
+++ b/lib/hanami/cli/usage.rb
@@ -1,7 +1,7 @@
 require "hanami/cli/program_name"
 
 module Hanami
-  class Cli
+  class CLI
     module Usage
       SUBCOMMAND_BANNER = " [SUBCOMMAND]".freeze
 
@@ -33,7 +33,7 @@ module Hanami
       end
 
       def self.arguments(command)
-        return unless Cli.command?(command)
+        return unless CLI.command?(command)
 
         required_arguments = command.required_arguments
         optional_arguments = command.optional_arguments
@@ -46,7 +46,7 @@ module Hanami
       end
 
       def self.description(command)
-        return unless Cli.command?(command)
+        return unless CLI.command?(command)
 
         " # #{command.description}" unless command.description.nil?
       end

--- a/lib/hanami/cli/version.rb
+++ b/lib/hanami/cli/version.rb
@@ -1,5 +1,5 @@
 module Hanami
-  class Cli
+  class CLI
     VERSION = "1.0.0".freeze
   end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -5,13 +5,13 @@ require 'hanami/cli'
 module Foo
   module CLI
     module Commands
-      extend Hanami::Cli::Registry
+      extend Hanami::CLI::Registry
 
-      class Command < Hanami::Cli::Command
+      class Command < Hanami::CLI::Command
       end
 
       module Assets
-        class Precompile < Hanami::Cli::Command
+        class Precompile < Hanami::CLI::Command
           desc "Precompile assets for deployment"
 
           example [
@@ -23,7 +23,7 @@ module Foo
         end
       end
 
-      class Console < Hanami::Cli::Command
+      class Console < Hanami::CLI::Command
         desc "Starts Foo console"
         option :engine, desc: "Force a console engine", values: %w(irb pry ripl)
 
@@ -38,35 +38,35 @@ module Foo
       end
 
       module DB
-        class Apply < Hanami::Cli::Command
+        class Apply < Hanami::CLI::Command
           desc "Migrate, dump the SQL schema, and delete the migrations (experimental)"
 
           def call(*)
           end
         end
 
-        class Console < Hanami::Cli::Command
+        class Console < Hanami::CLI::Command
           desc "Starts a database console"
 
           def call(*)
           end
         end
 
-        class Create < Hanami::Cli::Command
+        class Create < Hanami::CLI::Command
           desc "Create the database (only for development/test)"
 
           def call(*)
           end
         end
 
-        class Drop < Hanami::Cli::Command
+        class Drop < Hanami::CLI::Command
           desc "Drop the database (only for development/test)"
 
           def call(*)
           end
         end
 
-        class Migrate < Hanami::Cli::Command
+        class Migrate < Hanami::CLI::Command
           desc "Migrate the database"
           argument :version, desc: "The target version of the migration (see `foo db version`)"
 
@@ -79,14 +79,14 @@ module Foo
           end
         end
 
-        class Prepare < Hanami::Cli::Command
+        class Prepare < Hanami::CLI::Command
           desc "Drop, create, and migrate the database (only for development/test)"
 
           def call(*)
           end
         end
 
-        class Version < Hanami::Cli::Command
+        class Version < Hanami::CLI::Command
           desc "Print the current migrated version"
 
           def call(*)
@@ -95,7 +95,7 @@ module Foo
       end
 
       module Destroy
-        class Action < Hanami::Cli::Command
+        class Action < Hanami::CLI::Command
           desc "Destroy an action from app"
 
           example [
@@ -111,7 +111,7 @@ module Foo
           end
         end
 
-        class App < Hanami::Cli::Command
+        class App < Hanami::CLI::Command
           desc "Destroy an app"
 
           argument :app, required: true, desc: "The application name (eg. `web`)"
@@ -124,7 +124,7 @@ module Foo
           end
         end
 
-        class Mailer < Hanami::Cli::Command
+        class Mailer < Hanami::CLI::Command
           desc "Destroy a mailer"
 
           argument :mailer, required: true, desc: "The mailer name (eg. `welcome`)"
@@ -137,7 +137,7 @@ module Foo
           end
         end
 
-        class Migration < Hanami::Cli::Command
+        class Migration < Hanami::CLI::Command
           desc "Destroy a migration"
 
           argument :migration, required: true, desc: "The migration name (eg. `create_users`)"
@@ -150,7 +150,7 @@ module Foo
           end
         end
 
-        class Model < Hanami::Cli::Command
+        class Model < Hanami::CLI::Command
           desc "Destroy a model"
 
           argument :model, required: true, desc: "The model name (eg. `user`)"
@@ -165,7 +165,7 @@ module Foo
       end
 
       module Generate
-        class Action < Hanami::Cli::Command
+        class Action < Hanami::CLI::Command
           desc "Generate an action for app"
 
           example [
@@ -188,7 +188,7 @@ module Foo
           end
         end
 
-        class App < Hanami::Cli::Command
+        class App < Hanami::CLI::Command
           desc "Generate an app"
 
           argument :app, required: true, desc: "The application name (eg. `web`)"
@@ -203,7 +203,7 @@ module Foo
           end
         end
 
-        class Mailer < Hanami::Cli::Command
+        class Mailer < Hanami::CLI::Command
           desc "Generate a mailer"
 
           argument :mailer, required: true, desc: "The mailer name (eg. `welcome`)"
@@ -223,7 +223,7 @@ module Foo
           end
         end
 
-        class Migration < Hanami::Cli::Command
+        class Migration < Hanami::CLI::Command
           desc "Generate a migration"
 
           argument :migration, required: true, desc: "The migration name (eg. `create_users`)"
@@ -236,7 +236,7 @@ module Foo
           end
         end
 
-        class Model < Hanami::Cli::Command
+        class Model < Hanami::CLI::Command
           desc "Generate a model"
 
           argument :model, required: true, desc: "Model name (eg. `user`)"
@@ -252,7 +252,7 @@ module Foo
           end
         end
 
-        class Secret < Hanami::Cli::Command
+        class Secret < Hanami::CLI::Command
           desc "Generate session secret"
 
           argument :app, desc: "The application name (eg. `web`)"
@@ -268,7 +268,7 @@ module Foo
         end
       end
 
-      class New < Hanami::Cli::Command
+      class New < Hanami::CLI::Command
         desc "Generate a new Foo project"
         argument :project, required: true
 
@@ -292,14 +292,14 @@ module Foo
         end
       end
 
-      class Routes < Hanami::Cli::Command
+      class Routes < Hanami::CLI::Command
         desc "Print routes"
 
         def call(*)
         end
       end
 
-      class Server < Hanami::Cli::Command
+      class Server < Hanami::CLI::Command
         desc "Start Foo server (only for development)"
 
         option :server,         desc: "Force a server engine (eg, webrick, puma, thin, etc..)"
@@ -324,7 +324,7 @@ module Foo
         end
       end
 
-      class Version < Hanami::Cli::Command
+      class Version < Hanami::CLI::Command
         desc "Print Foo version"
 
         def call(*)
@@ -332,14 +332,14 @@ module Foo
         end
       end
 
-      class Hello < Hanami::Cli::Command
+      class Hello < Hanami::CLI::Command
         def call(*)
           raise NotImplementedError
         end
       end
 
       module Sub
-        class Command < Hanami::Cli::Command
+        class Command < Hanami::CLI::Command
           def call(*)
             raise NotImplementedError
           end
@@ -386,7 +386,7 @@ Foo::CLI::Commands.register "sub command", Foo::CLI::Commands::Sub::Command
 module Foo
   module Webpack
     module CLI
-      class Generate < Hanami::Cli::Command
+      class Generate < Hanami::CLI::Command
         desc "Generate webpack configuration"
 
         def call(*)
@@ -394,7 +394,7 @@ module Foo
         end
       end
 
-      class Hello < Hanami::Cli::Command
+      class Hello < Hanami::CLI::Command
         desc "Print a greeting"
 
         def call(*)
@@ -402,7 +402,7 @@ module Foo
         end
       end
 
-      class SubCommand < Hanami::Cli::Command
+      class SubCommand < Hanami::CLI::Command
         desc "Override a subcommand"
 
         def call(*)
@@ -417,5 +417,5 @@ Foo::CLI::Commands.register "generate webpack", Foo::Webpack::CLI::Generate
 Foo::CLI::Commands.register "hello",            Foo::Webpack::CLI::Hello
 Foo::CLI::Commands.register "sub command",      Foo::Webpack::CLI::SubCommand
 
-cli = Hanami::Cli.new(Foo::CLI::Commands)
+cli = Hanami::CLI.new(Foo::CLI::Commands)
 cli.call


### PR DESCRIPTION
`CLI` is an acronym for Command Line Interface, so it should be capitalized. Writing it as `Cli` looks awkward to me, and now's the time to fix it, before it's released :)

Note, this will require a similar search-and-replace PR in `hanami/hanami`, since `Cli` is referred to there much. That (and this PR) can wait until all the commands are migrated from `thor` to `hanami-cli`.