### PR TITLE
Work with command instances throughout gem

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -39,10 +39,10 @@ module Hanami
       command = result.command
       return [command, result.arguments] unless command?(command)
 
-      result = Parser.call(command.class, result.arguments, result.names)
+      result = Parser.call(command, result.arguments, result.names)
 
       if result.help?
-        Banner.call(command.class, out)
+        Banner.call(command, out)
         exit(0)
       end
 

--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -1,3 +1,4 @@
+require "forwardable"
 require "hanami/cli/option"
 require "concurrent/array"
 
@@ -11,7 +12,6 @@ module Hanami
       module ClassMethods
         def self.extended(base)
           base.class_eval do
-            @command_name = nil
             @description  = nil
             @examples     = Concurrent::Array.new
             @arguments    = Concurrent::Array.new
@@ -23,7 +23,6 @@ module Hanami
         attr_reader :examples
         attr_reader :arguments
         attr_reader :options
-        attr_accessor :command_name
       end
 
       def self.desc(description)
@@ -58,6 +57,25 @@ module Hanami
 
       def self.optional_arguments
         arguments.reject(&:required?)
+      end
+
+      extend Forwardable
+
+      delegate [
+        :description,
+        :examples,
+        :arguments,
+        :options,
+        :params,
+        :default_params,
+        :required_arguments,
+        :optional_arguments,
+      ] => "self.class"
+
+      attr_reader :command_name
+
+      def initialize(command_name:, **)
+        @command_name = command_name
       end
     end
   end

--- a/lib/hanami/cli/command_registry.rb
+++ b/lib/hanami/cli/command_registry.rb
@@ -51,10 +51,7 @@ module Hanami
       private
 
       def command_for(name, command, **options)
-        case command
-        when NilClass
-          command
-        when ->(c) { c.respond_to?(:call) }
+        if command.nil?
           command
         else
           command.new(command_name: name, **options)

--- a/lib/hanami/cli/command_registry.rb
+++ b/lib/hanami/cli/command_registry.rb
@@ -7,9 +7,9 @@ module Hanami
         @root = Node.new
       end
 
-      def set(name, command, aliases)
+      def set(name, command, aliases, **options)
         node = @root
-        command = command_for(command)
+        command = command_for(name, command, **options)
         name.split(/[[:space:]]/).each do |token|
           node = node.put(node, token)
         end
@@ -50,14 +50,14 @@ module Hanami
 
       private
 
-      def command_for(command)
+      def command_for(name, command, **options)
         case command
         when NilClass
           command
         when ->(c) { c.respond_to?(:call) }
           command
         else
-          command.new
+          command.new(command_name: name, **options)
         end
       end
 

--- a/lib/hanami/cli/registry.rb
+++ b/lib/hanami/cli/registry.rb
@@ -9,12 +9,11 @@ module Hanami
         end
       end
 
-      def register(name, command = nil, aliases: [])
+      def register(name, command = nil, aliases: [], **options)
         if block_given?
           yield Prefix.new(@commands, name, aliases)
         else
-          command.command_name = name if Cli.command?(command)
-          @commands.set(name, command, aliases)
+          @commands.set(name, command, aliases, **options)
         end
       end
 
@@ -30,11 +29,9 @@ module Hanami
           registry.set(prefix, nil, aliases)
         end
 
-        def register(name, command, aliases: [])
-          command_name         = "#{prefix} #{name}"
-          command.command_name = command_name if Cli.command?(command)
-
-          registry.set(command_name, command, aliases)
+        def register(name, command, aliases: [], **options)
+          command_name = "#{prefix} #{name}"
+          registry.set(command_name, command, aliases, **options)
         end
 
         private

--- a/lib/hanami/cli/usage.rb
+++ b/lib/hanami/cli/usage.rb
@@ -35,8 +35,8 @@ module Hanami
       def self.arguments(command)
         return unless Cli.command?(command)
 
-        required_arguments = command.class.required_arguments
-        optional_arguments = command.class.optional_arguments
+        required_arguments = command.required_arguments
+        optional_arguments = command.optional_arguments
 
         required = required_arguments.map { |arg| arg.name.upcase }.join(' ') if required_arguments.any?
         optional = optional_arguments.map { |arg| "[#{arg.name.upcase}]" }.join(' ') if optional_arguments.any?
@@ -48,7 +48,7 @@ module Hanami
       def self.description(command)
         return unless Cli.command?(command)
 
-        " # #{command.class.description}" unless command.class.description.nil?
+        " # #{command.description}" unless command.description.nil?
       end
 
       def self.justify(string, padding, usage)


### PR DESCRIPTION
This is the change I suggested in https://github.com/hanami/cli/pull/9#discussion_r128888120, which @jodosha said was good to be committed to master, but I figured I'd run this briefly through a PR so we have some extra visibility for those following the project :)

<hr>

In this PR, we  instantiate commands with options and provide a full command API via instance methods.

The `command_name` is also passed as the command as is instantiated, so we avoid mutating class-level ivars across potentially multiple registrations of the same command class.

By working with command instances throughout the framework (i.e. accessing command description, examples, arguments, etc. from the instance, rather than the class), it means that we better support any sort of object willing to provide the command API, rather than just `Hanami::Cli::Command` subclasses.

Passing extra options from registration through to command instantiation also makes it possible for dependencies or other sorts of configuration to be passed to commands at registration time. This leaves open various (and unforeseen) possibilities around dynamic passing of dependencies that users of this gem may wish to take advantage of at some point.

Along with this, we remove support for plain callable objects (like Ruby's procs/lambdas) as commands, since they don't provide the affordances necessary for a good CLI experience (i.e everything that `Hanami::Cli::Command` provides out of the box).