### PR TITLE
Rename option `list:` to `values:`

### DIFF
--- a/lib/hanami/cli/option.rb
+++ b/lib/hanami/cli/option.rb
@@ -16,7 +16,7 @@ module Hanami
 
       def desc
         desc = options[:desc]
-        list ? "#{desc}: (#{list.join('/')})" : desc
+        values ? "#{desc}: (#{values.join('/')})" : desc
       end
 
       def required?
@@ -27,8 +27,8 @@ module Hanami
         options[:type]
       end
 
-      def list
-        options[:list]
+      def values
+        options[:values]
       end
 
       def boolean?
@@ -56,7 +56,7 @@ module Hanami
           parser_options << "--#{dasherized_name}=#{name}"
           parser_options << "--#{dasherized_name} #{name}"
         end
-        parser_options << list if list
+        parser_options << values if values
         parser_options.unshift(alias_name) unless alias_name.nil?
         parser_options << desc if desc
         parser_options

--- a/spec/integration/commands_spec.rb
+++ b/spec/integration/commands_spec.rb
@@ -54,15 +54,15 @@ RSpec.describe "Commands" do
       expect(output).to eq("server - {:code_reloading=>false}\n")
     end
 
-    context "with list param" do
-      context "and with option of the list" do
+    context "with supported values" do
+      context "and with supported value passed" do
         it "call the command with the option" do
           output = `foo console --engine=pry`
           expect(output).to eq("console - engine: pry\n")
         end
       end
 
-      context "and with unknown option of the list" do
+      context "and with an unknown value passed" do
         it "prints error" do
           output = `foo console --engine=unknown`
           expect(output).to eq("Error: Invalid param provided\n")

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -25,7 +25,7 @@ module Foo
 
       class Console < Hanami::Cli::Command
         desc "Starts Foo console"
-        option :engine, desc: "Force a console engine", list: %w(irb pry ripl)
+        option :engine, desc: "Force a console engine", values: %w(irb pry ripl)
 
         example [
           "             # Uses the bundled engine",


### PR DESCRIPTION
Rename `list:` option for command options to `values:`, since this seems a little more natural, e.g.

```ruby
option :engine, desc: "Force a console engine", values: %w(irb pry ripl)
```