### PR TITLE
Add default value to arguments

### DIFF
--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -64,7 +64,8 @@ module Hanami
           end
         end
 
-        Result.success(parse_params.merge(parsed_options))
+        parse_params.reject! { |key, value| value.nil? }
+        Result.success(parsed_options.merge(parse_params))
       end
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize

--- a/spec/integration/subcommands_spec.rb
+++ b/spec/integration/subcommands_spec.rb
@@ -108,6 +108,20 @@ DESC
 
         expect(output).to eq(expected)
       end
+
+      context "and a default value" do
+        it "returns the default value if nothing is passed" do
+          output = `foo db rollback`
+
+          expect(output).to eq("1\n")
+        end
+
+        it "returns the passed value" do
+          output = `foo db rollback 3`
+
+          expect(output).to eq("3\n")
+        end
+      end
     end
   end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -92,6 +92,16 @@ module Foo
           def call(*)
           end
         end
+
+        class Rollback < Hanami::CLI::Command
+          desc "Rollback the database"
+
+          argument :versions, desc: "Number of versions to rollback", default: 1
+
+          def call(versions:, **)
+            puts versions
+          end
+        end
       end
 
       module Destroy
@@ -359,6 +369,7 @@ Foo::CLI::Commands.register "db" do |prefix|
   prefix.register "migrate", Foo::CLI::Commands::DB::Migrate
   prefix.register "prepare", Foo::CLI::Commands::DB::Prepare
   prefix.register "version", Foo::CLI::Commands::DB::Version
+  prefix.register "rollback", Foo::CLI::Commands::DB::Rollback
 end
 Foo::CLI::Commands.register "destroy", aliases: ["d"] do |prefix|
   prefix.register "action",    Foo::CLI::Commands::Destroy::Action


### PR DESCRIPTION
Why this PR? Because we want default values for arguments in our commands, an example would be `hanami db rollback`, by default we want value 1 but we can pass another value `hanami db rollback 2`.

Using an argument instead an option in a command changes the behaviour of the command, for example, using an argument you don't have to use something like this `--version 2`.