### PR TITLE
Introduce array type for arguments and options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ General purpose Command Line Interface (CLI) framework for Ruby
 
 ## v0.1.0.beta1 - 2017-08-11
 ### Added
+- [Anton Davydov] Array type for options
 - [Alfonso Uceda, Luca Guidi] Commands banner and usage
 - [Alfonso Uceda] Added support for subcommands
 - [Alfonso Uceda] Validations for arguments and options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ General purpose Command Line Interface (CLI) framework for Ruby
 
 ## v0.1.0.beta1 - 2017-08-11
 ### Added
-- [Anton Davydov] Array type for options
 - [Alfonso Uceda, Luca Guidi] Commands banner and usage
 - [Alfonso Uceda] Added support for subcommands
 - [Alfonso Uceda] Validations for arguments and options

--- a/README.md
+++ b/README.md
@@ -334,8 +334,10 @@ module Foo
         class Configuration < Hanami::CLI::Command
           desc "Generate configuration"
 
-          def call(*)
-            puts "generated configuration"
+          option :apps, type: :array, default: [], desc: "Generate configuration for specific apps"
+
+          def call(**options)
+            puts "generated configuration for apps: #{options.fetch(:apps)}"
           end
         end
 
@@ -456,6 +458,13 @@ stopped - graceful: true
 stopped - graceful: false
 ```
 
+### Array options
+
+```shell
+% foo generate config --apps=web,api
+generated configuration for apps: ["web", "api"]
+```
+
 ### Subcommands
 
 ```shell
@@ -491,7 +500,7 @@ Commands:
 
 ```shell
 % foo g config
-generated configuration
+generated configuration for apps: []
 ```
 
 ### Callbacks

--- a/README.md
+++ b/README.md
@@ -331,6 +331,17 @@ module Foo
         end
       end
 
+      class Exec < Hanami::CLI::Command
+        desc "Execute a task"
+
+        argument :task, type: :string, required: true,  desc: "Task to be executed"
+        argument :dirs, type: :array,  required: false, desc: "Optional directories"
+
+        def call(task:, dirs: [], **)
+          puts "exec - task: #{task}, dirs: #{dirs.inspect}"
+        end
+      end
+
       module Generate
         class Configuration < Hanami::CLI::Command
           desc "Generate configuration"
@@ -357,6 +368,7 @@ module Foo
       register "echo",    Echo
       register "start",   Start
       register "stop",    Stop
+      register "exec",    Exec
 
       register "generate", aliases: ["g"] do |prefix|
         prefix.register "config", Generate::Configuration
@@ -377,6 +389,7 @@ Let's have a look at the command line usage.
 % foo
 Commands:
   foo echo [INPUT]                       # Print input
+  foo exec TASK [DIRS]                   # Execute a task
   foo generate [SUBCOMMAND]
   foo start ROOT                         # Start Foo machinery
   foo stop                               # Stop Foo machinery
@@ -428,6 +441,21 @@ started - root: .
 % foo start
 ERROR: "foo start" was called with no arguments
 Usage: "foo start ROOT"
+```
+
+### Array arguments
+
+Captures all the remaining arguments in a single array.
+Please note that `array` argument must be used as last argument as it works as a _"catch-all"_.
+
+```shell
+% foo exec test
+exec - task: test, dirs: []
+```
+
+```shell
+% foo exec test spec/bookshelf/entities spec/bookshelf/repositories
+exec - task: test, dirs: ["spec/bookshelf/entities", "spec/bookshelf/repositories"]
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ General purpose Command Line Interface (CLI) framework for Ruby.
     - [Required arguments](#required-arguments)
     - [Options](#options)
     - [Boolean options](#boolean-options)
+    - [Array options](#array-options)
     - [Subcommands](#subcommands-1)
     - [Aliases](#aliases)
     - [Subcommand aliases](#subcommand-aliases)

--- a/lib/hanami/cli/option.rb
+++ b/lib/hanami/cli/option.rb
@@ -92,13 +92,14 @@ module Hanami
         dasherized_name = Hanami::Utils::String.dasherize(name)
         parser_options  = []
 
-        if type == :boolean
+        if boolean?
           parser_options << "--[no-]#{dasherized_name}"
         else
           parser_options << "--#{dasherized_name}=#{name}"
           parser_options << "--#{dasherized_name} #{name}"
         end
 
+        parser_options << Array if array?
         parser_options << values if values
         parser_options.unshift(alias_name) unless alias_name.nil?
         parser_options << desc if desc

--- a/lib/hanami/cli/option.rb
+++ b/lib/hanami/cli/option.rb
@@ -59,6 +59,12 @@ module Hanami
         type == :boolean
       end
 
+      # @since x.x.x
+      # @api private
+      def array?
+        type == :array
+      end
+
       # @since 0.1.0
       # @api private
       def default

--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -47,26 +47,26 @@ module Hanami
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
       def self.parse_required_params(command, arguments, names, parsed_options)
-        parse_params = Hash[command.arguments.map(&:name).zip(arguments)]
-        parse_required_params = Hash[command.required_arguments.map(&:name).zip(arguments)]
-        all_required_params_satisfied = command.required_arguments.all? { |param| !parse_required_params[param.name].nil? }
+        parsed_params = Hash[command.arguments.map(&:name).zip(arguments)]
+        parsed_required_params = Hash[command.required_arguments.map(&:name).zip(arguments)]
+        all_required_params_satisfied = command.required_arguments.all? { |param| !parsed_required_params[param.name].nil? }
 
         unused_arguments = arguments.drop(command.required_arguments.length)
 
         unless all_required_params_satisfied
-          parse_required_params_values = parse_required_params.values.compact
+          parsed_required_params_values = parsed_required_params.values.compact
 
           usage = "\nUsage: \"#{full_command_name(names)} #{command.required_arguments.map(&:description_name).join(' ')}\""
 
-          if parse_required_params_values.empty? # rubocop:disable Style/GuardClause
+          if parsed_required_params_values.empty? # rubocop:disable Style/GuardClause
             return Result.failure("ERROR: \"#{full_command_name(names)}\" was called with no arguments#{usage}")
           else
-            return Result.failure("ERROR: \"#{full_command_name(names)}\" was called with arguments #{parse_required_params_values}#{usage}")
+            return Result.failure("ERROR: \"#{full_command_name(names)}\" was called with arguments #{parsed_required_params_values}#{usage}")
           end
         end
 
-        parse_params.reject! { |_key, value| value.nil? }
-        parsed_options = parsed_options.merge(parse_params)
+        parsed_params.reject! { |_key, value| value.nil? }
+        parsed_options = parsed_options.merge(parsed_params)
         parsed_options = parsed_options.merge(args: unused_arguments) if unused_arguments.any?
         Result.success(parsed_options)
       end

--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -19,7 +19,7 @@ module Hanami
         OptionParser.new do |opts|
           command.options.each do |option|
             opts.on(*option.parser_options) do |value|
-              parsed_options[option.name.to_sym] = value
+              parsed_options[option.name.to_sym] = option.array? ? value.split(',') : value
             end
           end
 

--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -19,7 +19,7 @@ module Hanami
         OptionParser.new do |opts|
           command.options.each do |option|
             opts.on(*option.parser_options) do |value|
-              parsed_options[option.name.to_sym] = option.array? ? value.split(',') : value
+              parsed_options[option.name.to_sym] = value
             end
           end
 

--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -66,6 +66,9 @@ module Hanami
         end
 
         parsed_params.reject! { |_key, value| value.nil? }
+        parsed_params = parsed_params.each_with_object({}) do |(k, v), result|
+          result[k] = v.include?(",") ? v.split(",") : v
+        end
         parsed_options = parsed_options.merge(parsed_params)
         parsed_options = parsed_options.merge(args: unused_arguments) if unused_arguments.any?
         Result.success(parsed_options)

--- a/spec/integration/commands_spec.rb
+++ b/spec/integration/commands_spec.rb
@@ -54,6 +54,18 @@ RSpec.describe "Commands" do
       expect(output).to eq("server - {:code_reloading=>false}\n")
     end
 
+    context "with array param" do
+      it "allows to omit optional array argument" do
+        output = `foo exec test`
+        expect(output).to eq("exec - Task: test - Directories: []\n")
+      end
+
+      it "capture all the remaining arguments" do
+        output = `foo exec test api admin`
+        expect(output).to eq("exec - Task: test - Directories: [\"api\", \"admin\"]\n")
+      end
+    end
+
     context "with supported values" do
       context "and with supported value passed" do
         it "call the command with the option" do

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe "Rendering" do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
-        foo bar APPS                           # Generate webpack configuration
         foo callbacks DIR                      # Command with callbacks
         foo console                            # Starts Foo console
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
+        foo exec TASK [DIRS]                   # Execute a task
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                              # Print a greeting
@@ -62,11 +62,11 @@ RSpec.describe "Rendering" do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
-        foo bar APPS                           # Generate webpack configuration
         foo callbacks DIR                      # Command with callbacks
         foo console                            # Starts Foo console
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
+        foo exec TASK [DIRS]                   # Execute a task
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                              # Print a greeting
@@ -87,11 +87,11 @@ RSpec.describe "Rendering" do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
-        foo bar APPS                           # Generate webpack configuration
         foo callbacks DIR                      # Command with callbacks
         foo console                            # Starts Foo console
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
+        foo exec TASK [DIRS]                   # Execute a task
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                              # Print a greeting

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Rendering" do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
+        foo bar APPS                           # Generate webpack configuration
         foo callbacks DIR                      # Command with callbacks
         foo console                            # Starts Foo console
         foo db [SUBCOMMAND]
@@ -61,6 +62,7 @@ RSpec.describe "Rendering" do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
+        foo bar APPS                           # Generate webpack configuration
         foo callbacks DIR                      # Command with callbacks
         foo console                            # Starts Foo console
         foo db [SUBCOMMAND]
@@ -85,6 +87,7 @@ RSpec.describe "Rendering" do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
+        foo bar APPS                           # Generate webpack configuration
         foo callbacks DIR                      # Command with callbacks
         foo console                            # Starts Foo console
         foo db [SUBCOMMAND]

--- a/spec/integration/third_party_gems_spec.rb
+++ b/spec/integration/third_party_gems_spec.rb
@@ -43,6 +43,6 @@ RSpec.describe "Third-party gems" do
 
   it "allows to call array argument" do
     output = `foo bar test,api,admin`
-    expect(output).to eq("bar. Apps: test,api,admin\n")
+    expect(output).to eq("bar. Apps: [\"test\", \"api\", \"admin\"]\n")
   end
 end

--- a/spec/integration/third_party_gems_spec.rb
+++ b/spec/integration/third_party_gems_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe "Third-party gems" do
   it "allows to add a subcommand" do
     output = `foo generate webpack`
-    expect(output).to eq("generate webpack\n")
+    expect(output).to eq("generate webpack. Apps: []\n")
   end
 
   it "allows to invoke a subcommand via an inherited subcomand aliases" do
     output = `foo g webpack`
-    expect(output).to eq("generate webpack\n")
+    expect(output).to eq("generate webpack. Apps: []\n")
   end
 
   it "allows to override basic commands" do
@@ -34,5 +34,10 @@ RSpec.describe "Third-party gems" do
       output = `foo callbacks . --url=https://hanamirb.test`
       expect(output).to eq(expected)
     end
+  end
+
+  it "allows to call array option" do
+    output = `foo generate webpack --apps=test,api,admin`
+    expect(output).to eq("generate webpack. Apps: [\"test\", \"api\", \"admin\"]\n")
   end
 end

--- a/spec/integration/third_party_gems_spec.rb
+++ b/spec/integration/third_party_gems_spec.rb
@@ -40,4 +40,9 @@ RSpec.describe "Third-party gems" do
     output = `foo generate webpack --apps=test,api,admin`
     expect(output).to eq("generate webpack. Apps: [\"test\", \"api\", \"admin\"]\n")
   end
+
+  it "allows to call array argument" do
+    output = `foo bar test,api,admin`
+    expect(output).to eq("bar. Apps: test,api,admin\n")
+  end
 end

--- a/spec/integration/third_party_gems_spec.rb
+++ b/spec/integration/third_party_gems_spec.rb
@@ -40,9 +40,4 @@ RSpec.describe "Third-party gems" do
     output = `foo generate webpack --apps=test,api,admin`
     expect(output).to eq("generate webpack. Apps: [\"test\", \"api\", \"admin\"]\n")
   end
-
-  it "allows to call array argument" do
-    output = `foo bar test,api,admin`
-    expect(output).to eq("bar. Apps: [\"test\", \"api\", \"admin\"]\n")
-  end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -449,8 +449,10 @@ module Foo
       class Generate < Hanami::CLI::Command
         desc "Generate webpack configuration"
 
-        def call(*)
-          puts "generate webpack"
+        option :apps, desc: "Generate webpack apps", type: :array
+
+        def call(apps: [], **)
+          puts "generate webpack. Apps: #{apps}"
         end
       end
 

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -481,6 +481,16 @@ module Foo
           puts "dir: #{dir}, url: #{url.inspect}"
         end
       end
+
+      class Bar < Hanami::CLI::Command
+        desc "Generate webpack configuration"
+
+        argument :apps, desc: "Generate webpack apps", type: :array, required: true
+
+        def call(apps:, **)
+          puts "bar. Apps: #{apps}"
+        end
+      end
     end
   end
 end
@@ -489,6 +499,7 @@ Foo::CLI::Commands.register "generate webpack", Foo::Webpack::CLI::Generate
 Foo::CLI::Commands.register "hello",            Foo::Webpack::CLI::Hello
 Foo::CLI::Commands.register "sub command",      Foo::Webpack::CLI::SubCommand
 Foo::CLI::Commands.register "callbacks",        Foo::Webpack::CLI::CallbacksCommand
+Foo::CLI::Commands.register "bar",              Foo::Webpack::CLI::Bar
 
 # we need to be sure that command will not override with nil command
 Foo::CLI::Commands.register "generate webpack", nil

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -342,6 +342,17 @@ module Foo
         end
       end
 
+      class Exec < Hanami::CLI::Command
+        desc "Execute a task"
+
+        argument :task, desc: "Task to execute", type: :string, required: true
+        argument :dirs, desc: "Directories",     type: :array,  required: false
+
+        def call(task:, dirs: [], **)
+          puts "exec - Task: #{task} - Directories: #{dirs.inspect}"
+        end
+      end
+
       class Hello < Hanami::CLI::Command
         def call(*)
           raise NotImplementedError
@@ -434,6 +445,7 @@ Foo::CLI::Commands.register "new",     Foo::CLI::Commands::New
 Foo::CLI::Commands.register "routes",  Foo::CLI::Commands::Routes
 Foo::CLI::Commands.register "server",  Foo::CLI::Commands::Server,  aliases: ["s"]
 Foo::CLI::Commands.register "version", Foo::CLI::Commands::Version, aliases: ["v", "-v", "--version"]
+Foo::CLI::Commands.register "exec",    Foo::CLI::Commands::Exec
 
 Foo::CLI::Commands.register "hello",       Foo::CLI::Commands::Hello
 Foo::CLI::Commands.register "greeting",    Foo::CLI::Commands::Greeting
@@ -481,16 +493,6 @@ module Foo
           puts "dir: #{dir}, url: #{url.inspect}"
         end
       end
-
-      class Bar < Hanami::CLI::Command
-        desc "Generate webpack configuration"
-
-        argument :apps, desc: "Generate webpack apps", type: :array, required: true
-
-        def call(apps:, **)
-          puts "bar. Apps: #{apps}"
-        end
-      end
     end
   end
 end
@@ -499,7 +501,6 @@ Foo::CLI::Commands.register "generate webpack", Foo::Webpack::CLI::Generate
 Foo::CLI::Commands.register "hello",            Foo::Webpack::CLI::Hello
 Foo::CLI::Commands.register "sub command",      Foo::Webpack::CLI::SubCommand
 Foo::CLI::Commands.register "callbacks",        Foo::Webpack::CLI::CallbacksCommand
-Foo::CLI::Commands.register "bar",              Foo::Webpack::CLI::Bar
 
 # we need to be sure that command will not override with nil command
 Foo::CLI::Commands.register "generate webpack", nil


### PR DESCRIPTION
## Features

### Array arguments

Captures all the remaining arguments in a single array.
Please note that `array` argument must be used as last argument as it works as a _"catch-all"_.

```ruby
#!/usr/bin/env ruby
require "bundler/setup"
require "hanami/cli"

module Foo
  module CLI
    module Commands
      extend Hanami::CLI::Registry

      class Exec < Hanami::CLI::Command
        desc "Execute a task"

        argument :task, type: :string, required: true,  desc: "Task to be executed"
        argument :dirs, type: :array,  required: false, desc: "Optional directories"

        def call(task:, dirs: [], **)
          puts "exec - task: #{task}, dirs: #{dirs.inspect}"
        end
      end

      register "exec", Exec
    end
  end
end

Hanami::CLI.new(Foo::CLI::Commands).call
```

```shell
% foo exec test
exec - task: test, dirs: []
```

```shell
% foo exec test spec/bookshelf/entities spec/bookshelf/repositories
exec - task: test, dirs: ["spec/bookshelf/entities", "spec/bookshelf/repositories"]
```

### Array Options

```ruby
#!/usr/bin/env ruby
require "bundler/setup"
require "hanami/cli"

module Foo
  module CLI
    module Commands
      extend Hanami::CLI::Registry

      module Generate
        class Configuration < Hanami::CLI::Command
          desc "Generate configuration"

          option :apps, type: :array, default: [], desc: "Generate configuration for specific apps"

          def call(apps: **)
            puts "generated configuration for apps: #{apps.inspect}"
          end
        end
      end

      register "generate", aliases: ["g"] do |prefix|
        prefix.register "config", Generate::Configuration
      end
    end
  end
end

Hanami::CLI.new(Foo::CLI::Commands).call
```

```shell
% foo generate config --apps=web,api
generated configuration for apps: ["web", "api"]
```

---

Closes https://github.com/hanami/cli/issues/12