### PR TITLE
Add source_code_uri to gemspec

### DIFF
--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://hanamirb.org"
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
+  spec.metadata['source_code_uri'] = "https://github.com/hanami/cli"
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
[The rubygems page for `hanami-cli`](https://rubygems.org/gems/hanami-cli) doesn't link to (this) github repo. 

There's [soon-to-be-documented](https://github.com/rubygems/guides/pull/195) metadata fields that rubygems.org uses. The one we're adding here is `source_code_uri`.  It adds a "Source Code" link to the rubygems.org page for the gem. 

Example:
https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk/aws-sdk.gemspec#L18
https://rubygems.org/gems/aws-sdk

We may want to add some of the other metadata fields that are available:
```
changelog_uri
documentation_uri
wiki_uri
mailing_list_uri
bug_tracker_uri
download_uri
```

But let's see how this works; it may be enough. 
We should decide which we want, and apply the same changes to all Hanami repos. 🌸 

(Thanks to @bkuhlmann for pointing this out) 