### PR TITLE
Added README table of contents (TOC).

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,34 @@ General purpose Command Line Interface (CLI) framework for Ruby.
 
 :warning: **This is a general framework for Ruby (aka `thor` gem replacement), NOT the implementation of the `hanami` CLI commands** :warning:
 
+<!-- Tocer[start]: Auto-generated, don't remove. -->
+
+## Table of Contents
+
+  - [Features](#features)
+    - [Registration](#registration)
+    - [Commands as objects](#commands-as-objects)
+    - [Subcommands](#subcommands)
+    - [Arguments](#arguments)
+    - [Option](#option)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Available commands](#available-commands)
+    - [Help](#help)
+    - [Optional arguments](#optional-arguments)
+    - [Required arguments](#required-arguments)
+    - [Options](#options)
+    - [Boolean options](#boolean-options)
+    - [Subcommands](#subcommands-1)
+    - [Aliases](#aliases)
+    - [Subcommand aliases](#subcommand-aliases)
+  - [Development](#development)
+  - [Contributing](#contributing)
+  - [Alternatives](#alternatives)
+  - [Copyright](#copyright)
+
+<!-- Tocer[finish]: Auto-generated, don't remove. -->
+
 ## Features
 
 ### Registration


### PR DESCRIPTION
## Overview

Improves readability by being able to navigate the documentation with
clickable links. You can move the location of the TOC around in the
document as you like but is best if placed right after the document
label.

At any time, you can regenerate the TOC by running `tocer -g` from the
CLI. Everything else will be handled for you. There is no further
maintenance required. It's a good practice to do this during each
version release.

For more information (or advanced usage) of the Tocer gem, check out
the project [README](https://github.com/bkuhlmann/tocer) for details.

## Screenshots

![toc](https://user-images.githubusercontent.com/50245/31576914-5f1a6a1a-b0c2-11e7-945f-92dd9ca22710.png)
