### PR TITLE
Make unused arguments available to the end user

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -13,6 +13,20 @@ module Hanami
     require "hanami/cli/usage"
     require "hanami/cli/banner"
 
+    class << self
+      # Returns a list of arguments have not been defined for the subcommand.
+      #
+      # @return [Array] list of unused arguments
+      # @since 0.2.0
+      attr_reader :unused_arguments
+
+      # Assigns the unused arguments from the parser.
+      #
+      # @since 0.2.0
+      # @api private
+      attr_writer :unused_arguments
+    end
+
     # Check if command
     #
     # @param command [Object] the command to check

--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -51,6 +51,8 @@ module Hanami
         parse_required_params = Hash[command.required_arguments.map(&:name).zip(arguments)]
         all_required_params_satisfied = command.required_arguments.all? { |param| !parse_required_params[param.name].nil? }
 
+        Hanami::CLI.unused_arguments = arguments.drop(command.required_arguments.length).freeze
+
         unless all_required_params_satisfied
           parse_required_params_values = parse_required_params.values.compact
 

--- a/spec/integration/commands_spec.rb
+++ b/spec/integration/commands_spec.rb
@@ -141,5 +141,24 @@ RSpec.describe "Commands" do
         expect(output).to eq("response: bye, person: Alfonso\n")
       end
     end
+
+    context "with extra params" do
+      it "is accessible via Hanami::CLI.unused_arguments" do
+        output = `foo variadic default bar baz`
+        expect(output).to eq("Unused Arguments: bar, baz\n")
+      end
+
+      it "is an empty array by default" do
+        output = `foo variadic default`
+        expect(output).to eq("Unused Arguments: \n")
+      end
+
+      context 'when there is a required argument' do
+        it 'parses both separately' do
+          output = `foo variadic with-mandatory foo bar baz`
+          expect(output).to eq("first: foo\nUnused Arguments: bar, baz\n")
+        end
+      end
+    end
   end
 end

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Rendering" do
         foo routes                             # Print routes
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
+        foo variadic [SUBCOMMAND]
         foo version                            # Print Foo version
     DESC
 
@@ -69,6 +70,7 @@ RSpec.describe "Rendering" do
         foo routes                             # Print routes
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
+        foo variadic [SUBCOMMAND]
         foo version                            # Print Foo version
     DESC
 
@@ -91,6 +93,7 @@ RSpec.describe "Rendering" do
         foo routes                             # Print routes
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
+        foo variadic [SUBCOMMAND]
         foo version                            # Print Foo version
     DESC
 

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -358,6 +358,25 @@ module Foo
         end
       end
 
+      class VariadicArguments < Hanami::CLI::Command
+        desc "accept multiple arguments at the end of the command"
+
+        def call(*)
+          puts "Unused Arguments: #{Hanami::CLI.unused_arguments.join(', ')}"
+        end
+      end
+
+      class MandatoryAndVariadicArguments < Hanami::CLI::Command
+        desc "require one command and accept multiple other arguments"
+
+        argument :first, desc: 'mandatory first argument', required: true
+
+        def call(first:, **)
+          puts "first: #{first}"
+          puts "Unused Arguments: #{Hanami::CLI.unused_arguments.join(', ')}"
+        end
+      end
+
       module Sub
         class Command < Hanami::CLI::Command
           def call(*)
@@ -404,6 +423,9 @@ Foo::CLI::Commands.register "version", Foo::CLI::Commands::Version, aliases: ["v
 Foo::CLI::Commands.register "hello",       Foo::CLI::Commands::Hello
 Foo::CLI::Commands.register "greeting",    Foo::CLI::Commands::Greeting
 Foo::CLI::Commands.register "sub command", Foo::CLI::Commands::Sub::Command
+
+Foo::CLI::Commands.register "variadic default",        Foo::CLI::Commands::VariadicArguments
+Foo::CLI::Commands.register "variadic with-mandatory", Foo::CLI::Commands::MandatoryAndVariadicArguments
 
 module Foo
   module Webpack


### PR DESCRIPTION
In several use cases users will want to allow their CLI users to pass in
a variable number of arguments to the CLI.

Example:

```bash
ssh root@192.168.0.1 -- /bin/bash -c "echo '127.0.0.1 myapp.com' >
/etc/hosts"

docker run -it --rm postgres:latest /bin/bash

cat foo.txt bar.txt baz.txt
```

This commit allows users to process unused arguments by assigning them
to `Hanami::CLI.unused_arguments`

Closes #26