### PR TITLE
Revert PR #27

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -13,20 +13,6 @@ module Hanami
     require "hanami/cli/usage"
     require "hanami/cli/banner"
 
-    class << self
-      # Returns a list of arguments have not been defined for the subcommand.
-      #
-      # @return [Array] list of unused arguments
-      # @since 0.2.0
-      attr_reader :unused_arguments
-
-      # Assigns the unused arguments from the parser.
-      #
-      # @since 0.2.0
-      # @api private
-      attr_writer :unused_arguments
-    end
-
     # Check if command
     #
     # @param command [Object] the command to check

--- a/lib/hanami/cli/parser.rb
+++ b/lib/hanami/cli/parser.rb
@@ -51,8 +51,6 @@ module Hanami
         parse_required_params = Hash[command.required_arguments.map(&:name).zip(arguments)]
         all_required_params_satisfied = command.required_arguments.all? { |param| !parse_required_params[param.name].nil? }
 
-        Hanami::CLI.unused_arguments = arguments.drop(command.required_arguments.length).freeze
-
         unless all_required_params_satisfied
           parse_required_params_values = parse_required_params.values.compact
 

--- a/spec/integration/commands_spec.rb
+++ b/spec/integration/commands_spec.rb
@@ -141,34 +141,5 @@ RSpec.describe "Commands" do
         expect(output).to eq("response: bye, person: Alfonso\n")
       end
     end
-
-    context "with extra params" do
-      it "is accessible via Hanami::CLI.unused_arguments" do
-        output = `foo variadic default bar baz`
-        expect(output).to eq("Unused Arguments: bar, baz\n")
-      end
-
-      it "is an empty array by default" do
-        output = `foo variadic default`
-        expect(output).to eq("Unused Arguments: \n")
-      end
-
-      context "when there is a required argument" do
-        it "parses both separately" do
-          output = `foo variadic with-mandatory foo bar baz`
-          expect(output).to eq("first: foo\nUnused Arguments: bar, baz\n")
-        end
-
-        context "and there are options" do
-          it "parses both separately" do
-            output = `foo variadic with-mandatory-and-options foo bar baz`
-            expect(output).to eq("first: foo\nurl: \nmethod: \nUnused Arguments: bar, baz\n")
-
-            output = `foo variadic with-mandatory-and-options --url="root" --method="index" foo bar baz`
-            expect(output).to eq("first: foo\nurl: root\nmethod: index\nUnused Arguments: bar, baz\n")
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Rendering" do
         foo routes                             # Print routes
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
-        foo variadic [SUBCOMMAND]
         foo version                            # Print Foo version
     DESC
 
@@ -70,7 +69,6 @@ RSpec.describe "Rendering" do
         foo routes                             # Print routes
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
-        foo variadic [SUBCOMMAND]
         foo version                            # Print Foo version
     DESC
 
@@ -93,7 +91,6 @@ RSpec.describe "Rendering" do
         foo routes                             # Print routes
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
-        foo variadic [SUBCOMMAND]
         foo version                            # Print Foo version
     DESC
 

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -358,43 +358,6 @@ module Foo
         end
       end
 
-<<<<<<< HEAD
-      class VariadicArguments < Hanami::CLI::Command
-        desc "accept multiple arguments at the end of the command"
-
-        def call(*)
-          puts "Unused Arguments: #{Hanami::CLI.unused_arguments.join(', ')}"
-        end
-      end
-
-      class MandatoryAndVariadicArguments < Hanami::CLI::Command
-        desc "require one command and accept multiple unused arguments"
-
-        argument :first, desc: 'mandatory first argument', required: true
-
-        def call(first:, **)
-          puts "first: #{first}"
-          puts "Unused Arguments: #{Hanami::CLI.unused_arguments.join(', ')}"
-        end
-      end
-
-      class MandatoryOptionsAndVariadicArguments < Hanami::CLI::Command
-        desc "require one command, accept options and multiple unused arguments"
-
-        argument :first, desc: 'mandatory first argument', required: true
-        option :url, desc: "The action URL"
-        option :method, desc: "The action HTTP method"
-
-        def call(params = {})
-          puts "first: #{params[:first]}"
-          puts "url: #{params[:url]}"
-          puts "method: #{params[:method]}"
-          puts "Unused Arguments: #{Hanami::CLI.unused_arguments.join(', ')}"
-        end
-      end
-
-=======
->>>>>>> parent of 2ab7871... Make unused arguments available to the end user
       module Sub
         class Command < Hanami::CLI::Command
           def call(*)

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -358,6 +358,7 @@ module Foo
         end
       end
 
+<<<<<<< HEAD
       class VariadicArguments < Hanami::CLI::Command
         desc "accept multiple arguments at the end of the command"
 
@@ -392,6 +393,8 @@ module Foo
         end
       end
 
+=======
+>>>>>>> parent of 2ab7871... Make unused arguments available to the end user
       module Sub
         class Command < Hanami::CLI::Command
           def call(*)
@@ -438,10 +441,6 @@ Foo::CLI::Commands.register "version", Foo::CLI::Commands::Version, aliases: ["v
 Foo::CLI::Commands.register "hello",       Foo::CLI::Commands::Hello
 Foo::CLI::Commands.register "greeting",    Foo::CLI::Commands::Greeting
 Foo::CLI::Commands.register "sub command", Foo::CLI::Commands::Sub::Command
-
-Foo::CLI::Commands.register "variadic default",                    Foo::CLI::Commands::VariadicArguments
-Foo::CLI::Commands.register "variadic with-mandatory",             Foo::CLI::Commands::MandatoryAndVariadicArguments
-Foo::CLI::Commands.register "variadic with-mandatory-and-options", Foo::CLI::Commands::MandatoryOptionsAndVariadicArguments
 
 module Foo
   module Webpack


### PR DESCRIPTION
This PR reverts #27 

There are two reasons:

  1. It's a new feature that landed in `master`, but it should've been in `develop`. This holds the release of `1.1.1`.
  1. The implementation alters the global state at the runtime, by assigning unused arguments for the current command to `Hanami::CLI.unused_arguments`. This isn't thread safe.

---

I'd love to keep this feature, but with a different implementation. Maybe passing the unused arguments to `Result`.

/cc @whoward 