### PR TITLE
Add usage descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ module Foo
     module Commands
       extend Hanami::CLI::Registry
 
+      usage_description before: 'This is Usage header.',
+        after: 'This is additional comment.'
+
       class Version < Hanami::CLI::Command
         desc "Print version"
 
@@ -330,12 +333,16 @@ Let's have a look at the command line usage.
 
 ```shell
 % foo
+This is usage header.
+
 Commands:
   foo echo [INPUT]                       # Print input
   foo generate [SUBCOMMAND]
   foo start ROOT                         # Start Foo machinery
   foo stop                               # Stop Foo machinery
   foo version                            # Print version
+
+This is additional comment.
 ```
 
 ### Help

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -106,7 +106,7 @@ module Hanami
     # @since 0.1.0
     # @api private
     def usage(result, out)
-      Usage.call(result, out)
+      Usage.call(result, out, commands.usage_descriptions)
       exit(1)
     end
 

--- a/lib/hanami/cli/registry.rb
+++ b/lib/hanami/cli/registry.rb
@@ -6,11 +6,17 @@ module Hanami
     #
     # @since 0.1.0
     module Registry
+
+      # @since 0.2.1
+      # @api private
+      attr_reader :usage_descriptions
+
       # @since 0.1.0
       # @api private
       def self.extended(base)
         base.class_eval do
           @commands = CommandRegistry.new
+          @usage_descriptions = {}
         end
       end
 
@@ -250,6 +256,29 @@ module Hanami
       #   end
       def after(command_name, callback = nil, &blk)
         command(command_name).after_callbacks.append(&_callback(callback, blk))
+      end
+
+      # Add usage description
+      #
+      # @param before [String] the description at the beginning of usage 
+      # @param after [String] the description at the end of usage
+      #
+      # @since 0.2.1
+      #
+      # @example
+      #   require "hanami/cli"
+      #
+      #   module Foo
+      #     module Commands
+      #       extend Hanami::CLI::Registry
+      #       usage_description before: 'This will be visible before usage.', 
+      #         after: 'This will be visible after usage.'
+      #
+      #     end
+      #   end
+      #
+      def usage_description(options)
+        @usage_descriptions = options
       end
 
       # @since 0.1.0

--- a/lib/hanami/cli/registry.rb
+++ b/lib/hanami/cli/registry.rb
@@ -6,7 +6,6 @@ module Hanami
     #
     # @since 0.1.0
     module Registry
-
       # @since 0.2.1
       # @api private
       attr_reader :usage_descriptions
@@ -260,7 +259,7 @@ module Hanami
 
       # Add usage description
       #
-      # @param before [String] the description at the beginning of usage 
+      # @param before [String] the description at the beginning of usage
       # @param after [String] the description at the end of usage
       #
       # @since 0.2.1
@@ -271,7 +270,7 @@ module Hanami
       #   module Foo
       #     module Commands
       #       extend Hanami::CLI::Registry
-      #       usage_description before: 'This will be visible before usage.', 
+      #       usage_description before: 'This will be visible before usage.',
       #         after: 'This will be visible after usage.'
       #
       #     end

--- a/lib/hanami/cli/registry.rb
+++ b/lib/hanami/cli/registry.rb
@@ -15,7 +15,7 @@ module Hanami
       def self.extended(base)
         base.class_eval do
           @commands = CommandRegistry.new
-          @usage_descriptions = {}
+          @usage_descriptions = Concurrent::Hash.new
         end
       end
 
@@ -277,7 +277,7 @@ module Hanami
       #   end
       #
       def usage_description(options)
-        @usage_descriptions = options
+        @usage_descriptions.merge!(options)
       end
 
       # @since 0.1.0

--- a/lib/hanami/cli/usage.rb
+++ b/lib/hanami/cli/usage.rb
@@ -13,7 +13,9 @@ module Hanami
 
       # @since 0.1.0
       # @api private
-      def self.call(result, out)
+      def self.call(result, out, descriptions)
+        out.puts descriptions[:before] + "\n\n" if show_description?(:before, result, descriptions)
+
         out.puts "Commands:"
         max_length, commands = commands_and_arguments(result)
 
@@ -21,6 +23,8 @@ module Hanami
           usage = description(node.command) if node.leaf?
           out.puts "#{justify(banner, max_length, usage)}#{usage}"
         end
+
+        out.puts "\n" + descriptions[:after] if show_description?(:after, result, descriptions)
       end
 
       # @since 0.1.0
@@ -83,6 +87,12 @@ module Hanami
       def self.command_name(result, name)
         ProgramName.call([result.names, name])
       end
+
+      # @since 0.2.1
+      # @api private
+      def self.show_description?(name, result, descriptions)
+        descriptions.key?(name) && result.names.none?
+      end 
     end
   end
 end

--- a/lib/hanami/cli/usage.rb
+++ b/lib/hanami/cli/usage.rb
@@ -14,7 +14,7 @@ module Hanami
       # @since 0.1.0
       # @api private
       def self.call(result, out, descriptions)
-        out.puts descriptions[:before] + "\n\n" if show_description?(:before, result, descriptions)
+        show_description :before, result, out, descriptions
 
         out.puts "Commands:"
         max_length, commands = commands_and_arguments(result)
@@ -24,7 +24,7 @@ module Hanami
           out.puts "#{justify(banner, max_length, usage)}#{usage}"
         end
 
-        out.puts "\n" + descriptions[:after] if show_description?(:after, result, descriptions)
+        show_description :after, result, out, descriptions
       end
 
       # @since 0.1.0
@@ -90,9 +90,10 @@ module Hanami
 
       # @since 0.2.1
       # @api private
-      def self.show_description?(name, result, descriptions)
-        descriptions.key?(name) && result.names.none?
-      end 
+      def self.show_description(name, result, out, descriptions)
+        return unless descriptions.key?(name) && result.names.none?
+        out.puts name == :before ? descriptions[name] + "\n\n" : "\n" + descriptions[name]
+      end
     end
   end
 end

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Rendering" do
   it "prints required params and banners" do
-    output = `foo 2>&1`
+    output = `foo`
 
     expected = <<~DESC
       This is before description.

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -1,8 +1,10 @@
 RSpec.describe "Rendering" do
-  it "prints required params" do
-    output = `foo`
+  it "prints required params and banners" do
+    output = `foo 2>&1`
 
     expected = <<~DESC
+      This is before description.
+
       Commands:
         foo assets [SUBCOMMAND]
         foo callbacks DIR                      # Command with callbacks
@@ -17,6 +19,8 @@ RSpec.describe "Rendering" do
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
         foo version                            # Print Foo version
+
+      This is after description.
     DESC
 
     expect(output).to eq(expected)
@@ -58,6 +62,8 @@ RSpec.describe "Rendering" do
     output = `foo unknown`
 
     expected = <<~DESC
+      This is before description.
+
       Commands:
         foo assets [SUBCOMMAND]
         foo callbacks DIR                      # Command with callbacks
@@ -72,6 +78,8 @@ RSpec.describe "Rendering" do
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
         foo version                            # Print Foo version
+
+      This is after description.
     DESC
 
     expect(output).to eq(expected)
@@ -81,6 +89,8 @@ RSpec.describe "Rendering" do
     output = `foo`
 
     expected = <<~DESC
+      This is before description.
+
       Commands:
         foo assets [SUBCOMMAND]
         foo callbacks DIR                      # Command with callbacks
@@ -95,6 +105,8 @@ RSpec.describe "Rendering" do
         foo server                             # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
         foo version                            # Print Foo version
+
+      This is after description.
     DESC
 
     expect(output).to eq(expected)

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -7,6 +7,9 @@ module Foo
     module Commands
       extend Hanami::CLI::Registry
 
+      usage_description before: 'This is before description.',
+        after: 'This is after description.'
+
       class Command < Hanami::CLI::Command
       end
 

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -8,7 +8,7 @@ module Foo
       extend Hanami::CLI::Registry
 
       usage_description before: 'This is before description.',
-        after: 'This is after description.'
+                        after: 'This is after description.'
 
       class Command < Hanami::CLI::Command
       end


### PR DESCRIPTION
Sometimes when creating a CLI utility we want to add some extra text before or after the usage. This PR adds `usage_description` which allows setting a Usage header and footer with` before` and `after`. **I know naming is not perfect, I'm super-open to suggestions!**

Our case: we have a semi-mandatory (you can set a default in configuration) `--country` argument for almost every command in our toolkit but to know that you need to run `foo command --help`.