### PR TITLE
Inheritable commands

### DIFF
--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -3,6 +3,7 @@
 require "forwardable"
 require "concurrent/array"
 require "hanami/cli/option"
+require "hanami/utils/class_attribute"
 
 module Hanami
   class CLI
@@ -22,32 +23,28 @@ module Hanami
       module ClassMethods
         # @since 0.1.0
         # @api private
+        #
+        # rubocop:disable Metrics/MethodLength
         def self.extended(base)
           super
 
           base.class_eval do
-            @description  = nil
-            @examples     = Concurrent::Array.new
-            @arguments    = Concurrent::Array.new
-            @options      = Concurrent::Array.new
+            include Utils::ClassAttribute
+
+            class_attribute :description
+            self.description = nil
+
+            class_attribute :examples
+            self.examples = Concurrent::Array.new
+
+            class_attribute :arguments
+            self.arguments = Concurrent::Array.new
+
+            class_attribute :options
+            self.options = Concurrent::Array.new
           end
         end
-
-        # @since 0.1.0
-        # @api private
-        attr_reader :description
-
-        # @since 0.1.0
-        # @api private
-        attr_reader :examples
-
-        # @since 0.1.0
-        # @api private
-        attr_reader :arguments
-
-        # @since 0.1.0
-        # @api private
-        attr_reader :options
+        # rubocop:enable Metrics/MethodLength
       end
 
       # Set the description of the command
@@ -67,7 +64,7 @@ module Hanami
       #     end
       #   end
       def self.desc(description)
-        @description = description
+        self.description = description
       end
 
       # Describe the usage of the command
@@ -103,7 +100,7 @@ module Hanami
       #   #     foo server --port=2306         # Bind to a port
       #   #     foo server --no-code-reloading # Disable code reloading
       def self.example(*examples)
-        @examples += examples.flatten
+        self.examples += examples.flatten
       end
 
       # Specify an argument
@@ -197,7 +194,7 @@ module Hanami
       #   #   Options:
       #   #     --help, -h          # Print this help
       def self.argument(name, options = {})
-        @arguments << Argument.new(name, options)
+        arguments << Argument.new(name, options)
       end
 
       # Command line option (aka optional argument)
@@ -311,13 +308,13 @@ module Hanami
       #   # Options:
       #   #   --port=VALUE, -p VALUE
       def self.option(name, options = {})
-        @options << Option.new(name, options)
+        self.options << Option.new(name, options)
       end
 
       # @since 0.1.0
       # @api private
       def self.params
-        (@arguments + @options).uniq
+        (arguments + options).uniq
       end
 
       # @since 0.1.0

--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -27,6 +27,7 @@ module Hanami
         # rubocop:disable Metrics/MethodLength
         def self.extended(base)
           super
+          return unless extend?(base)
 
           base.class_eval do
             include Utils::ClassAttribute
@@ -45,6 +46,39 @@ module Hanami
           end
         end
         # rubocop:enable Metrics/MethodLength
+
+        # Only add class attributes if a command is inheriting directly from `Hanami::CLI::Command`.
+        # In this way, its subclasses can inherit arguments/options from the parent class.
+        #
+        # @return [TrueClass,FalseClass] the result of the check
+        #
+        # @since x.x.x
+        # @api private
+        #
+        # @example
+        #   # For this class `extend?` will return `true`
+        #   class Server < Hanami::CLI::Command
+        #     option :engine
+        #
+        #     def call(**options)
+        #       # start the server
+        #     end
+        #   end
+        #
+        #   # For this class `extend?` will return `false`
+        #   class ServerReloader < Server
+        #     option :reload, type: :boolean, default: true
+        #
+        #     def call(**options)
+        #       reload = options.fetch(:reload)
+        #       super unless reload
+        #
+        #       # activate reloading
+        #     end
+        #   end
+        def self.extend?(base)
+          base.superclass == Hanami::CLI::Command
+        end
       end
 
       # Set the description of the command

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -321,14 +321,12 @@ module Foo
         option :warn,           desc: "Turn on warnings"
         option :daemonize,      desc: "Daemonize the server"
         option :pid,            desc: "Path to write a pid file after daemonize"
-        option :code_reloading, desc: "Code reloading", type: :boolean, default: true
 
         example [
           "                    # Basic usage (it uses the bundled server engine)",
           "--server=webrick    # Force `webrick` server engine",
           "--host=0.0.0.0      # Bind to a host",
-          "--port=2306         # Bind to a port",
-          "--no-code-reloading # Disable code reloading"
+          "--port=2306         # Bind to a port"
         ]
 
         def call(options)
@@ -506,6 +504,26 @@ Foo::CLI::Commands.register "callbacks",        Foo::Webpack::CLI::CallbacksComm
 
 # we need to be sure that command will not override with nil command
 Foo::CLI::Commands.register "generate webpack", nil
+
+module Foo
+  module Reloader
+    module CLI
+      class Server < Foo::CLI::Commands::Server
+        option :code_reloading, type: :boolean, default: true, desc: "Code reloading"
+
+        example [
+          "--no-code-reloading # Disable code reloading"
+        ]
+
+        def call(options)
+          super
+        end
+      end
+    end
+  end
+end
+
+Foo::CLI::Commands.register "server", Foo::Reloader::CLI::Server
 
 Foo::CLI::Commands.before("callbacks") do |args|
   puts "before command callback #{self.class.name} #{args.inspect}"


### PR DESCRIPTION
## Feature

Allow third-party command providers to inherit from an original command and use `super`, if needed.

## Real problem (solved)

`hanami` 2.0 will not provide directly code reloading, but there will be `hanami-reloader` to add this feature. It's `Hanami::Reloader::CLI::Server`.

`hanami-reloader` needs to provide an object that is responsible for `hanami server` command. It works fine, but there are a few problems.

### Original options are gone

By calling `hanami server --help` all the original CLI options from `hanami` (the gem) are **gone**:

```shell
$ bundle exec hanami sever --help
Command:
  hanami server

Usage:
  hanami server

Options:
  --guardfile=VALUE               	# Path to Guardfile, default: "/Users/luca/Code/soundeck/Guardfile"
  --[no-]code-reloading           	# Code reloading, default: true
  --help, -h                      	# Print this help
```

These options above are provided by `hanami-reloader`.

The only way to solve this problem was to **copy all the original options from `Hanami::CLI::Commands::Server` to `Hanami::Reloader::CLI::Server`**.

This solution doesn't provide an easy maintenance experience for third-party devs, because they need to keep in sync the options/arguments of their commands (e.g. `Hanami::Reloader::CLI::Server`) with the options/arguments of the corresponding original command (e.g. `Hanami::CLI::Commands::Server`).

### Can't invoke `super`

What if we want to skip code reloading for a second? There was no way for `Hanami::Reloader::CLI::Server` to invoke `super` unless all the _options_ from `Hanami::CLI::Commands::Server` were copied `Hanami::Reloader::CLI::Server`.

## Solution

Allow `Hanami::Reloader::CLI::Server` inherit from `Hanami::CLI::Commands::Server`. By doing so, **it inherits all the original options/arguments**, and it's able to invoke `super` in case we want to skip code reloading.

Here's the results applying this PR:

### Options in help

```shell
$ bundle exec hanami server --help
Command:
  hanami server

Usage:
  hanami server

Description:
  Start Hanami server (only for development)

Options:
  --server=VALUE                  	# Force a server engine (eg, webrick, puma, thin, etc..)
  --host=VALUE                    	# The host address to bind to
  --port=VALUE, -p VALUE          	# The port to run the server on
  --[no-]debug                    	# Turn on debug output
  --[no-]warn                     	# Turn on warnings
  --[no-]daemonize                	# Daemonize the server
  --pid=VALUE                     	# Path to write a pid file after daemonize
  --guardfile=VALUE               	# Path to Guardfile, default: "/Users/luca/Code/soundeck/Guardfile"
  --[no-]code-reloading           	# Code reloading, default: true
  --help, -h                      	# Print this help

Examples:
  hanami server                     # Basic usage (it uses the bundled server engine)
  hanami server --server=webrick    # Force `webrick` server engine
  hanami server --host=0.0.0.0      # Bind to a host
  hanami server --port=2306         # Bind to a port
  hanami server --no-code-reloading # Disable code reloading
```

⚠️  Please note that the command invoked is the one from `hanami-reloader`, which enrich the original one from `hanami`, by adding a few extra options and examples.

### Code reloading

In this case `hanami-reloader` hijacks the call to `hanami server` and provides code reloading functionality.

```shell
$ bundle exec hanami server
10:26:35 - INFO - Using Guardfile at /Users/luca/Code/soundeck/Guardfile.
10:26:35 - INFO - Puma starting on port 2300 in development environment.
10:26:35 - INFO - Guard is now watching at '/Users/luca/Code/soundeck'
Puma starting in single mode...
* Version 3.12.0 (ruby 2.6.0-p0), codename: Llamas in Pajamas
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:2300
* Starting control server on tcp://localhost:9293
Use Ctrl-C to stop
```

### No code reloading

Because `--no-code-reloading` is used `hanami-reloader` returns the control to the original command from `hanami` by calling `super`.

```shell
$ bundle exec hanami server --no-code-reloading
Puma starting in single mode...
* Version 3.12.0 (ruby 2.6.0-p0), codename: Llamas in Pajamas
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:2300
Use Ctrl-C to stop
```