### PR TITLE
Fix command `hanami db rollback`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "hanami", require: false, git: "https://github.com/hanami/hanami.git", branch: "unstable"
-gem "hanami-view", require: false, git: "https://github.com/hanami/view.git", branch: "unstable"
+gem "hanami", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"
+gem "hanami-view", require: false, git: "https://github.com/hanami/view.git", branch: "main"
 
 gem "rack"
 

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-cli", "~> 0.6"
   spec.add_dependency "dry-files", "~> 0.1"
   spec.add_dependency "dry-inflector", "~> 0.2"
+  spec.add_dependency "rom-sql", "~> 3.5.0"
 
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "rubocop", "~> 1.11"

--- a/lib/hanami/cli/commands/db/utils/database.rb
+++ b/lib/hanami/cli/commands/db/utils/database.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sequel"
+require "sequel/extensions/migration"
 require_relative "database_config"
 
 module Hanami

--- a/lib/hanami/cli/commands/monolith/db/rollback.rb
+++ b/lib/hanami/cli/commands/monolith/db/rollback.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "pry"
 
 require_relative "../../application"
 require_relative "structure/dump"
@@ -24,6 +25,8 @@ module Hanami
 
               measure "database #{database.name} rolled back to #{migration_name}" do
                 database.run_migrations(target: Integer(migration_code))
+
+                true
               end
 
               run_command Structure::Dump if dump
@@ -36,7 +39,7 @@ module Hanami
                 if code
                   migrations.detect { |m| m.split("_").first == code }
                 else
-                  migrations.last
+                  migrations[-2]
                 end
               }
 

--- a/spec/unit/hanami/cli/commands/monolith/db/rollback_spec.rb
+++ b/spec/unit/hanami/cli/commands/monolith/db/rollback_spec.rb
@@ -3,13 +3,23 @@
 require "hanami/cli/commands/monolith/db/rollback"
 
 RSpec.describe Hanami::CLI::Commands::Monolith::DB::Rollback, :app, :command, :db do
+  it "rolls back to the second-to-last migration when target is not specified" do
+    allow(database).to receive(:applied_migrations).and_return(["312_create_users", "325_create_groups"])
+    allow(database).to receive(:run_migrations)
+
+    command.call(dump: false)
+
+    expect(database).to have_received(:run_migrations).with(target: 312)
+  end
+
   it "rolls back to specified migration" do
     expect(database).to receive(:applied_migrations).and_return(["312_create_users"])
-    expect(database).to receive(:run_migrations).with(target: 312).and_return(true)
+    expect(database).to receive(:run_migrations).with(target: 312)
 
     command.call(target: "312", dump: false)
 
     expect(output).to include("database test rolled back to 312_create_users")
+    expect(output).not_to match(/failed/i)
   end
 
   it "warns if target migration is not found" do


### PR DESCRIPTION
The command `hanami db rollback` wasn't working as expected: instead of rolling back the last migration it was crashing with a `NameError: uninitialized constant Hanami::CLI::Commands::DB::Utils::Database::Sequel`

Once this exception was fixed I also changed the logic to select the target migration, otherwise the last migration is selected and the database remains unchanged.

### TODO

- [ ] Still failing when there is only one migration applied