### PR TITLE
Fix console context (make slice readers properly available)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ unless ENV["CI"]
 end
 
 gem "hanami", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"
+gem "hanami-router", require: false, git: "https://github.com/hanami/router.git", branch: "main"
 gem "hanami-view", require: false, git: "https://github.com/hanami/view.git", branch: "main"
 
 gem "rack"

--- a/lib/hanami/cli/commands/monolith/console.rb
+++ b/lib/hanami/cli/commands/monolith/console.rb
@@ -25,7 +25,7 @@ module Hanami
 
           desc "Application REPL"
 
-          option :repl, required: false, desc: "REPL gem that should be used"
+          option :repl, required: false, desc: "REPL gem that should be used ('pry' or 'irb')"
 
           # @api private
           def call(repl: nil, **opts)
@@ -35,7 +35,6 @@ module Hanami
 
           private
 
-          # @api private
           def resolve_engine(repl, opts)
             if repl
               REPLS.fetch(repl).(application, opts)

--- a/lib/hanami/console/context.rb
+++ b/lib/hanami/console/context.rb
@@ -10,16 +10,20 @@ module Hanami
     # @since 2.0.0
     class Context < Module
       # @api private
-      def initialize(application)
-        @application = application
-      end
+      attr_reader :application
 
       # @api private
-      def extended(other)
-        super
-        app = @application
+      def initialize(application)
+        @application = application
 
-        extend(Plugins::SliceReaders.new(app))
+        define_context_methods
+        include Plugins::SliceReaders.new(application)
+      end
+
+      private
+
+      def define_context_methods
+        app = application
 
         define_method(:inspect) do
           "#<#{self.class} application=#{app} env=#{app.config.env}>"

--- a/lib/hanami/console/context.rb
+++ b/lib/hanami/console/context.rb
@@ -29,6 +29,14 @@ module Hanami
           "#<#{self.class} application=#{app} env=#{app.config.env}>"
         end
 
+        define_method(:app) do
+          app
+        end
+
+        define_method(:application) do
+          app
+        end
+
         define_method(:method_missing) do |name, *args, &block|
           return app.public_send(name, *args, &block) if app.respond_to?(name)
           super(name, *args, &block)

--- a/lib/hanami/console/plugins/slice_readers.rb
+++ b/lib/hanami/console/plugins/slice_readers.rb
@@ -12,27 +12,7 @@ module Hanami
         def initialize(application)
           application.slices.each do |(name, slice)|
             define_method(name) do
-              SliceDelegator.new(slice)
-            end
-          end
-        end
-
-        # @api private
-        # @since 2.0.0
-        class SliceDelegator < SimpleDelegator
-          # @api private
-          def respond_to_missing?(name)
-            key?(name)
-          end
-
-          private
-
-          # @api private
-          def method_missing(name, *args, &block)
-            if args.empty? && key?(name)
-              self[name]
-            else
-              super
+              slice
             end
           end
         end


### PR DESCRIPTION
This PR makes the slice readers properly available in the console context methods. With the previous approach, they were unavailable (e.g. in the console for our application template, typing `main` would raise a `NoMethodError`).

This could have been fixed most simply by changing `extend(Plugins::SliceReaders.new(app))` inside `Context.extended` so it was actually `other.extend(Plugins::SliceReaders.new(app))`. However, I took this change to refactor this module since we didn't actually have to define all this behavior at the moment of being extended (`other` was never used anywhere!) — since we have all the information we need at the time of initialization, that's the best time to define all the behavior. We can leave the module hooks alone until we actually need access to that `other` object for some reason.

Along with this, I've changed the slice readers so that they no longer automatic delegate to top-level components based on method_missing. This is a neat trick but I think it may lead to more confusion than convenience, especially given that the majority of slice behavior will not be available via these shortcuts, since most slice behavior will not typically reside in top-level components.

Lastly, I've also added a couple of extra top-level console convenience methods: `app` and `application`, both returning the current Hanami application. In actuality, `self` inside the console is _kind of_ a way to get to the application, but this is non-obvious, and its still somewhat indirect, since it won't return the application itself, but rather the REPL's context object that just so happens to delegate its missing methods to the application.