### PR TITLE
Properly show a custom prompt in IRB

### DIFF
--- a/lib/hanami/cli/repl/irb.rb
+++ b/lib/hanami/cli/repl/irb.rb
@@ -11,29 +11,26 @@ module Hanami
       class Irb < Core
         # @api public
         def start
+          $stdout.sync = true
+
           ARGV.shift until ARGV.empty?
           TOPLEVEL_BINDING.eval('self').extend(context)
 
-          IRB.conf[:PROMPT] = {}
+          # Initializes the IRB.conf; our own conf changes must be after this
+          IRB.setup(nil)
 
-          IRB.conf[:PROMPT][:MY_PROMPT] = {
-            :AUTO_INDENT => true,
-            :PROMPT_I =>  ">> ",
-            :PROMPT_S => nil,
-            :PROMPT_C => nil,
-            :RETURN => "    ==>%s\n"
+          IRB.conf[:PROMPT][:HANAMI] = {
+            AUTO_INDENT: true,
+            PROMPT_I: "#{prompt}> ",
+            PROMPT_N: "#{prompt}> ",
+            PROMPT_S: "#{prompt} %l> ",
+            PROMPT_C: "#{prompt} ?> ",
+            RETURN: "=> %s\n"
           }
 
-          IRB.conf[:PROMPT_MODE] = :MY_PROMPT
+          IRB.conf[:PROMPT_MODE] = :HANAMI
 
-          IRB.start
-        end
-
-        private
-
-        # @api private
-        def conf
-          @conf ||= IRB.conf
+          IRB::Irb.new.run
         end
       end
     end


### PR DESCRIPTION
This required us not to use IRB.start, which sets all initial vaues of IRB.conf in a place we can't control.

Instead, start IRB manually (by following the steps from the code inside IRB.start) and set our custom prompt config _after_ the initial IRB.conf has been prepared.

This ensures that the prompt will be respected when IRB finally runs.