### PR TITLE
Support `postgresql://` scheme designators

### DIFF
--- a/lib/hanami/cli/commands/db/utils/database.rb
+++ b/lib/hanami/cli/commands/db/utils/database.rb
@@ -19,6 +19,10 @@ module Hanami
                 require_relative("postgres")
                 Postgres
               },
+              "postgresql" => -> {
+                require_relative("postgres")
+                Postgres
+              },
               "mysql" => -> {
                 require_relative("mysql")
                 Mysql


### PR DESCRIPTION
According to PostgreSQL's docs, the URL scheme designator can be either
`postgresql://` or `postgres://.

This change duplicates the `"postgres"` entry to support both options.

[Docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING):

![image (14)](https://user-images.githubusercontent.com/10128/144765420-d609160d-acdf-417d-aac2-836bb1919490.png)


