### PR TITLE
Respect HANAMI_ENV if command line env option is not specified.

### DIFF
--- a/lib/hanami/cli/commands/application.rb
+++ b/lib/hanami/cli/commands/application.rb
@@ -11,14 +11,18 @@ module Hanami
         module Environment
           def call(**opts)
             env = opts[:env]
-            ENV["HANAMI_ENV"] = env.to_s
+
+            hanami_env = env ? env.to_s : ENV["HANAMI_ENV"] || "development"
+
+            ENV["HANAMI_ENV"] = hanami_env
+
             super(**opts)
           end
         end
 
         def self.inherited(klass)
           super
-          klass.option(:env, required: false, default: "development", desc: "Application's environment")
+          klass.option(:env, required: false, desc: "Application's environment")
           klass.prepend(Environment)
         end
 


### PR DESCRIPTION
Upgrading a Hanami 2 application from the unstable branch to hanami 2.0.0.alpha5, I noticed that — while setting the application environment via the `bin/hanami console --env environment` option works — setting it via a HANAMI_ENV environment variable no longer does:

```bash
# works
bin/hanami console --env production
hanami_app[production]> Hanami.env
=> :production

# no longer works
HANAMI_ENV=production bin/hanami console
hanami_app[development]> Hanami.env
=> :development # expected :production
```

I think this behaviour changed [in this commit](https://github.com/hanami/cli/commit/cd3a7b4458b5d2017fecbbe47d992fc068d5ebfb), in part due to the adoption of the development default? 

This PR proposes adjusting how Hanami.env is determined to adhere to the following:
- first use any environment specified via the `--env` option
- if no option is provided, use any environment specified by the HANAMI_ENV environment variable
- if no HANAMI_ENV variable is set, assume development

I am assuming that the above logic is what is preferred, but it may not be if the intention is to use `--env` exclusively — let me know :)

Note: the specs added here pass when using hanami/hanami on the commit previous to [this one](https://github.com/hanami/hanami/commit/8bb320cac55d93bb1bb79d0831b4c27f4436047d). That commit causes broader spec failures in hanami/cli 
