### PR TITLE
Fix redundant method when loading database command

### DIFF
--- a/lib/hanami/cli/commands/db/utils/database.rb
+++ b/lib/hanami/cli/commands/db/utils/database.rb
@@ -69,7 +69,7 @@ module Hanami
             def rom_config
               @rom_config ||=
                 begin
-                  application.init_bootable(:persistence)
+                  application.prepare(:persistence)
                   application.container["persistence.config"]
                 end
             end


### PR DESCRIPTION
The method `init_bootable` is redundant, replaced by `prepare`

Solve issue https://github.com/hanami/cli/issues/10