### PR TITLE
Add `hanami server` command

### DIFF
--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "rubocop", "~> 1.0"
+  spec.add_development_dependency "puma"
 end

--- a/lib/hanami/cli/commands/monolith.rb
+++ b/lib/hanami/cli/commands/monolith.rb
@@ -10,6 +10,7 @@ module Hanami
         require_relative "monolith/install"
         require_relative "monolith/generate"
         require_relative "monolith/console"
+        require_relative "monolith/server"
         require_relative "monolith/db/create"
         require_relative "monolith/db/create_migration"
         require_relative "monolith/db/drop"
@@ -35,6 +36,8 @@ module Hanami
             # end
 
             register "console", Commands::Monolith::Console
+
+            register "server", Commands::Monolith::Server
 
             register "db create", Commands::Monolith::DB::Create
             register "db create_migration", Commands::Monolith::DB::CreateMigration

--- a/lib/hanami/cli/commands/monolith/server.rb
+++ b/lib/hanami/cli/commands/monolith/server.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rack"
+require_relative "../application"
+require_relative "../../server"
+
+module Hanami
+  module CLI
+    module Commands
+      module Monolith
+        # Launch Hanami web server.
+        #
+        # It's intended to be used only on development. For production, you
+        # should use the rack handler command directly (i.e. `bundle exec puma
+        # -C config/puma.rb`).
+        #
+        # The server is just a thin wrapper on top of Rack::Server. The options that it
+        # accepts fall into two different categories:
+        #
+        # - When not explicitly set, port and host are not passed to the rack
+        # server instance. This way, they can be configured through the
+        # configured rack handler (e.g., the puma configuration file).
+        #
+        # - All others are always given by the Hanami command.
+        #
+        # Run `bundle exec hanami server -h` to see all the supported options.
+        class Server < Application
+          desc "Start Hanami server"
+
+          option :host, default: nil, required: false, desc: "The host address to bind to (falls back to the rack handler)"
+          option :port, default: nil, required: false, desc: "The port to run the server on (falls back to the rack handler)"
+          option :config, default: 'config.ru', required: false, desc: "Rack configuration file"
+          option :debug, default: false, required: false, desc: "Turn on/off debug output", type: :boolean
+          option :warn, default: false, required: false, desc: "Turn on/off warnings", type: :boolean
+
+          private attr_reader :server
+
+          def initialize(server: Hanami::CLI::Server.new)
+            @server = server
+          end
+
+          # @api private
+          def call(...)
+            server.call(...)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/server.rb
+++ b/lib/hanami/cli/server.rb
@@ -1,0 +1,43 @@
+module Hanami
+  module CLI
+    # @api private
+    class Server
+      attr_reader :rack_server
+
+      RACK_FALLBACK_OPTIONS = {
+        host: :Host,
+        port: :Port
+      }.freeze
+
+      OVERRIDING_OPTIONS = {
+        config: :config,
+        debug: :debug,
+        warn: :warn
+      }.freeze
+
+      def initialize(rack_server: Rack::Server)
+        @rack_server = rack_server
+      end
+
+      def call(**options)
+        rack_server.start(Hash[
+          extract_rack_fallback_options(options) + extract_overriding_options(options)
+        ])
+      end
+
+      private
+
+      def extract_rack_fallback_options(options)
+        RACK_FALLBACK_OPTIONS.filter_map do |(name, rack_name)|
+          options[name] && [rack_name, options[name]]
+        end
+      end
+
+      def extract_overriding_options(options)
+        OVERRIDING_OPTIONS.map do |(name, rack_name)|
+          [rack_name, options[name]]
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/test/config.ru
+++ b/spec/fixtures/test/config.ru
@@ -1,0 +1,5 @@
+require "hanami"
+
+app = ->(_env) { [200, {}, ["Hello, world! (#{Hanami.env})"]] }
+
+run app

--- a/spec/unit/hanami/cli/commands/monolith/server_spec.rb
+++ b/spec/unit/hanami/cli/commands/monolith/server_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "hanami/cli/commands/monolith/server"
+require "open-uri"
+require "puma"
+
+RSpec.describe Hanami::CLI::Commands::Monolith::Server do
+  subject { described_class.new }
+
+  it "starts rack server in the given environment" do
+    host = ENV.fetch("HANAMI_CLI_TEST_HOST", "0.0.0.0")
+    port = ENV.fetch("HANAMI_CLI_TEST_PORT", "9292")
+    begin
+      pid = fork do
+        $stdout.reopen "/dev/null", "a"
+        $stderr.reopen "/dev/null", "a"
+        subject.call(
+          config: File.join(File.dirname(__FILE__), '../../../../../fixtures/test/config.ru'),
+          host: host,
+          port: port,
+          env: "staging"
+        )
+      end
+
+      response = open_uri("http://#{host}:#{port}/")
+
+      expect(response).to eq("Hello, world! (staging)")
+    ensure
+      Process.kill(:KILL, pid)
+    end
+  end
+
+  def open_uri(uri, attempts = 5)
+    URI.open(uri).read
+  rescue Errno::ECONNREFUSED => e
+    raise if attempts.zero?
+
+    sleep 1
+    open_uri(uri, attempts - 1)
+  end
+end

--- a/spec/unit/hanami/cli/server_spec.rb
+++ b/spec/unit/hanami/cli/server_spec.rb
@@ -1,0 +1,47 @@
+require "hanami/cli/server"
+
+RSpec.describe Hanami::CLI::Server do
+  describe "#call" do
+    subject { described_class.new(rack_server: rack_server) }
+
+    let(:rack_server) do
+      Class.new do
+        attr_reader :options
+
+        def start(options)
+          @options = options
+        end
+      end.new
+    end
+
+    it "delegates host as Host" do
+      subject.call(host: "127.0.0.3")
+
+      expect(subject.rack_server.options[:Host]).to eq("127.0.0.3")
+    end
+
+    it "delegates port as Port" do
+      subject.call(port: 2000)
+
+      expect(subject.rack_server.options[:Port]).to be(2000)
+    end
+
+    it "delegates config as config" do
+      subject.call(config: "config.ru")
+
+      expect(subject.rack_server.options[:config]).to eq("config.ru")
+    end
+
+    it "delegates debug as debug" do
+      subject.call(debug: true)
+
+      expect(subject.rack_server.options[:debug]).to be(true)
+    end
+
+    it "delegates warn as warn" do
+      subject.call(warn: true)
+
+      expect(subject.rack_server.options[:warn]).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
The server is just a thin wrapper on top of Rack::Server. The options
that it accepts fall into two different categories:

- When not explicitly set, port and host are not passed to the rack
server instance. This way, they can be configured through the configured
rack handler (e.g., the puma configuration file).

- All others are always given by the Hanami command.

The test for the command forks a new process so that the one running the
tests is not blocked and can assert that endpoint is working. Standard
outputs are silenced to avoid the command output being rendered.