### PR TITLE
Import Sequel for db version command

### DIFF
--- a/lib/hanami/cli/commands/db/utils/database.rb
+++ b/lib/hanami/cli/commands/db/utils/database.rb
@@ -108,7 +108,11 @@ module Hanami
             private
 
             def sequel_migrator
-              Sequel::TimestampMigrator.new(migrator.connection, migrations_path, {})
+              @sequel_migrator ||= begin
+                require 'sequel'
+                Sequel.extension :migration
+                Sequel::TimestampMigrator.new(migrator.connection, migrations_path, {})
+              end
             end
 
             def migrations_path


### PR DESCRIPTION
On the latest version of `hanami-template`, running `bin/hanami db version` raises error: `hanami-cli-2.0.0.alpha7/lib/hanami/cli/commands/db/utils/database.rb:114:in `sequel_migrator': uninitialized constant Hanami::CLI::Commands::DB::Utils::Database::Sequel (NameError)`.

This PR loads `Sequel` with `migration` extension before initializing `Sequel::TimestampMigrator`.