### PR TITLE
Add `hanami routes` command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "hanami", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"
-gem "hanami-router", require: false, git: "https://github.com/hanami/router.git", branch: "main"
+gem "hanami", require: false, git: "https://github.com/hanami/hanami.git", branch: "waiting-for-dev/inspector"
+gem "hanami-router", github: "hanami/router", branch: :main
 
 gem "rack"
 

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -8,6 +8,7 @@ module Hanami
         require_relative "app/install"
         require_relative "app/console"
         require_relative "app/server"
+        require_relative "app/routes"
         # require_relative "app/generate"
         # require_relative "app/db/create"
         # require_relative "app/db/create_migration"
@@ -27,6 +28,7 @@ module Hanami
             register "install", Commands::App::Install
             register "console", Commands::App::Console, aliases: ["c"]
             register "server",  Commands::App::Server,  aliases: ["s"]
+            register "routes",  Commands::App::Routes
 
             # FIXME: temporary disabled for Hanami v2.0.0.alpha2
             # register "install", Install

--- a/lib/hanami/cli/commands/app/routes.rb
+++ b/lib/hanami/cli/commands/app/routes.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/router/inspector"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        # Inspect the application routes
+        #
+        # All the formatters available from `hanami-router` are available:
+        #
+        # ```
+        # $ hanami routes --format=csv
+        # ```
+        #
+        # Experimental: You can also use a custom formatter registered in the
+        # application container. You can identify it by its key:
+        #
+        # ```
+        # $ hanami routes --format=custom_routes_formatter
+        # ```
+        class Routes < Hanami::CLI::Command
+          DEFAULT_FORMAT = "human_friendly"
+          private_constant :DEFAULT_FORMAT
+
+          VALID_FORMATS = [
+            DEFAULT_FORMAT,
+            "csv"
+          ].freeze
+          private_constant :VALID_FORMATS
+
+          desc "Inspect application"
+
+          option :format,
+                 default: DEFAULT_FORMAT,
+                 required: false,
+                 desc: "Output format"
+
+          # @api private
+          def call(format: DEFAULT_FORMAT, slice: nil)
+            require "hanami/prepare"
+            inspector = Hanami::Router::Inspector.new(formatter: resolve_formatter(format))
+            app.router(inspector: inspector)
+            out.puts inspector.call
+          end
+
+          private
+
+          def resolve_formatter(format)
+            if VALID_FORMATS.include?(format)
+              resolve_formatter_from_hanami_router(format)
+            else
+              resolve_formatter_from_app(format)
+            end
+          end
+
+          def resolve_formatter_from_hanami_router(format)
+            case format
+            when "human_friendly"
+              require "hanami/router/formatter/human_friendly"
+              Hanami::Router::Formatter::HumanFriendly.new
+            when "csv"
+              require "hanami/router/formatter/csv"
+              Hanami::Router::Formatter::CSV.new
+            end
+          end
+
+          # Experimental
+          def resolve_formatter_from_app(format)
+            app[format]
+          end
+
+          def app
+            Hanami.app
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/test/config/routes.rb
+++ b/spec/fixtures/test/config/routes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "hanami/routes"
+
+module Test
+  class Routes < Hanami::Routes
+    define do
+      get "/", to: "home.index"
+      get "/about", to: "home.about"
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/routes_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/routes_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "hanami/cli/commands/app/routes"
+
+RSpec.describe Hanami::CLI::Commands::App::Routes, :app, :command do # see fixture app for the defined routes
+  # TODO: better Hanami tear down
+  after do
+    app = Hanami.app
+    app.remove_instance_variable(:@_router) if app.instance_variable_defined?(:@_router)
+  end
+
+  it "defaults to the human friendly formatter" do
+    command.call
+
+    expect(output).to match %r{
+     ^GET\s+/\s+home\.index.*
+      GET\s+/about\s+home\.about\s+$
+    }xm
+  end
+
+  it "can use the csv formatter" do
+    command.call(format: "csv")
+
+    expect(output).to match %r{
+      GET,/,home\.index.*
+      GET,/about,home\.about
+    }xm
+  end
+
+  it "can use a custom formatter registered in the container" do
+    formatter = ->(routes) do
+      routes.filter_map { |route| !route.head? && route.http_method }.join(" ")
+    end
+    app.register_provider :custom_routes_formatter do
+      start { register "custom_routes_formatter", formatter }
+    end
+
+    command.call(format: "custom_routes_formatter")
+
+    expect(output).to match %r{GET GET}
+  end
+end


### PR DESCRIPTION
Without the `slice` option, it will inspect the application routes:

```ruby
$ hanami routes
```

All the formatters available from `hanami-router` are available:

```ruby
$ hanami routes --format=csv
```

A custom formatter registered in the application container can also be
used. It needs to be identified by its key:

```ruby
$ hanami routes --format=custom_routes_formatter
```