### PR TITLE
Add `hanami middlewares` command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,5 @@ Style/TrailingCommaInArrayLiteral:
   Enabled: false
 Style/TrailingCommaInHashLiteral:
   Enabled: false
+Style/StringConcatenation:
+  Enabled: false

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -10,6 +10,7 @@ module Hanami
         require_relative "app/server"
         require_relative "app/routes"
         require_relative "app/generate"
+        require_relative "app/middlewares"
         # require_relative "app/db/create"
         # require_relative "app/db/create_migration"
         # require_relative "app/db/drop"
@@ -24,11 +25,12 @@ module Hanami
 
         def self.extended(base)
           base.module_eval do
-            register "version", Commands::App::Version, aliases: ["v", "-v", "--version"]
-            register "install", Commands::App::Install
-            register "console", Commands::App::Console, aliases: ["c"]
-            register "server",  Commands::App::Server,  aliases: ["s"]
-            register "routes",  Commands::App::Routes
+            register "version",      Commands::App::Version, aliases: ["v", "-v", "--version"]
+            register "install",      Commands::App::Install
+            register "console",      Commands::App::Console, aliases: ["c"]
+            register "server",       Commands::App::Server,  aliases: ["s"]
+            register "routes",       Commands::App::Routes
+            register "middlewares",  Commands::App::Middlewares
 
             register "generate", aliases: ["g"] do |prefix|
               prefix.register "slice", Generate::Slice

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -25,12 +25,12 @@ module Hanami
 
         def self.extended(base)
           base.module_eval do
-            register "version",      Commands::App::Version, aliases: ["v", "-v", "--version"]
-            register "install",      Commands::App::Install
-            register "console",      Commands::App::Console, aliases: ["c"]
-            register "server",       Commands::App::Server,  aliases: ["s"]
-            register "routes",       Commands::App::Routes
-            register "middlewares",  Commands::App::Middlewares
+            register "version", Commands::App::Version, aliases: ["v", "-v", "--version"]
+            register "install", Commands::App::Install
+            register "console", Commands::App::Console, aliases: ["c"]
+            register "server", Commands::App::Server, aliases: ["s"]
+            register "routes", Commands::App::Routes
+            register "middlewares", Commands::App::Middlewares
 
             register "generate", aliases: ["g"] do |prefix|
               prefix.register "slice", Generate::Slice

--- a/lib/hanami/cli/commands/app/middlewares.rb
+++ b/lib/hanami/cli/commands/app/middlewares.rb
@@ -14,7 +14,7 @@ module Hanami
         #
         # ```
         # $ hanami middlewares
-        # /    Rack::Session::Cookie args: [{:secret=>"foo"}]
+        # /    Rack::Session::Cookie
         # ```
         #
         # Given arguments can be inspected:

--- a/lib/hanami/cli/commands/app/middlewares.rb
+++ b/lib/hanami/cli/commands/app/middlewares.rb
@@ -33,13 +33,11 @@ module Hanami
           # @api private
           def call(with_arguments: DEFAULT_WITH_ARGUMENTS)
             require "hanami/prepare"
-            out.puts MiddlewareStackInspector.new(stack: stack).inspect(include_arguments: with_arguments)
-          end
 
-          private
-
-          def stack
-            Hanami.app.router.middleware_stack
+            if Hanami.app.router
+              inspector = MiddlewareStackInspector.new(stack: Hanami.app.router.middleware_stack)
+              out.puts inspector.inspect(include_arguments: with_arguments)
+            end
           end
         end
       end

--- a/lib/hanami/cli/commands/app/middlewares.rb
+++ b/lib/hanami/cli/commands/app/middlewares.rb
@@ -28,7 +28,8 @@ module Hanami
 
           DEFAULT_WITH_ARGUMENTS = false
 
-          option :with_arguments, default: DEFAULT_WITH_ARGUMENTS, required: false, desc: "Include inspected arguments", type: :boolean
+          option :with_arguments, default: DEFAULT_WITH_ARGUMENTS, required: false,
+                                  desc: "Include inspected arguments", type: :boolean
 
           # @api private
           def call(with_arguments: DEFAULT_WITH_ARGUMENTS)

--- a/lib/hanami/cli/commands/app/middlewares.rb
+++ b/lib/hanami/cli/commands/app/middlewares.rb
@@ -21,7 +21,7 @@ module Hanami
         #
         # ```
         # $ hanami middlewares --with-arguments
-        # /    Rack::Session::Cookie args: [{:secret=>"foo"}
+        # /    Rack::Session::Cookie args: [{:secret=>"foo"}]
         # ```
         class Middlewares < Hanami::CLI::Command
           desc "List all the registered middlewares"

--- a/lib/hanami/cli/commands/app/middlewares.rb
+++ b/lib/hanami/cli/commands/app/middlewares.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/cli/middleware_stack_inspector"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        # List registered middlewares in the app router
+        #
+        # It outputs middlewares registered along with the paths where they
+        # apply:
+        #
+        # ```
+        # $ hanami middlewares
+        # /    Rack::Session::Cookie args: [{:secret=>"foo"}]
+        # ```
+        #
+        # Given arguments can be inspected:
+        #
+        # ```
+        # $ hanami middlewares --with-arguments
+        # /    Rack::Session::Cookie args: [{:secret=>"foo"}
+        # ```
+        class Middlewares < Hanami::CLI::Command
+          desc "List all the registered middlewares"
+
+          DEFAULT_WITH_ARGUMENTS = false
+
+          option :with_arguments, default: DEFAULT_WITH_ARGUMENTS, required: false, desc: "Include inspected arguments", type: :boolean
+
+          # @api private
+          def call(with_arguments: DEFAULT_WITH_ARGUMENTS)
+            require "hanami/prepare"
+            out.puts MiddlewareStackInspector.new(stack: stack).inspect(include_arguments: with_arguments)
+          end
+
+          private
+
+          def stack
+            Hanami.app.router.middleware_stack
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/middleware_stack_inspector.rb
+++ b/lib/hanami/cli/middleware_stack_inspector.rb
@@ -34,7 +34,7 @@ module Hanami
       end
 
       def format_arguments(arguments)
-        " args: #{arguments.inspect}"
+        "args: #{arguments.inspect}"
       end
     end
   end

--- a/lib/hanami/cli/middleware_stack_inspector.rb
+++ b/lib/hanami/cli/middleware_stack_inspector.rb
@@ -11,11 +11,13 @@ module Hanami
       def inspect(include_arguments: false)
         max_path_length = @stack.map { |(path)| path.length }.max
 
-        @stack.map do |path, middlewares|
-          middlewares.map do |(middleware, arguments)|
-            "#{path.ljust(max_path_length + 3)} #{format_middleware(middleware)}#{format_arguments(arguments) if include_arguments}"
-          end
-        end.join("\n") + "\n"
+        @stack.map { |path, middlewares|
+          middlewares.map { |(middleware, arguments)|
+            "#{path.ljust(max_path_length + 3)} #{format_middleware(middleware)}".tap { |line|
+              line << " #{format_arguments(arguments)}" if include_arguments
+            }
+          }
+        }.join("\n") + "\n"
       end
 
       private

--- a/lib/hanami/cli/middleware_stack_inspector.rb
+++ b/lib/hanami/cli/middleware_stack_inspector.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    # @api private
+    class MiddlewareStackInspector
+      def initialize(stack:)
+        @stack = stack
+      end
+
+      def inspect(include_arguments: false)
+        max_path_length = @stack.map { |(path)| path.length }.max
+
+        @stack.map do |path, middlewares|
+          middlewares.map do |(middleware, arguments)|
+            "#{path.ljust(max_path_length + 3)} #{format_middleware(middleware)}#{format_arguments(arguments) if include_arguments}"
+          end
+        end.join("\n") + "\n"
+      end
+
+      private
+
+      def format_middleware(middleware)
+        case middleware
+        when Class
+          middleware.name || "(class)"
+        when Module
+          middleware.name || "(module)"
+        else
+          "#{middleware.class.name} (instance)"
+        end
+      end
+
+      def format_arguments(arguments)
+        " args: #{arguments.inspect}"
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/middlewares_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/middlewares_spec.rb
@@ -22,4 +22,16 @@ RSpec.describe Hanami::CLI::Commands::App::Middlewares, :app, :command do
 
     expect(output).to include("args: []")
   end
+
+  context "no router" do
+    before do
+      allow(Hanami.app).to receive(:router).and_return nil
+    end
+
+    it "outputs nothing" do
+      command.call
+
+      expect(output).to be_empty
+    end
+  end
 end

--- a/spec/unit/hanami/cli/commands/app/middlewares_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/middlewares_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "hanami/cli/commands/app/middlewares"
+
+RSpec.describe Hanami::CLI::Commands::App::Middlewares, :app, :command do
+  # TODO: better Hanami tear down
+  after do
+    app = Hanami.app
+    app.remove_instance_variable(:@_router) if app.instance_variable_defined?(:@_router)
+  end
+
+  it "lists registered middlewares" do
+    command.call
+
+    expect(output).to eq <<~OUTPUT
+      /    Dry::Monitor::Rack::Middleware (instance)
+    OUTPUT
+  end
+
+  it "can include arguments" do
+    command.call(with_arguments: true)
+
+    expect(output).to include("args: []")
+  end
+end

--- a/spec/unit/hanami/cli/middleware_stack_inspector_spec.rb
+++ b/spec/unit/hanami/cli/middleware_stack_inspector_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "hanami/cli/middleware_stack_inspector"
+require "hanami/slice/routing/middleware/stack"
+
+RSpec.describe Hanami::CLI::MiddlewareStackInspector do
+  let(:stack) { Hanami::Slice::Routing::Middleware::Stack.new }
+
+  describe "#inspect" do
+    it "indents from the longest path" do
+      stack.use(Object)
+      stack.with("/a/really/really/long/path") { stack.use(Object) }
+
+      inspected = described_class.new(stack: stack).inspect
+
+      expect(inspected).to eq <<~RESULT
+        /                             Object
+        /a/really/really/long/path    Object
+      RESULT
+    end
+
+    it "can include inspected arguments" do
+      stack.use(Object, "foo")
+
+      inspected = described_class.new(stack: stack).inspect(include_arguments: true)
+
+      expect(inspected).to eq <<~RESULT
+        /    Object args: ["foo"]
+      RESULT
+    end
+
+    context "when middleware is a class" do
+      it "includes its name when it's named" do
+        stack.use(Object)
+
+        expect(described_class.new(stack: stack).inspect).to include("Object")
+      end
+
+      it "includes (class) when is anonymous" do
+        stack.use(Class.new)
+
+        expect(described_class.new(stack: stack).inspect).to include("(class)")
+      end
+    end
+
+    context "when middleware is a module" do
+      it "includes its name when it's named" do
+        Foo = Module.new
+        stack.use(Foo)
+
+        expect(described_class.new(stack: stack).inspect).to include("Foo")
+      ensure
+        Object.send(:remove_const, :Foo)
+      end
+
+      it "includes (module) when is anonymous" do
+        stack.use(Module.new)
+
+        expect(described_class.new(stack: stack).inspect).to include("(module)")
+      end
+    end
+
+    context "when middleware is an instance" do
+      it "includes its class name" do
+        stack.use(Object.new)
+
+        expect(described_class.new(stack: stack).inspect).to include("Object")
+      end
+
+      it "includes (instance)" do
+        stack.use(Object.new)
+
+        expect(described_class.new(stack: stack).inspect).to include("(instance)")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This command lists all registered middlewares in the app router along
with the paths where they apply:

```
$ hanami middlewares
/    Rack::Session::Cookie
```

Given arguments can be inspected:

```
$ hanami middlewares --with-arguments
/    Rack::Session::Cookie args: [{:secret=>"foo"}
```