### PR TITLE
Restore hanami-validations

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -6,6 +6,7 @@ gem "rake"
 
 gem "hanami-router", "<%= hanami_version %>"
 gem "hanami-controller", "<%= hanami_version %>"
+gem "hanami-validations", "<%=hanami_version %>"
 gem "hanami", "<%= hanami_version %>"
 
 gem "puma"

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -6,7 +6,7 @@ gem "rake"
 
 gem "hanami-router", "<%= hanami_version %>"
 gem "hanami-controller", "<%= hanami_version %>"
-gem "hanami-validations", "<%=hanami_version %>"
+gem "hanami-validations", "<%= hanami_version %>"
 gem "hanami", "<%= hanami_version %>"
 
 gem "puma"

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         gem "hanami-router", "#{hanami_version}"
         gem "hanami-controller", "#{hanami_version}"
+        gem "hanami-validations", "#{hanami_version}"
         gem "hanami", "#{hanami_version}"
 
         gem "puma"


### PR DESCRIPTION
Resolves: https://trello.com/c/Lx86f21b/192-hanami-validations-not-included-in-a-brand-new-application

When you create a new hanami app, using `hanami new`, the `hanami-validations` is not included. This results in a problem, where we cannot use

```ruby
params do
end
```

within actions - I believe this should be built-in feature.