### PR TITLE
Introduce `hanami generate slice`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "dry-files", require: false, github: "dry-rb/dry-files", branch: "memory-fix-multiline-write"
+gem "dry-files", require: false, github: "dry-rb/dry-files", branch: :main
 gem "hanami", require: false, github: "hanami/hanami", branch: :main
 gem "hanami-router", github: "hanami/router", branch: :main
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
+gem "dry-files", require: false, github: "dry-rb/dry-files", branch: "memory-fix-multiline-write"
 gem "hanami", require: false, github: "hanami/hanami", branch: :main
 gem "hanami-router", github: "hanami/router", branch: :main
 

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -9,7 +9,7 @@ module Hanami
         require_relative "app/console"
         require_relative "app/server"
         require_relative "app/routes"
-        # require_relative "app/generate"
+        require_relative "app/generate"
         # require_relative "app/db/create"
         # require_relative "app/db/create_migration"
         # require_relative "app/db/drop"
@@ -30,14 +30,10 @@ module Hanami
             register "server",  Commands::App::Server,  aliases: ["s"]
             register "routes",  Commands::App::Routes
 
-            # FIXME: temporary disabled for Hanami v2.0.0.alpha2
-            # register "install", Install
-
-            # FIXME: temporary disabled for Hanami v2.0.0.alpha2
-            # register "generate", aliases: ["g"] do |prefix|
-            #   prefix.register "slice", Generate::Slice
-            #   prefix.register "action", Generate::Action
-            # end
+            register "generate", aliases: ["g"] do |prefix|
+              prefix.register "slice", Generate::Slice
+              #   prefix.register "action", Generate::Action
+            end
           end
         end
       end

--- a/lib/hanami/cli/commands/app/command.rb
+++ b/lib/hanami/cli/commands/app/command.rb
@@ -22,7 +22,6 @@ module Hanami
 
           def self.inherited(klass)
             super
-            klass.option(:env, required: false, desc: "App's environment")
             klass.prepend(Environment)
           end
 

--- a/lib/hanami/cli/commands/app/console.rb
+++ b/lib/hanami/cli/commands/app/console.rb
@@ -25,6 +25,7 @@ module Hanami
 
           desc "App REPL"
 
+          option :env, required: false, desc: "Application environment"
           option :repl, required: false, desc: "REPL gem that should be used ('pry' or 'irb')"
 
           # @api private

--- a/lib/hanami/cli/commands/app/generate.rb
+++ b/lib/hanami/cli/commands/app/generate.rb
@@ -6,7 +6,7 @@ module Hanami
       module App
         module Generate
           require_relative "./generate/slice"
-          require_relative "./generate/action"
+          # require_relative "./generate/action"
         end
       end
     end

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -14,23 +14,24 @@ module Hanami
             @inflector = inflector
           end
 
-          def call(app, slice, slice_url_prefix, context: SliceContext.new(inflector, app, slice, slice_url_prefix)) # rubocop:disable Metrics/AbcSize
+          def call(app, slice, slice_url_prefix, context: SliceContext.new(inflector, app, slice, slice_url_prefix))
             fs.inject_line_before_last(fs.join("config", "routes.rb"), /end/, t("routes.erb", context).chomp)
 
             fs.mkdir(directory = "slices/#{slice}")
 
             fs.chdir(directory) do
+              fs.write("slice.rb", t("slice.erb", context))
               fs.write("action.rb", t("action.erb", context))
-              fs.write("view.rb", t("view.erb", context))
-              fs.write("entities.rb", t("entities.erb", context))
-              fs.write("repository.rb", t("repository.erb", context))
+              # fs.write("view.rb", t("view.erb", context))
+              # fs.write("entities.rb", t("entities.erb", context))
+              # fs.write("repository.rb", t("repository.erb", context))
 
               fs.write("actions/.keep", t("keep.erb", context))
-              fs.write("views/.keep", t("keep.erb", context))
-              fs.write("templates/.keep", t("keep.erb", context))
-              fs.write("templates/layouts/.keep", t("keep.erb", context))
-              fs.write("entities/.keep", t("keep.erb", context))
-              fs.write("repositories/.keep", t("keep.erb", context))
+              # fs.write("views/.keep", t("keep.erb", context))
+              # fs.write("templates/.keep", t("keep.erb", context))
+              # fs.write("templates/layouts/.keep", t("keep.erb", context))
+              # fs.write("entities/.keep", t("keep.erb", context))
+              # fs.write("repositories/.keep", t("keep.erb", context))
             end
           end
 

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -20,7 +20,7 @@ module Hanami
             fs.mkdir(directory = "slices/#{slice}")
 
             fs.chdir(directory) do
-              fs.write("slice.rb", t("slice.erb", context))
+              # fs.write("config/slice.rb", t("slice.erb", context))
               fs.write("action.rb", t("action.erb", context))
               # fs.write("view.rb", t("view.erb", context))
               # fs.write("entities.rb", t("entities.erb", context))

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -15,7 +15,7 @@ module Hanami
           end
 
           def call(app, slice, slice_url_prefix, context: SliceContext.new(inflector, app, slice, slice_url_prefix))
-            fs.inject_line_before_last(fs.join("config", "routes.rb"), /end/, t("routes.erb", context).chomp)
+            fs.inject_line_at_block_bottom(fs.join("config", "routes.rb"), /define/, t("routes.erb", context).chomp)
 
             fs.mkdir(directory = "slices/#{slice}")
 

--- a/lib/hanami/cli/generators/app/slice/routes.erb
+++ b/lib/hanami/cli/generators/app/slice/routes.erb
@@ -1,2 +1,3 @@
-  slice :<%= underscored_slice_name %>, at: "<%= slice_url_prefix %>" do
-  end
+
+slice :<%= underscored_slice_name %>, at: "<%= slice_url_prefix %>" do
+end

--- a/lib/hanami/cli/generators/app/slice/slice.erb
+++ b/lib/hanami/cli/generators/app/slice/slice.erb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module <%= classified_slice_name %>
+  class Slice < Hanami::Slice
+  end
+end

--- a/spec/integration/run_spec.rb
+++ b/spec/integration/run_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "bin/hanami", :app do
     it "prints out usage" do
       expect(stdout).to include("install")
       expect(stdout).to include("console")
+      expect(stdout).to include("generate")
       # expect(stdout).to include("db [SUBCOMMAND]")
     end
   end

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -129,7 +129,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
     end
   end
 
-
   private
 
   def within_application_directory

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -20,11 +20,24 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
       subject.call(name: slice)
 
       # Route
-      route = <<~CODE
-        slice :#{slice}, at: "/#{slice}" do
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            define do
+              root { "Hello from Hanami" }
+
+              slice :#{slice}, at: "/#{slice}" do
+              end
+            end
+          end
+        end
       CODE
 
-      expect(fs.read("config/routes.rb")).to include(route)
+      expect(fs.read("config/routes.rb")).to include(routes)
 
       # Slice directory
       expect(fs.directory?("slices/#{slice}")).to be(true)
@@ -85,6 +98,37 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
       }.to raise_error(ArgumentError, "invalid URL prefix: `//FooBar'")
     end
   end
+
+  it "generates multiple slices over time" do
+    within_application_directory do
+      subject.call(name: "admin")
+      subject.call(name: "billing")
+
+      # Route
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            define do
+              root { "Hello from Hanami" }
+
+              slice :admin, at: "/admin" do
+              end
+
+              slice :billing, at: "/billing" do
+              end
+            end
+          end
+        end
+      CODE
+
+      expect(fs.read("config/routes.rb")).to eq(routes)
+    end
+  end
+
 
   private
 

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -42,16 +42,16 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
       # Slice directory
       expect(fs.directory?("slices/#{slice}")).to be(true)
 
-      # Slice
-      slice_class = <<~CODE
-        # frozen_string_literal: true
-
-        module Admin
-          class Slice < Hanami::Slice
-          end
-        end
-      CODE
-      expect(fs.read("slices/#{slice}/slice.rb")).to eq(slice_class)
+      # # Slice
+      # slice_class = <<~CODE
+      #   # frozen_string_literal: true
+      #
+      #   module Admin
+      #     class Slice < Hanami::Slice
+      #     end
+      #   end
+      # CODE
+      # expect(fs.read("slices/#{slice}/config/slice.rb")).to eq(slice_class)
 
       # Action
       action = <<~CODE


### PR DESCRIPTION
# Feature

Add `hanami generate slice` CLI command to Hanami applications.

It performs the following actions:

  * Edit `config/routes.rb` to add a `slice` block
  * Create `slices/[slice]` directory
  * Create `slices/[slice]/action.rb` file (with `MySlice::Action < MyApp::Action` class definition)
  * Create `slices/[slice]/actions/.keep` file

Example:

```shell
⚡ bundle exec hanami generate slice admin
⚡ tree slices
slices
└── admin
    ├── action.rb
    └── actions

2 directories, 1 file
``` 