### PR TITLE
Introduce `hanami generate action`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,10 @@ inherit_from:
 Layout/LineLength:
   Exclude:
     - Gemfile
+    - 'spec/**/*.rb'
 Lint/EmptyFile:
   Exclude:
-    - "spec/fixtures/**/*.rb"
+    - 'spec/fixtures/**/*.rb'
 Naming/HeredocDelimiterNaming:
   Enabled: false
 Naming/MethodParameterName:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "dry-files", require: false, github: "dry-rb/dry-files", branch: "inject_line_at_block_bottom-nested-block-2"
+gem "dry-files", require: false, github: "dry-rb/dry-files", branch: :main
 gem "hanami", require: false, github: "hanami/hanami", branch: :main
 gem "hanami-router", github: "hanami/router", branch: :main
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ unless ENV["CI"]
   gem "yard",   require: false
 end
 
-gem "dry-files", require: false, github: "dry-rb/dry-files", branch: :main
+gem "dry-files", require: false, github: "dry-rb/dry-files", branch: "inject_line_at_block_bottom-nested-block-2"
 gem "hanami", require: false, github: "hanami/hanami", branch: :main
 gem "hanami-router", github: "hanami/router", branch: :main
 

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -34,7 +34,7 @@ module Hanami
 
             register "generate", aliases: ["g"] do |prefix|
               prefix.register "slice", Generate::Slice
-              #   prefix.register "action", Generate::Action
+              prefix.register "action", Generate::Action
             end
           end
         end

--- a/lib/hanami/cli/commands/app/generate.rb
+++ b/lib/hanami/cli/commands/app/generate.rb
@@ -6,7 +6,7 @@ module Hanami
       module App
         module Generate
           require_relative "./generate/slice"
-          # require_relative "./generate/action"
+          require_relative "./generate/action"
         end
       end
     end

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -20,13 +20,13 @@ module Hanami
             DEFAULT_SKIP_VIEW = false
             private_constant :DEFAULT_SKIP_VIEW
 
-            argument :slice, required: true, desc: "Slice name"
             argument :name, required: true, desc: "Action name"
             option :url, required: false, type: :string, desc: "Action URL"
             option :http, required: false, type: :string, desc: "Action HTTP method"
             option :format, required: false, type: :string, default: DEFAULT_FORMAT, desc: "Template format"
             option :skip_view, required: false, type: :boolean, default: DEFAULT_SKIP_VIEW,
                                desc: "Skip view and template generation"
+            option :slice, required: false, desc: "Slice name"
 
             def initialize(fs: Dry::Files.new, inflector: Dry::Inflector.new,
                            generator: Generators::App::Action.new(fs: fs, inflector: inflector), **)
@@ -35,8 +35,8 @@ module Hanami
             end
 
             # rubocop:disable Metrics/ParameterLists
-            def call(slice:, name:, url: nil, http: nil, format: DEFAULT_FORMAT, skip_view: DEFAULT_SKIP_VIEW, **)
-              slice = inflector.underscore(Shellwords.shellescape(slice))
+            def call(name:, url: nil, http: nil, format: DEFAULT_FORMAT, skip_view: DEFAULT_SKIP_VIEW, slice: nil, **)
+              slice = inflector.underscore(Shellwords.shellescape(slice)) unless slice.nil?
               name = inflector.underscore(Shellwords.shellescape(name))
               *controller, action = name.split(ACTION_SEPARATOR)
 
@@ -44,7 +44,7 @@ module Hanami
                 raise ArgumentError.new("cannot parse controller and action name: `#{name}'\n\texample: users.show")
               end
 
-              generator.call(slice, controller, action, url, http, format, skip_view)
+              generator.call(controller, action, url, http, format, skip_view, slice)
             end
             # rubocop:enable Metrics/ParameterLists
 

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -36,7 +36,7 @@ module Hanami
 
             # rubocop:disable Metrics/ParameterLists
             def call(name:, url: nil, http: nil, format: DEFAULT_FORMAT, skip_view: DEFAULT_SKIP_VIEW, slice: nil, **)
-              slice = inflector.underscore(Shellwords.shellescape(slice)) unless slice.nil?
+              slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
               name = inflector.underscore(Shellwords.shellescape(name))
               *controller, action = name.split(ACTION_SEPARATOR)
 

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/cli/command"
+require "hanami/cli/commands/app/command"
 require "hanami/cli/generators/app/action"
 require "dry/inflector"
 require "dry/files"
@@ -11,7 +11,7 @@ module Hanami
     module Commands
       module App
         module Generate
-          class Action < Command
+          class Action < App::Command
             # TODO: ideally the default format should lookup
             #       slice configuration (Action's `default_response_format`)
             DEFAULT_FORMAT = "html"
@@ -44,7 +44,7 @@ module Hanami
                 raise ArgumentError.new("cannot parse controller and action name: `#{name}'\n\texample: users.show")
               end
 
-              generator.call(controller, action, url, http, format, skip_view, slice)
+              generator.call(app.namespace, controller, action, url, http, format, skip_view, slice)
             end
             # rubocop:enable Metrics/ParameterLists
 

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -23,9 +23,9 @@ module Hanami
             argument :name, required: true, desc: "Action name"
             option :url, required: false, type: :string, desc: "Action URL"
             option :http, required: false, type: :string, desc: "Action HTTP method"
-            option :format, required: false, type: :string, default: DEFAULT_FORMAT, desc: "Template format"
-            option :skip_view, required: false, type: :boolean, default: DEFAULT_SKIP_VIEW,
-                               desc: "Skip view and template generation"
+            # option :format, required: false, type: :string, default: DEFAULT_FORMAT, desc: "Template format"
+            # option :skip_view, required: false, type: :boolean, default: DEFAULT_SKIP_VIEW,
+            #                    desc: "Skip view and template generation"
             option :slice, required: false, desc: "Slice name"
 
             def initialize(fs: Dry::Files.new, inflector: Dry::Inflector.new,

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -15,10 +15,9 @@ module Hanami
             @inflector = inflector
           end
 
-          # rubocop:disable Metrics/AbcSize
           # rubocop:disable Metrics/ParameterLists
           # rubocop:disable Layout/LineLength
-          def call(slice, controller, action, url, http, format, skip_view, context: ActionContext.new(inflector, slice, controller, action))
+          def call(slice, controller, action, url, http, _format, _skip_view, context: ActionContext.new(inflector, slice, controller, action))
             slice_directory = fs.join("slices", slice)
             raise ArgumentError.new("slice not found `#{slice}'") unless fs.directory?(slice_directory)
 
@@ -32,18 +31,17 @@ module Hanami
               fs.mkdir(directory = fs.join("actions", controller))
               fs.write(fs.join(directory, "#{action}.rb"), t("action.erb", context))
 
-              unless skip_view
-                fs.mkdir(directory = fs.join("views", controller))
-                fs.write(fs.join(directory, "#{action}.rb"), t("view.erb", context))
-
-                fs.mkdir(directory = fs.join("templates", controller))
-                fs.write(fs.join(directory, "#{action}.#{format}.erb"), t(template_format(format), context))
-              end
+              # unless skip_view
+              #   fs.mkdir(directory = fs.join("views", controller))
+              #   fs.write(fs.join(directory, "#{action}.rb"), t("view.erb", context))
+              #
+              #   fs.mkdir(directory = fs.join("templates", controller))
+              #   fs.write(fs.join(directory, "#{action}.#{format}.erb"), t(template_format(format), context))
+              # end
             end
           end
           # rubocop:enable Layout/LineLength
           # rubocop:enable Metrics/ParameterLists
-          # rubocop:enable Metrics/AbcSize
 
           private
 

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -17,7 +17,7 @@ module Hanami
 
           # rubocop:disable Metrics/ParameterLists
           # rubocop:disable Layout/LineLength
-          def call(slice, controller, action, url, http, _format, _skip_view, context: ActionContext.new(inflector, slice, controller, action))
+          def call(controller, action, url, http, _format, _skip_view, slice, context: ActionContext.new(inflector, slice, controller, action))
             slice_directory = fs.join("slices", slice)
             raise ArgumentError.new("slice not found `#{slice}'") unless fs.directory?(slice_directory)
 

--- a/lib/hanami/cli/generators/app/action/action.erb
+++ b/lib/hanami/cli/generators/app/action/action.erb
@@ -1,4 +1,3 @@
-# auto_register: false
 # frozen_string_literal: true
 
 require "<%= underscored_slice_name %>/action"

--- a/lib/hanami/cli/generators/app/action/action.erb
+++ b/lib/hanami/cli/generators/app/action/action.erb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require "<%= underscored_slice_name %>/action"
+require "<%= underscored_app_name %>/action"
 
-module <%= classified_slice_name %>
+module <%= classified_app_name %>
   module Actions
 <%= module_controller_declaration %>
-<%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_slice_name %>::Action
+<%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_app_name %>::Action
 <%= module_controller_offset %>end
 <%= module_controller_end %>
   end

--- a/lib/hanami/cli/generators/app/action/action.erb
+++ b/lib/hanami/cli/generators/app/action/action.erb
@@ -4,7 +4,7 @@ module <%= classified_app_name %>
   module Actions
 <%= module_controller_declaration %>
 <%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_app_name %>::Action
-<%= module_controller_offset %>  def call(*, res)
+<%= module_controller_offset %>  def handle(*, res)
 <%= module_controller_offset %>    res.body = self.class.name
 <%= module_controller_offset %>  end
 <%= module_controller_offset %>end

--- a/lib/hanami/cli/generators/app/action/action.erb
+++ b/lib/hanami/cli/generators/app/action/action.erb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-require "<%= underscored_app_name %>/action"
-
 module <%= classified_app_name %>
   module Actions
 <%= module_controller_declaration %>
 <%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_app_name %>::Action
+<%= module_controller_offset %>  def call(*, res)
+<%= module_controller_offset %>    res.body = self.class.name
+<%= module_controller_offset %>  end
 <%= module_controller_offset %>end
 <%= module_controller_end %>
   end

--- a/lib/hanami/cli/generators/app/action/action.erb
+++ b/lib/hanami/cli/generators/app/action/action.erb
@@ -4,8 +4,8 @@ module <%= classified_app_name %>
   module Actions
 <%= module_controller_declaration %>
 <%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_app_name %>::Action
-<%= module_controller_offset %>  def handle(*, res)
-<%= module_controller_offset %>    res.body = self.class.name
+<%= module_controller_offset %>  def handle(*, response)
+<%= module_controller_offset %>    response.body = self.class.name
 <%= module_controller_offset %>  end
 <%= module_controller_offset %>end
 <%= module_controller_end %>

--- a/lib/hanami/cli/generators/app/action/slice_action.erb
+++ b/lib/hanami/cli/generators/app/action/slice_action.erb
@@ -4,7 +4,7 @@ module <%= classified_slice_name %>
   module Actions
 <%= module_controller_declaration %>
 <%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_slice_name %>::Action
-<%= module_controller_offset %>  def call(*, res)
+<%= module_controller_offset %>  def handle(*, res)
 <%= module_controller_offset %>    res.body = self.class.name
 <%= module_controller_offset %>  end
 <%= module_controller_offset %>end

--- a/lib/hanami/cli/generators/app/action/slice_action.erb
+++ b/lib/hanami/cli/generators/app/action/slice_action.erb
@@ -4,8 +4,8 @@ module <%= classified_slice_name %>
   module Actions
 <%= module_controller_declaration %>
 <%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_slice_name %>::Action
-<%= module_controller_offset %>  def handle(*, res)
-<%= module_controller_offset %>    res.body = self.class.name
+<%= module_controller_offset %>  def handle(*, response)
+<%= module_controller_offset %>    response.body = self.class.name
 <%= module_controller_offset %>  end
 <%= module_controller_offset %>end
 <%= module_controller_end %>

--- a/lib/hanami/cli/generators/app/action/slice_action.erb
+++ b/lib/hanami/cli/generators/app/action/slice_action.erb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-require "<%= underscored_slice_name %>/action"
-
 module <%= classified_slice_name %>
   module Actions
 <%= module_controller_declaration %>
 <%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_slice_name %>::Action
+<%= module_controller_offset %>  def call(*, res)
+<%= module_controller_offset %>    res.body = self.class.name
+<%= module_controller_offset %>  end
 <%= module_controller_offset %>end
 <%= module_controller_end %>
   end

--- a/lib/hanami/cli/generators/app/action/slice_action.erb
+++ b/lib/hanami/cli/generators/app/action/slice_action.erb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "<%= underscored_slice_name %>/action"
+
+module <%= classified_slice_name %>
+  module Actions
+<%= module_controller_declaration %>
+<%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_slice_name %>::Action
+<%= module_controller_offset %>end
+<%= module_controller_end %>
+  end
+end

--- a/lib/hanami/cli/generators/app/action_context.rb
+++ b/lib/hanami/cli/generators/app/action_context.rb
@@ -8,10 +8,10 @@ module Hanami
     module Generators
       module App
         class ActionContext < SliceContext
-          def initialize(inflector, slice, controller, action)
+          def initialize(inflector, app, slice, controller, action)
             @controller = controller
             @action = action
-            super(inflector, nil, slice, nil)
+            super(inflector, app, slice, nil)
           end
 
           def classified_controller_name

--- a/lib/hanami/cli/generators/app/slice/action.erb
+++ b/lib/hanami/cli/generators/app/slice/action.erb
@@ -1,8 +1,6 @@
 # auto_register: false
 # frozen_string_literal: true
 
-require "<%= underscored_app_name %>/action"
-
 module <%= classified_slice_name %>
   class Action < <%= classified_app_name %>::Action
   end

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -16,6 +16,78 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action do
   let(:action) { "index" }
   let(:action_name) { "#{controller}.#{action}" }
 
+  context "generate for app" do
+    it "generates action" do
+      within_application_directory do
+        subject.call(name: action_name)
+
+        # Route
+        routes = <<~CODE
+          # frozen_string_literal: true
+
+          require "hanami/routes"
+
+          module #{app}
+            class Routes < Hanami::Routes
+              define do
+                root { "Hello from Hanami" }
+                get "/users", to: "users.index"
+              end
+            end
+          end
+        CODE
+
+        # route
+        expect(fs.read("config/routes.rb")).to eq(routes)
+
+        action_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "#{inflector.underscore(app)}/action"
+
+          module #{inflector.classify(app)}
+            module Actions
+              module #{inflector.camelize(controller)}
+                class #{inflector.classify(action)} < #{inflector.classify(app)}::Action
+                end
+              end
+            end
+          end
+        EXPECTED
+        expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
+
+        # # view
+        # expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(true)
+        #
+        # view_file = <<~EXPECTED
+        #   # auto_register: false
+        #   # frozen_string_literal: true
+        #
+        #   require "#{inflector.underscore(slice)}/view"
+        #
+        #   module #{inflector.classify(slice)}
+        #     module Views
+        #       module #{inflector.camelize(controller)}
+        #         class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
+        #         end
+        #       end
+        #     end
+        #   end
+        # EXPECTED
+        # expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
+
+        # template
+        # expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
+        #
+        # template_file = <<~EXPECTED
+        #   <h1>#{inflector.classify(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.classify(action)}</h1>
+        #   <h2>slices/#{slice}/templates/#{controller}/#{action}.html.erb</h2>
+        # EXPECTED
+        # expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
+      end
+    end
+  end
+
   context "generate for a slice" do
     let(:slice) { "main" }
 

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             module Actions
               module #{inflector.camelize(controller)}
                 class #{inflector.classify(action)} < #{inflector.classify(app)}::Action
-                  def handle(*, res)
-                    res.body = self.class.name
+                  def handle(*, response)
+                    response.body = self.class.name
                   end
                 end
               end
@@ -212,8 +212,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             module Actions
               module #{inflector.camelize(controller)}
                 class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
-                  def handle(*, res)
-                    res.body = self.class.name
+                  def handle(*, response)
+                    response.body = self.class.name
                   end
                 end
               end
@@ -299,8 +299,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                   module Bestsellers
                     module Nonfiction
                       class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
-                        def handle(*, res)
-                          res.body = self.class.name
+                        def handle(*, response)
+                          response.body = self.class.name
                         end
                       end
                     end

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -4,13 +4,13 @@ require "hanami"
 require "hanami/cli/commands/app/generate/action"
 require "ostruct"
 
-RSpec.describe Hanami::CLI::Commands::App::Generate::Action do
+RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
   subject { described_class.new(fs: fs, inflector: inflector, generator: generator) }
 
   let(:fs) { Dry::Files.new(memory: true) }
   let(:inflector) { Dry::Inflector.new }
   let(:generator) { Hanami::CLI::Generators::App::Action.new(fs: fs, inflector: inflector) }
-  let(:app) { "Bookshelf" }
+  let(:app) { Hanami.app.namespace }
   let(:dir) { inflector.underscore(app) }
   let(:controller) { "users" }
   let(:action) { "index" }
@@ -411,11 +411,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action do
   private
 
   def within_application_directory
-    application = Struct.new(:namespace).new(app)
-
-    allow(Hanami).to receive(:app)
-      .and_return(application)
-
     fs.mkdir(dir)
     fs.chdir(dir) do
       routes = <<~CODE

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             module Actions
               module #{inflector.camelize(controller)}
                 class #{inflector.classify(action)} < #{inflector.classify(app)}::Action
-                  def call(*, res)
+                  def handle(*, res)
                     res.body = self.class.name
                   end
                 end
@@ -212,7 +212,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             module Actions
               module #{inflector.camelize(controller)}
                 class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
-                  def call(*, res)
+                  def handle(*, res)
                     res.body = self.class.name
                   end
                 end
@@ -299,7 +299,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                   module Bestsellers
                     module Nonfiction
                       class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
-                        def call(*, res)
+                        def handle(*, res)
                           res.body = self.class.name
                         end
                       end

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -43,12 +43,13 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         action_file = <<~EXPECTED
           # frozen_string_literal: true
 
-          require "#{inflector.underscore(app)}/action"
-
           module #{inflector.classify(app)}
             module Actions
               module #{inflector.camelize(controller)}
                 class #{inflector.classify(action)} < #{inflector.classify(app)}::Action
+                  def call(*, res)
+                    res.body = self.class.name
+                  end
                 end
               end
             end
@@ -207,12 +208,13 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         action_file = <<~EXPECTED
           # frozen_string_literal: true
 
-          require "#{inflector.underscore(slice)}/action"
-
           module #{inflector.classify(slice)}
             module Actions
               module #{inflector.camelize(controller)}
                 class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
+                  def call(*, res)
+                    res.body = self.class.name
+                  end
                 end
               end
             end
@@ -291,14 +293,15 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           action_file = <<~EXPECTED
             # frozen_string_literal: true
 
-            require "#{inflector.underscore(slice)}/action"
-
             module #{inflector.classify(slice)}
               module Actions
                 module Books
                   module Bestsellers
                     module Nonfiction
                       class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
+                        def call(*, res)
+                          res.body = self.class.name
+                        end
                       end
                     end
                   end

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "hanami"
 require "hanami/cli/commands/app/generate/action"
 require "ostruct"
 
@@ -10,288 +11,378 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action do
   let(:inflector) { Dry::Inflector.new }
   let(:generator) { Hanami::CLI::Generators::App::Action.new(fs: fs, inflector: inflector) }
   let(:app) { "Bookshelf" }
-  let(:slice) { "main" }
+  let(:dir) { inflector.underscore(app) }
   let(:controller) { "users" }
   let(:action) { "index" }
   let(:action_name) { "#{controller}.#{action}" }
 
-  before { prepare_slice! }
+  context "generate for a slice" do
+    let(:slice) { "main" }
 
-  it "generates action" do
-    subject.call(slice: slice, name: action_name)
-
-    # route
-    expect(fs.read("config/routes.rb")).to match(%(get "/users", to: "users.index"))
-
-    # action
-    expect(fs.directory?(directory = "slices/#{slice}/actions/#{controller}")).to be(true)
-
-    fs.chdir(directory) do
-      action_file = <<~EXPECTED
-        # auto_register: false
-        # frozen_string_literal: true
-
-        require "#{inflector.underscore(slice)}/action"
-
-        module #{inflector.classify(slice)}
-          module Actions
-            module #{inflector.camelize(controller)}
-              class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
-              end
-            end
-          end
-        end
-      EXPECTED
-      expect(fs.read("#{action}.rb")).to eq(action_file)
-    end
-
-    # view
-    expect(fs.directory?(directory = "slices/#{slice}/views/#{controller}")).to be(true)
-
-    fs.chdir(directory) do
-      view_file = <<~EXPECTED
-        # auto_register: false
-        # frozen_string_literal: true
-
-        require "#{inflector.underscore(slice)}/view"
-
-        module #{inflector.classify(slice)}
-          module Views
-            module #{inflector.camelize(controller)}
-              class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
-              end
-            end
-          end
-        end
-      EXPECTED
-      expect(fs.read("#{action}.rb")).to eq(view_file)
-    end
-
-    # template
-    expect(fs.directory?(directory = "slices/#{slice}/templates/#{controller}")).to be(true)
-
-    fs.chdir(directory) do
-      template_file = <<~EXPECTED
-        <h1>#{inflector.classify(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.classify(action)}</h1>
-        <h2>slices/#{slice}/templates/#{controller}/#{action}.html.erb</h2>
-      EXPECTED
-      expect(fs.read("#{action}.html.erb")).to eq(template_file)
-    end
-  end
-
-  context "deeply nested action" do
-    let(:controller) { %w[books bestsellers nonfiction] }
-    let(:controller_name) { controller.join(".") }
-    let(:action) { "index" }
-    let(:action_name) { "#{controller_name}.#{action}" }
+    before { prepare_slice! }
 
     it "generates action" do
-      subject.call(slice: slice, name: action_name)
+      within_application_directory do
+        prepare_slice!
 
-      # route
-      expect(fs.read("config/routes.rb")).to match(
-        %(get "/books/bestsellers/nonfiction", to: "books.bestsellers.nonfiction.index")
-      )
+        subject.call(name: action_name, slice: slice)
 
-      # action
-      expect(fs.directory?(directory = "slices/#{slice}/actions/books/bestsellers/nonfiction")).to be(true)
+        # Route
+        routes = <<~CODE
+          # frozen_string_literal: true
 
-      fs.chdir(directory) do
+          require "hanami/routes"
+
+          module #{app}
+            class Routes < Hanami::Routes
+              define do
+                root { "Hello from Hanami" }
+
+                slice :#{slice}, at: "/#{slice}" do
+                  get "/users", to: "users.index"
+                end
+              end
+            end
+          end
+        CODE
+
+        # route
+        expect(fs.read("config/routes.rb")).to eq(routes)
+
+        # action
+        expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
+
         action_file = <<~EXPECTED
-          # auto_register: false
           # frozen_string_literal: true
 
           require "#{inflector.underscore(slice)}/action"
 
           module #{inflector.classify(slice)}
             module Actions
-              module Books
-                module Bestsellers
-                  module Nonfiction
-                    class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
-                    end
-                  end
+              module #{inflector.camelize(controller)}
+                class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
                 end
               end
             end
           end
         EXPECTED
-        expect(fs.read("#{action}.rb")).to eq(action_file)
+        expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
+
+        # # view
+        # expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(true)
+        #
+        # view_file = <<~EXPECTED
+        #   # auto_register: false
+        #   # frozen_string_literal: true
+        #
+        #   require "#{inflector.underscore(slice)}/view"
+        #
+        #   module #{inflector.classify(slice)}
+        #     module Views
+        #       module #{inflector.camelize(controller)}
+        #         class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
+        #         end
+        #       end
+        #     end
+        #   end
+        # EXPECTED
+        # expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
+
+        # template
+        # expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
+        #
+        # template_file = <<~EXPECTED
+        #   <h1>#{inflector.classify(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.classify(action)}</h1>
+        #   <h2>slices/#{slice}/templates/#{controller}/#{action}.html.erb</h2>
+        # EXPECTED
+        # expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
       end
+    end
 
-      # view
-      expect(fs.directory?(directory = "slices/#{slice}/views/books/bestsellers/nonfiction")).to be(true)
+    context "deeply nested action" do
+      let(:controller) { %w[books bestsellers nonfiction] }
+      let(:controller_name) { controller.join(".") }
+      let(:action) { "index" }
+      let(:action_name) { "#{controller_name}.#{action}" }
 
-      fs.chdir(directory) do
-        view_file = <<~EXPECTED
-          # auto_register: false
+      it "generates action" do
+        within_application_directory do
+          prepare_slice!
+
+          subject.call(slice: slice, name: action_name)
+
+          # Route
+          routes = <<~CODE
+            # frozen_string_literal: true
+
+            require "hanami/routes"
+
+            module #{app}
+              class Routes < Hanami::Routes
+                define do
+                  root { "Hello from Hanami" }
+
+                  slice :#{slice}, at: "/#{slice}" do
+                    get "/books/bestsellers/nonfiction", to: "books.bestsellers.nonfiction.index"
+                  end
+                end
+              end
+            end
+          CODE
+
+          # route
+          expect(fs.read("config/routes.rb")).to eq(routes)
+
+          # action
+          expect(fs.directory?("slices/#{slice}/actions/books/bestsellers/nonfiction")).to be(true)
+
+          action_file = <<~EXPECTED
+            # frozen_string_literal: true
+
+            require "#{inflector.underscore(slice)}/action"
+
+            module #{inflector.classify(slice)}
+              module Actions
+                module Books
+                  module Bestsellers
+                    module Nonfiction
+                      class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          EXPECTED
+          expect(fs.read("slices/#{slice}/actions/books/bestsellers/nonfiction/#{action}.rb")).to eq(action_file)
+
+          # # view
+          # expect(fs.directory?("slices/#{slice}/views/books/bestsellers/nonfiction")).to be(true)
+          #
+          # view_file = <<~EXPECTED
+          #   # auto_register: false
+          #   # frozen_string_literal: true
+          #
+          #   require "#{inflector.underscore(slice)}/view"
+          #
+          #   module #{inflector.classify(slice)}
+          #     module Views
+          #       module Books
+          #         module Bestsellers
+          #           module Nonfiction
+          #             class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
+          #             end
+          #           end
+          #         end
+          #       end
+          #     end
+          #   end
+          # EXPECTED
+          # expect(fs.read("slices/#{slice}/views/books/bestsellers/nonfiction/#{action}.rb")).to eq(view_file)
+
+          # # template
+          # expect(fs.directory?("slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
+          #
+          # template_file = <<~EXPECTED
+          #   <h1>#{inflector.classify(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
+          #   <h2>slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb</h2>
+          # EXPECTED
+          # expect(fs.read("slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb")).to eq(template_file)
+        end
+      end
+    end
+
+    it "appends routes within the proper slice block" do
+      within_application_directory do
+        prepare_slice!
+        fs.mkdir("slices/api")
+
+        routes_contents = <<~CODE
           # frozen_string_literal: true
 
-          require "#{inflector.underscore(slice)}/view"
+          require "hanami/routes"
 
-          module #{inflector.classify(slice)}
-            module Views
-              module Books
-                module Bestsellers
-                  module Nonfiction
-                    class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
-                    end
-                  end
+          module #{app}
+            class Routes < Hanami::Routes
+              define do
+                root { "Hello from Hanami" }
+
+                slice :#{slice}, at: "/#{slice}" do
+                  root to: "home.index"
+                end
+
+                slice :api, at: "/api" do
+                  root to: "home.index"
                 end
               end
             end
           end
-        EXPECTED
-        expect(fs.read("#{action}.rb")).to eq(view_file)
+        CODE
+        fs.write("config/routes.rb", routes_contents)
+
+        expected = <<~CODE
+          # frozen_string_literal: true
+
+          require "hanami/routes"
+
+          module #{app}
+            class Routes < Hanami::Routes
+              define do
+                root { "Hello from Hanami" }
+
+                slice :#{slice}, at: "/#{slice}" do
+                  root to: "home.index"
+                  get "/users", to: "users.index"
+                end
+
+                slice :api, at: "/api" do
+                  root to: "home.index"
+                  get "/users/:id", to: "users.show"
+                end
+              end
+            end
+          end
+        CODE
+
+        subject.call(slice: slice, name: "users.index")
+        subject.call(slice: "api", name: "users.show")
+
+        expect(fs.read("config/routes.rb")).to eq(expected)
       end
+    end
 
-      # template
-      expect(fs.directory?(directory = "slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
+    it "infers RESTful action URL and HTTP method for routes" do
+      subject.call(slice: slice, name: "users.index")
+      expect(fs.read("config/routes.rb")).to match(%(get "/users", to: "users.index"))
 
-      fs.chdir(directory) do
+      subject.call(slice: slice, name: "users.new")
+      expect(fs.read("config/routes.rb")).to match(%(get "/users/new", to: "users.new"))
+
+      subject.call(slice: slice, name: "users.create")
+      expect(fs.read("config/routes.rb")).to match(%(post "/users", to: "users.create"))
+
+      subject.call(slice: slice, name: "users.edit")
+      expect(fs.read("config/routes.rb")).to match(%(get "/users/:id/edit", to: "users.edit"))
+
+      subject.call(slice: slice, name: "users.update")
+      expect(fs.read("config/routes.rb")).to match(%(patch "/users/:id", to: "users.update"))
+
+      subject.call(slice: slice, name: "users.show")
+      expect(fs.read("config/routes.rb")).to match(%(get "/users/:id", to: "users.show"))
+
+      subject.call(slice: slice, name: "users.destroy")
+      expect(fs.read("config/routes.rb")).to match(%(delete "/users/:id", to: "users.destroy"))
+    end
+
+    it "allows to specify action URL" do
+      subject.call(slice: slice, name: action_name, url: "/people")
+      expect(fs.read("config/routes.rb")).to match(%(get "/people", to: "users.index"))
+    end
+
+    it "allows to specify action HTTP method" do
+      subject.call(slice: slice, name: action_name, http: "put")
+      expect(fs.read("config/routes.rb")).to match(%(put "/users", to: "users.index"))
+    end
+
+    xit "allows to specify MIME Type for template" do
+      subject.call(slice: slice, name: action_name, format: format = "json")
+
+      fs.chdir("slices/#{slice}") do
+        expect(fs.exist?("actions/#{controller}/#{action}.rb")).to be(true)
+        expect(fs.exist?("views/#{controller}/#{action}.rb")).to be(true)
+
+        # template
+        expect(fs.exist?(file = "templates/#{controller}/#{action}.#{format}.erb")).to be(true)
+
         template_file = <<~EXPECTED
-          <h1>#{inflector.classify(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
-          <h2>slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb</h2>
         EXPECTED
-        expect(fs.read("#{action}.html.erb")).to eq(template_file)
+        expect(fs.read(file)).to eq(template_file)
       end
     end
-  end
 
-  it "appends routes within the proper slice block" do
-    fs.mkdir("slices/api")
+    it "can skip view creation" do
+      subject.call(slice: slice, name: action_name, skip_view: true)
 
-    routes_contents = <<~CODE
-      # frozen_string_literal: true
+      fs.chdir("slices/#{slice}") do
+        expect(fs.exist?("actions/#{controller}/#{action}.rb")).to be(true)
 
-      Hanami.app.routes do
-        slice :#{slice}, at: "/" do
-          root to: "home.index"
-        end
-
-        slice :api, at: "/api" do
-          root to: "home.index"
-        end
+        expect(fs.exist?("views/#{controller}/#{action}.rb")).to be(false)
+        expect(fs.exist?("templates/#{controller}/#{action}.html.erb")).to be(false)
       end
-    CODE
-    fs.write("config/routes.rb", routes_contents)
-
-    expected = <<~CODE
-      # frozen_string_literal: true
-
-      Hanami.app.routes do
-        slice :#{slice}, at: "/" do
-          root to: "home.index"
-          get "/users", to: "users.index"
-        end
-
-        slice :api, at: "/api" do
-          root to: "home.index"
-          get "/users/:id", to: "users.show"
-        end
-      end
-    CODE
-
-    subject.call(slice: slice, name: "users.index")
-    subject.call(slice: "api", name: "users.show")
-    expect(fs.read("config/routes.rb")).to eq(expected)
-  end
-
-  it "infers RESTful action URL and HTTP method for routes" do
-    subject.call(slice: slice, name: "users.index")
-    expect(fs.read("config/routes.rb")).to match(%(get "/users", to: "users.index"))
-
-    subject.call(slice: slice, name: "users.new")
-    expect(fs.read("config/routes.rb")).to match(%(get "/users/new", to: "users.new"))
-
-    subject.call(slice: slice, name: "users.create")
-    expect(fs.read("config/routes.rb")).to match(%(post "/users", to: "users.create"))
-
-    subject.call(slice: slice, name: "users.edit")
-    expect(fs.read("config/routes.rb")).to match(%(get "/users/:id/edit", to: "users.edit"))
-
-    subject.call(slice: slice, name: "users.update")
-    expect(fs.read("config/routes.rb")).to match(%(patch "/users/:id", to: "users.update"))
-
-    subject.call(slice: slice, name: "users.show")
-    expect(fs.read("config/routes.rb")).to match(%(get "/users/:id", to: "users.show"))
-
-    subject.call(slice: slice, name: "users.destroy")
-    expect(fs.read("config/routes.rb")).to match(%(delete "/users/:id", to: "users.destroy"))
-  end
-
-  it "allows to specify action URL" do
-    subject.call(slice: slice, name: action_name, url: "/people")
-    expect(fs.read("config/routes.rb")).to match(%(get "/people", to: "users.index"))
-  end
-
-  it "allows to specify action HTTP method" do
-    subject.call(slice: slice, name: action_name, http: "put")
-    expect(fs.read("config/routes.rb")).to match(%(put "/users", to: "users.index"))
-  end
-
-  it "allows to specify MIME Type for template" do
-    subject.call(slice: slice, name: action_name, format: format = "json")
-
-    fs.chdir("slices/#{slice}") do
-      expect(fs.exist?("actions/#{controller}/#{action}.rb")).to be(true)
-      expect(fs.exist?("views/#{controller}/#{action}.rb")).to be(true)
-
-      # template
-      expect(fs.exist?(file = "templates/#{controller}/#{action}.#{format}.erb")).to be(true)
-
-      template_file = <<~EXPECTED
-      EXPECTED
-      expect(fs.read(file)).to eq(template_file)
     end
-  end
 
-  it "can skip view creation" do
-    subject.call(slice: slice, name: action_name, skip_view: true)
-
-    fs.chdir("slices/#{slice}") do
-      expect(fs.exist?("actions/#{controller}/#{action}.rb")).to be(true)
-
-      expect(fs.exist?("views/#{controller}/#{action}.rb")).to be(false)
-      expect(fs.exist?("templates/#{controller}/#{action}.html.erb")).to be(false)
+    it "raises error if slice is unexisting" do
+      expect { subject.call(slice: "foo", name: action_name) }.to raise_error(ArgumentError, "slice not found `foo'")
     end
-  end
 
-  it "raises error if slice is unexisting" do
-    expect { subject.call(slice: "foo", name: action_name) }.to raise_error(ArgumentError, "slice not found `foo'")
-  end
+    it "raises error if action name doesn't respect the convention" do
+      expect {
+        subject.call(slice: slice, name: "foo")
+      }.to raise_error(ArgumentError, "cannot parse controller and action name: `foo'\n\texample: users.show")
+    end
 
-  it "raises error if action name doesn't respect the convention" do
-    expect {
-      subject.call(slice: slice, name: "foo")
-    }.to raise_error(ArgumentError, "cannot parse controller and action name: `foo'\n\texample: users.show")
-  end
+    it "raises error if HTTP method is unknown" do
+      expect {
+        subject.call(slice: slice, name: action_name, http: "foo")
+      }.to raise_error(ArgumentError, "unknown HTTP method: `foo'")
+    end
 
-  it "raises error if HTTP method is unknown" do
-    expect {
-      subject.call(slice: slice, name: action_name, http: "foo")
-    }.to raise_error(ArgumentError, "unknown HTTP method: `foo'")
-  end
-
-  it "raises error if URL is invalid" do
-    expect {
-      subject.call(slice: slice, name: action_name, url: "//")
-    }.to raise_error(ArgumentError, "invalid URL: `//'")
+    it "raises error if URL is invalid" do
+      expect {
+        subject.call(slice: slice, name: action_name, url: "//")
+      }.to raise_error(ArgumentError, "invalid URL: `//'")
+    end
   end
 
   private
 
+  def within_application_directory
+    application = Struct.new(:namespace).new(app)
+
+    allow(Hanami).to receive(:app)
+      .and_return(application)
+
+    fs.mkdir(dir)
+    fs.chdir(dir) do
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            define do
+              root { "Hello from Hanami" }
+            end
+          end
+        end
+      CODE
+
+      fs.write("config/routes.rb", routes)
+
+      yield
+    end
+  end
+
   def prepare_slice!
     fs.mkdir("slices/#{slice}")
-
-    routes_contents = <<~CODE
+    routes = <<~CODE
       # frozen_string_literal: true
 
-      Hanami.app.routes do
-        slice :#{slice}, at: "/" do
+      require "hanami/routes"
+
+      module #{app}
+        class Routes < Hanami::Routes
+          define do
+            root { "Hello from Hanami" }
+
+            slice :#{slice}, at: "/#{slice}" do
+            end
+          end
         end
       end
     CODE
-    fs.write("config/routes.rb", routes_contents)
+
+    fs.write("config/routes.rb", routes)
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
         # auto_register: false
         # frozen_string_literal: true
 
-        require "#{underscored_app}/action"
-
         module Admin
           class Action < #{app}::Action
           end


### PR DESCRIPTION
# Feature

Add `hanami generate action` CLI command to Hanami applications.

## Generate Action for App

It performs the following actions:

  * Edit `config/routes.rb` to add a the route
  * Create `app/actions/[controller]` directory
  * Create `app/actions/[controller]/[action].rb` file (with `MyApp::Actions::Books::Index < MyApp::Action` class definition)

Example:

```shell
⚡ bundle exec hanami generate action books.index
```

```shell
⚡ tree app
app
├── action.rb
└── actions
    └── books
        └── index.rb

2 directories, 2 files
```

`config/routes.rb`

```ruby
# frozen_string_literal: true

require "hanami/routes"

module Bookshelf
  class Routes < Hanami::Routes
    define do
      root { "Hello from Hanami" }
      get "/books", to: "books.index"
    end
  end
end
``` 

`app/actions/books/index.rb`

```ruby
# frozen_string_literal: true

module Bookshelf
  module Actions
    module Books
      class Index < Bookshelf::Action
        def handle(_req, res)
          res.body = self.class.name
        end
      end
    end
  end
end
```

## Generate Action for Slice

It performs the following actions:

  * Edit `config/routes.rb` to add a the route within the corresponding `slice` block
  * Create `slices/[slice]/actions/[controller]` directory
  * Create `slices/[slice]/actions/[controller]/[action].rb` file (with `MySlice::Actions::Users::Index < MySlice::Action` class definition)

Example:

```shell
⚡ bundle exec hanami generate action users.index --slice=admin
```

```shell
⚡ tree slices/admin
slices/admin
├── action.rb
└── actions
    └── users
        └── index.rb

2 directories, 2 files
``` 

`config/routes.rb`

```ruby
# frozen_string_literal: true

require "hanami/routes"

module Bookshelf
  class Routes < Hanami::Routes
    define do
      root { "Hello from Hanami" }

      slice :admin, at: "/admin" do
        get "/users", to: "users.index"
      end
    end
  end
end
```

`slices/admin/actions/users/index.rb`

```ruby
# frozen_string_literal: true

module Admin
  module Actions
    module Users
      class Index < Admin::Action
        def handle(*, res)
          res.body = self.class.name
        end
      end
    end
  end
end
```

## Options

```shell
⚡ bundle exec hanami g action --help
Command:
  hanami g action

Usage:
  hanami g action NAME

Arguments:
  NAME                              # REQUIRED Action name

Options:
  --url=VALUE                       # Action URL
  --http=VALUE                      # Action HTTP method
  --slice=VALUE                     # Slice name
  --help, -h                        # Print this help
```

---

Note for the reviewers: specs will be generated by `hanami-rspec`