### PR TITLE
Leverage Hanami's file detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ unless ENV["CI"]
 end
 
 gem "dry-files", require: false, github: "dry-rb/dry-files", branch: :main
-gem "hanami", require: false, github: "hanami/hanami", branch: :main
+gem "hanami", require: false, github: "hanami/hanami", branch: "waiting-for-dev/robust_setup"
 gem "hanami-router", github: "hanami/router", branch: :main
 
 gem "rack"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ unless ENV["CI"]
 end
 
 gem "dry-files", require: false, github: "dry-rb/dry-files", branch: :main
-gem "hanami", require: false, github: "hanami/hanami", branch: "waiting-for-dev/robust_setup"
+gem "hanami", require: false, github: "hanami/hanami", branch: :main
 gem "hanami-router", github: "hanami/router", branch: :main
 
 gem "rack"

--- a/lib/hanami/cli/commands.rb
+++ b/lib/hanami/cli/commands.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require "hanami/app_detector"
+
 module Hanami
   module CLI
     def self.within_hanami_app?
-      File.exist?("config/app.rb") ||
-        File.exist?("app.rb")
+      Hanami::AppDetector.new.() || false
     end
 
     module Commands

--- a/lib/hanami/cli/commands.rb
+++ b/lib/hanami/cli/commands.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
-require "hanami/app_detector"
+require "hanami"
 
 module Hanami
   module CLI
-    def self.within_hanami_app?
-      Hanami::AppDetector.new.() || false
-    end
-
     module Commands
     end
 
-    def self.register_commands!(within_hanami_app = Hanami::CLI.within_hanami_app?)
+    def self.register_commands!(within_hanami_app = !!Hanami.app_path)
       commands = if within_hanami_app
                    require_relative "commands/app"
                    Commands::App

--- a/lib/hanami/cli/commands.rb
+++ b/lib/hanami/cli/commands.rb
@@ -7,7 +7,7 @@ module Hanami
     module Commands
     end
 
-    def self.register_commands!(within_hanami_app = !!Hanami.app_path)
+    def self.register_commands!(within_hanami_app = Hanami.app_path)
       commands = if within_hanami_app
                    require_relative "commands/app"
                    Commands::App

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -159,8 +159,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action do
   end
 
   it "appends routes within the proper slice block" do
-    pending "FIXME: something changed and the output has too many new-lines now"
-
     fs.mkdir("slices/api")
 
     routes_contents = <<~CODE

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -134,8 +134,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
   def within_application_directory
     application = Struct.new(:namespace).new(app)
 
-    allow(Hanami).to receive(:app)
-      .and_return(application)
+    allow(Hanami).to receive(:app).and_return(application)
+    allow(Hanami).to receive(:app?).and_return(true)
 
     fs.mkdir(dir)
     fs.chdir(dir) do


### PR DESCRIPTION
Use the robust app file detection introduced in hanami/hanami#1197, to allow the CLI to be run even within nested directories and still find the Hanami app file at `config/app.rb` in the project root.