### PR TITLE
Respect plural name when generate code

### DIFF
--- a/lib/hanami/cli/generators/app/action/action.erb
+++ b/lib/hanami/cli/generators/app/action/action.erb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module <%= classified_app_name %>
+module <%= camelized_app_name %>
   module Actions
 <%= module_controller_declaration %>
-<%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_app_name %>::Action
+<%= module_controller_offset %>class <%= camelized_action_name %> < <%= camelized_app_name %>::Action
 <%= module_controller_offset %>  def handle(*, response)
 <%= module_controller_offset %>    response.body = self.class.name
 <%= module_controller_offset %>  end

--- a/lib/hanami/cli/generators/app/action/slice_action.erb
+++ b/lib/hanami/cli/generators/app/action/slice_action.erb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module <%= classified_slice_name %>
+module <%= camelized_slice_name %>
   module Actions
 <%= module_controller_declaration %>
-<%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_slice_name %>::Action
+<%= module_controller_offset %>class <%= camelized_action_name %> < <%= camelized_slice_name %>::Action
 <%= module_controller_offset %>  def handle(*, response)
 <%= module_controller_offset %>    response.body = self.class.name
 <%= module_controller_offset %>  end

--- a/lib/hanami/cli/generators/app/action/template.html.erb
+++ b/lib/hanami/cli/generators/app/action/template.html.erb
@@ -1,2 +1,2 @@
-<h1><%= classified_slice_name %>::Views::<%= classified_controller_name %>::<%= classified_action_name %></h1>
+<h1><%= camelized_slice_name %>::Views::<%= camelized_controller_name %>::<%= camelized_action_name %></h1>
 <h2><%= template_path %></h2>

--- a/lib/hanami/cli/generators/app/action/view.erb
+++ b/lib/hanami/cli/generators/app/action/view.erb
@@ -3,10 +3,10 @@
 
 require "<%= underscored_slice_name %>/view"
 
-module <%= classified_slice_name %>
+module <%= camelized_slice_name %>
   module Views
 <%= module_controller_declaration %>
-<%= module_controller_offset %>class <%= classified_action_name %> < <%= classified_slice_name %>::View
+<%= module_controller_offset %>class <%= camelized_action_name %> < <%= camelized_slice_name %>::View
 <%= module_controller_offset %>end
 <%= module_controller_end %>
   end

--- a/lib/hanami/cli/generators/app/action_context.rb
+++ b/lib/hanami/cli/generators/app/action_context.rb
@@ -14,14 +14,14 @@ module Hanami
             super(inflector, app, slice, nil)
           end
 
-          def classified_controller_name
+          def camelized_controller_name
             controller.map do |token|
               inflector.camelize(token)
             end.join(NAMESPACE_SEPARATOR)
           end
 
-          def classified_action_name
-            inflector.classify(action)
+          def camelized_action_name
+            inflector.camelize(action)
           end
 
           def underscored_controller_name

--- a/lib/hanami/cli/generators/app/slice/action.erb
+++ b/lib/hanami/cli/generators/app/slice/action.erb
@@ -1,7 +1,7 @@
 # auto_register: false
 # frozen_string_literal: true
 
-module <%= classified_slice_name %>
-  class Action < <%= classified_app_name %>::Action
+module <%= camelized_slice_name %>
+  class Action < <%= camelized_app_name %>::Action
   end
 end

--- a/lib/hanami/cli/generators/app/slice/entities.erb
+++ b/lib/hanami/cli/generators/app/slice/entities.erb
@@ -1,7 +1,7 @@
 # auto_register: false
 # frozen_string_literal: true
 
-module <%= classified_slice_name %>
+module <%= camelized_slice_name %>
   module Entities
   end
 end

--- a/lib/hanami/cli/generators/app/slice/repository.erb
+++ b/lib/hanami/cli/generators/app/slice/repository.erb
@@ -3,8 +3,8 @@
 require "<%= underscored_app_name %>/repository"
 require_relative "entities"
 
-module <%= classified_slice_name %>
-  class Repository < <%= classified_app_name %>::Repository
+module <%= camelized_slice_name %>
+  class Repository < <%= camelized_app_name %>::Repository
     struct_namespace Entities
   end
 end

--- a/lib/hanami/cli/generators/app/slice/slice.erb
+++ b/lib/hanami/cli/generators/app/slice/slice.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module <%= classified_slice_name %>
+module <%= camelized_slice_name %>
   class Slice < Hanami::Slice
   end
 end

--- a/lib/hanami/cli/generators/app/slice/view.erb
+++ b/lib/hanami/cli/generators/app/slice/view.erb
@@ -3,7 +3,7 @@
 
 require "<%= underscored_app_name %>/view"
 
-module <%= classified_slice_name %>
-  class View < <%= classified_app_name %>::View
+module <%= camelized_slice_name %>
+  class View < <%= camelized_app_name %>::View
   end
 end

--- a/lib/hanami/cli/generators/app/slice_context.rb
+++ b/lib/hanami/cli/generators/app/slice_context.rb
@@ -13,8 +13,8 @@ module Hanami
             super(inflector, app)
           end
 
-          def classified_slice_name
-            inflector.classify(slice)
+          def camelized_slice_name
+            inflector.camelize(slice)
           end
 
           def underscored_slice_name

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -19,8 +19,8 @@ module Hanami
           Version.gem_requirement
         end
 
-        def classified_app_name
-          inflector.classify(app)
+        def camelized_app_name
+          inflector.camelize(app)
         end
 
         def underscored_app_name

--- a/lib/hanami/cli/generators/gem/app/action.erb
+++ b/lib/hanami/cli/generators/gem/app/action.erb
@@ -3,7 +3,7 @@
 
 require "hanami/action"
 
-module <%= classified_app_name %>
+module <%= camelized_app_name %>
   class Action < Hanami::Action
   end
 end

--- a/lib/hanami/cli/generators/gem/app/app.erb
+++ b/lib/hanami/cli/generators/gem/app/app.erb
@@ -2,7 +2,7 @@
 
 require "hanami"
 
-module <%= classified_app_name %>
+module <%= camelized_app_name %>
   class App < Hanami::App
   end
 end

--- a/lib/hanami/cli/generators/gem/app/readme.erb
+++ b/lib/hanami/cli/generators/gem/app/readme.erb
@@ -1,1 +1,1 @@
-# <%= classified_app_name %>
+# <%= camelized_app_name %>

--- a/lib/hanami/cli/generators/gem/app/routes.erb
+++ b/lib/hanami/cli/generators/gem/app/routes.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module <%= classified_app_name %>
+module <%= camelized_app_name %>
   class Routes < Hanami::Routes
     define do
       root { "Hello from Hanami" }

--- a/lib/hanami/cli/generators/gem/app/settings.erb
+++ b/lib/hanami/cli/generators/gem/app/settings.erb
@@ -2,7 +2,7 @@
 
 require "<%= underscored_app_name %>/types"
 
-module <%= classified_app_name %>
+module <%= camelized_app_name %>
   class Settings < Hanami::Settings
     # Define your app settings here, for example:
     #

--- a/lib/hanami/cli/generators/gem/app/types.erb
+++ b/lib/hanami/cli/generators/gem/app/types.erb
@@ -2,7 +2,7 @@
 
 require "dry/types"
 
-module <%= classified_app_name %>
+module <%= camelized_app_name %>
   Types = Dry.Types
 
   module Types

--- a/lib/hanami/cli/generators/gem/app/validator.erb
+++ b/lib/hanami/cli/generators/gem/app/validator.erb
@@ -4,7 +4,7 @@
 require "dry/validation"
 require "dry/schema/messages/i18n"
 
-module <%= classified_app_name %>
+module <%= camelized_app_name %>
   module Validator < Dry::Validation::Contract
     config.messages.backend = :i18n
     config.messages.top_namespace = "validation"

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         action_file = <<~EXPECTED
           # frozen_string_literal: true
 
-          module #{inflector.classify(app)}
+          module #{inflector.camelize(app)}
             module Actions
               module #{inflector.camelize(controller)}
-                class #{inflector.classify(action)} < #{inflector.classify(app)}::Action
+                class #{inflector.camelize(action)} < #{inflector.camelize(app)}::Action
                   def handle(*, response)
                     response.body = self.class.name
                   end
@@ -64,10 +64,10 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         #
         #   require "#{inflector.underscore(slice)}/view"
         #
-        #   module #{inflector.classify(slice)}
+        #   module #{inflector.camelize(slice)}
         #     module Views
         #       module #{inflector.camelize(controller)}
-        #         class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
+        #         class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
         #         end
         #       end
         #     end
@@ -79,7 +79,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         # expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
         #
         # template_file = <<~EXPECTED
-        #   <h1>#{inflector.classify(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.classify(action)}</h1>
+        #   <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
         #   <h2>slices/#{slice}/templates/#{controller}/#{action}.html.erb</h2>
         # EXPECTED
         # expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
@@ -208,10 +208,10 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         action_file = <<~EXPECTED
           # frozen_string_literal: true
 
-          module #{inflector.classify(slice)}
+          module #{inflector.camelize(slice)}
             module Actions
               module #{inflector.camelize(controller)}
-                class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
+                class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
                   def handle(*, response)
                     response.body = self.class.name
                   end
@@ -231,10 +231,10 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         #
         #   require "#{inflector.underscore(slice)}/view"
         #
-        #   module #{inflector.classify(slice)}
+        #   module #{inflector.camelize(slice)}
         #     module Views
         #       module #{inflector.camelize(controller)}
-        #         class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
+        #         class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
         #         end
         #       end
         #     end
@@ -246,7 +246,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         # expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
         #
         # template_file = <<~EXPECTED
-        #   <h1>#{inflector.classify(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.classify(action)}</h1>
+        #   <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
         #   <h2>slices/#{slice}/templates/#{controller}/#{action}.html.erb</h2>
         # EXPECTED
         # expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
@@ -293,12 +293,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           action_file = <<~EXPECTED
             # frozen_string_literal: true
 
-            module #{inflector.classify(slice)}
+            module #{inflector.camelize(slice)}
               module Actions
                 module Books
                   module Bestsellers
                     module Nonfiction
-                      class #{inflector.classify(action)} < #{inflector.classify(slice)}::Action
+                      class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
                         def handle(*, response)
                           response.body = self.class.name
                         end
@@ -320,12 +320,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           #
           #   require "#{inflector.underscore(slice)}/view"
           #
-          #   module #{inflector.classify(slice)}
+          #   module #{inflector.camelize(slice)}
           #     module Views
           #       module Books
           #         module Bestsellers
           #           module Nonfiction
-          #             class #{inflector.classify(action)} < #{inflector.classify(slice)}::View
+          #             class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
           #             end
           #           end
           #         end
@@ -339,7 +339,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           # expect(fs.directory?("slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
           #
           # template_file = <<~EXPECTED
-          #   <h1>#{inflector.classify(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
+          #   <h1>#{inflector.camelize(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
           #   <h2>slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb</h2>
           # EXPECTED
           # expect(fs.read("slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb")).to eq(template_file)

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -16,14 +16,28 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
   it "normalizes app name" do
     expect(bundler).to receive(:install!)
+      .at_least(1)
       .and_return(true)
 
     expect(command_line).to receive(:call)
       .with("hanami install")
+      .at_least(1)
       .and_return(successful_system_call_result)
 
     app_name = "HanamiTeam"
     app = "hanami_team"
+    subject.call(app: app_name)
+
+    expect(fs.directory?(app)).to be(true)
+
+    app_name = "Rubygems"
+    app = "rubygems"
+    subject.call(app: app_name)
+
+    expect(fs.directory?(app)).to be(true)
+
+    app_name = "CodeInsights"
+    app = "code_insights"
     subject.call(app: app_name)
 
     expect(fs.directory?(app)).to be(true)
@@ -49,7 +63,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # README.md
       readme = <<~EXPECTED
-        # #{inflector.classify(app)}
+        # #{inflector.camelize(app)}
       EXPECTED
       expect(fs.read("README.md")).to eq(readme)
 
@@ -152,7 +166,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         require "hanami/action"
 
-        module #{inflector.classify(app)}
+        module #{inflector.camelize(app)}
           class Action < Hanami::Action
           end
         end
@@ -165,7 +179,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         require "dry/types"
 
-        module #{inflector.classify(app)}
+        module #{inflector.camelize(app)}
           Types = Dry.Types
 
           module Types
@@ -174,6 +188,42 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         end
       EXPECTED
       expect(fs.read("lib/#{app}/types.rb")).to eq(types)
+    end
+  end
+
+  it "respects plural app name" do
+    app = "rubygems"
+
+    expect(bundler).to receive(:install!)
+      .and_return(true)
+
+    expect(command_line).to receive(:call)
+      .with("hanami install")
+      .and_return(successful_system_call_result)
+
+    subject.call(app: app)
+
+    expect(fs.directory?(app)).to be(true)
+
+    fs.chdir(app) do
+      # README.md
+      readme = <<~EXPECTED
+        # #{inflector.camelize(app)}
+      EXPECTED
+      expect(fs.read("README.md")).to eq(readme)
+
+      # config/app.rb
+      hanami_app = <<~EXPECTED
+        # frozen_string_literal: true
+
+        require "hanami"
+
+        module #{inflector.camelize(app)}
+          class App < Hanami::App
+          end
+        end
+      EXPECTED
+      expect(fs.read("config/app.rb")).to eq(hanami_app)
     end
   end
 end


### PR DESCRIPTION
# Fix

```shell
⚡hanami new rubygems
```

## Before

```ruby
Hanami.app # => Rubygem::Application
```

## After

```ruby
Hanami.app # => Rubygems::Application
```

---

Closes #37 
https://trello.com/c/UoexUHqg