### PR TITLE
`hanami new` to generate Puma configuration

### DIFF
--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -40,6 +40,7 @@ module Hanami
             fs.write("config/app.rb", t("app.erb", context))
             fs.write("config/settings.rb", t("settings.erb", context))
             fs.write("config/routes.rb", t("routes.erb", context))
+            fs.write("config/puma.rb", t("puma.erb", context))
 
             fs.write("lib/tasks/.keep", t("keep.erb", context))
             fs.write("lib/#{app}/types.rb", t("types.erb", context))

--- a/lib/hanami/cli/generators/gem/app/puma.erb
+++ b/lib/hanami/cli/generators/gem/app/puma.erb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
+threads min_threads_count, max_threads_count
+
+port        ENV.fetch("HANAMI_PORT", 2300)
+environment ENV.fetch("HANAMI_ENV", "development")
+workers     ENV.fetch("HANAMI_WEB_CONCURRENCY", 2)
+
+on_worker_boot do
+  Hanami.shutdown
+end
+
+preload_app!

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -154,6 +154,26 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       EXPECTED
       expect(fs.read("config/routes.rb")).to eq(routes)
 
+      # config/puma.rb
+      puma = <<~EXPECTED
+        # frozen_string_literal: true
+
+        max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
+        min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
+        threads min_threads_count, max_threads_count
+
+        port        ENV.fetch("HANAMI_PORT", 2300)
+        environment ENV.fetch("HANAMI_ENV", "development")
+        workers     ENV.fetch("HANAMI_WEB_CONCURRENCY", 2)
+
+        on_worker_boot do
+          Hanami.shutdown
+        end
+
+        preload_app!
+      EXPECTED
+      expect(fs.read("config/puma.rb")).to eq(puma)
+
       # lib/tasks/.keep
       tasks_keep = <<~EXPECTED
       EXPECTED


### PR DESCRIPTION
`config/puma.rb`

```ruby
# frozen_string_literal: true

max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
threads min_threads_count, max_threads_count

port        ENV.fetch("HANAMI_PORT", 2300)
environment ENV.fetch("HANAMI_ENV", "development")
workers     ENV.fetch("HANAMI_WEB_CONCURRENCY", 2)

on_worker_boot do
  Hanami.shutdown
end

preload_app!
```

---

https://trello.com/c/V3IMSlso