### PR TITLE
Ensure `hanami generate action` to work with non-RESTful actions

### DIFF
--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -42,15 +42,18 @@ module Hanami
           private_constant :ROUTE_RESTFUL_HTTP_METHODS
 
           ROUTE_RESTFUL_URL_SUFFIXES = {
-            "index" => "",
-            "new" => "/new",
-            "create" => "",
-            "edit" => "/:id/edit",
-            "update" => "/:id",
-            "show" => "/:id",
-            "destroy" => "/:id"
+            "index" => [],
+            "new" => ["new"],
+            "create" => [],
+            "edit" => [":id", "edit"],
+            "update" => [":id"],
+            "show" => [":id"],
+            "destroy" => [":id"]
           }.freeze
           private_constant :ROUTE_RESTFUL_URL_SUFFIXES
+
+          PATH_SEPARATOR = "/"
+          private_constant :PATH_SEPARATOR
 
           attr_reader :fs
 
@@ -120,7 +123,10 @@ module Hanami
           alias_method :t, :template
 
           def route_url(controller, action, url)
-            CLI::URL.call(url || ("/#{controller.join('/')}" + ROUTE_RESTFUL_URL_SUFFIXES.fetch(action)))
+            action = ROUTE_RESTFUL_URL_SUFFIXES.fetch(action) { [action] }
+            url ||= "#{PATH_SEPARATOR}#{(controller + action).join(PATH_SEPARATOR)}"
+
+            CLI::URL.call(url)
           end
 
           def route_http(action, http)

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -129,6 +129,13 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       end
     end
 
+    it "allows to non-RESTful action URL" do
+      within_application_directory do
+        subject.call(name: "talent.apply", url: "/talent/apply")
+        expect(fs.read("config/routes.rb")).to match(%(get "/talent/apply", to: "talent.apply"))
+      end
+    end
+
     it "allows to specify action URL" do
       within_application_directory do
         subject.call(name: action_name, url: "/people")


### PR DESCRIPTION
# Bug

Example:

```shell
⚡bundle exec hanami generate action talent.apply
```

Before this fix, it was crashing.

---

Ref https://trello.com/c/FYeNF65B