### PR TITLE
`hanami new` to add `hanami-reloader` to `Gemfile`

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -15,6 +15,10 @@ group :development, :test do
   gem "dotenv"
 end
 
+group :cli, :development do
+  gem "hanami-reloader"
+end
+
 group :cli, :development, :test do
   gem "hanami-rspec"
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "dotenv"
         end
 
+        group :cli, :development do
+          gem "hanami-reloader"
+        end
+
         group :cli, :development, :test do
           gem "hanami-rspec"
         end


### PR DESCRIPTION
Use `hanami-reloader` by default.