### PR TITLE
Add required hanami-controller and hanami-view to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ end
 gem "dry-files", require: false, github: "dry-rb/dry-files", branch: :main
 gem "hanami", require: false, github: "hanami/hanami", branch: :main
 gem "hanami-router", github: "hanami/router", branch: :main
+gem "hanami-controller", github: "hanami/controller", branch: :main
+gem "hanami-view", github: "hanami/view", branch: :main
 
 gem "rack"
 


### PR DESCRIPTION
Since hanami/hanami#1204, we're no longer returning a null configuration
when action/view/router are not present. We need to add all the required
gems to the Gemfile to test their related commands.