### PR TITLE
Take app_path as argument for `hanami new`

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -15,7 +15,7 @@ module Hanami
           SKIP_BUNDLE_DEFAULT = false
           private_constant :SKIP_BUNDLE_DEFAULT
 
-          argument :app, required: true, desc: "App name"
+          argument :app_path, required: true, desc: "App path"
 
           option :skip_bundle, type: :boolean, required: false,
                                default: SKIP_BUNDLE_DEFAULT, desc: "Skip bundle install"
@@ -36,12 +36,10 @@ module Hanami
           end
           # rubocop:enable Metrics/ParameterLists
 
-          def call(app:, skip_bundle: SKIP_BUNDLE_DEFAULT, **)
-            app = inflector.underscore(app)
-
-            fs.mkdir(app)
-            fs.chdir(app) do
-              generator.call(app) do
+          def call(app_path:, skip_bundle: SKIP_BUNDLE_DEFAULT, **)
+            fs.mkdir(app_path)
+            fs.chdir(app_path) do
+              generator.call(app_path) do
                 unless skip_bundle
                   bundler.install!
                   run_install_commmand!

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -15,6 +15,9 @@ module Hanami
           SKIP_BUNDLE_DEFAULT = false
           private_constant :SKIP_BUNDLE_DEFAULT
 
+          ROOT_PATH = "/"
+          private_constant :ROOT_PATH
+
           argument :app_path, required: true, desc: "App path"
 
           option :skip_bundle, type: :boolean, required: false,
@@ -37,6 +40,10 @@ module Hanami
           # rubocop:enable Metrics/ParameterLists
 
           def call(app_path:, skip_bundle: SKIP_BUNDLE_DEFAULT, **)
+            raise ArgumentError, <<~MSG if app_path == ROOT_PATH
+              System's root directory is not allowed as the application path
+            MSG
+
             fs.mkdir(app_path)
             fs.chdir(app_path) do
               app_name = File.basename(File.expand_path(app_path))

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -39,7 +39,8 @@ module Hanami
           def call(app_path:, skip_bundle: SKIP_BUNDLE_DEFAULT, **)
             fs.mkdir(app_path)
             fs.chdir(app_path) do
-              generator.call(app_path) do
+              app_name = File.basename(File.expand_path(app_path))
+              generator.call(app_name) do
                 unless skip_bundle
                   bundler.install!
                   run_install_commmand!

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -29,7 +29,7 @@ module Hanami
 
           attr_reader :command_line
 
-          def generate_app(app, context) # rubocop:disable Metrics/AbcSize
+          def generate_app(app_path, context) # rubocop:disable Metrics/AbcSize
             fs.write(".env", t("env.erb", context))
 
             fs.write("README.md", t("readme.erb", context))
@@ -43,7 +43,7 @@ module Hanami
             fs.write("config/puma.rb", t("puma.erb", context))
 
             fs.write("lib/tasks/.keep", t("keep.erb", context))
-            fs.write("lib/#{app}/types.rb", t("types.erb", context))
+            fs.write("lib/#{app_path}/types.rb", t("types.erb", context))
 
             fs.write("app/actions/.keep", t("keep.erb", context))
             fs.write("app/action.rb", t("action.erb", context))

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   let(:inflector) { Dry::Inflector.new }
   let(:app_path) { "bookshelf" }
 
-  it "creates the app path" do
+  def stub_installation
     expect(bundler).to receive(:install!)
       .at_least(1)
       .and_return(true)
@@ -23,6 +23,10 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       .with("hanami install")
       .at_least(1)
       .and_return(successful_system_call_result)
+  end
+
+  it "creates the app path" do
+    stub_installation
 
     subject.call(app_path: app_path)
 
@@ -30,14 +34,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   end
 
   it "inflects the app name from the app path's basename" do
-    expect(bundler).to receive(:install!)
-      .at_least(1)
-      .and_return(true)
-
-    expect(command_line).to receive(:call)
-      .with("hanami install")
-      .at_least(1)
-      .and_return(successful_system_call_result)
+    stub_installation
 
     subject.call(app_path: app_path)
 
@@ -45,14 +42,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   end
 
   it "doesn't fail if the directory already exists", :aggregate_failures do
-    expect(bundler).to receive(:install!)
-      .at_least(1)
-      .and_return(true)
-
-    expect(command_line).to receive(:call)
-      .with("hanami install")
-      .at_least(1)
-      .and_return(successful_system_call_result)
+    stub_installation
 
     fs.mkdir(app_path)
 
@@ -61,14 +51,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   end
 
   it "can create an app in a nested directory" do
-    expect(bundler).to receive(:install!)
-      .at_least(1)
-      .and_return(true)
-
-    expect(command_line).to receive(:call)
-      .with("hanami install")
-      .at_least(1)
-      .and_return(successful_system_call_result)
+    stub_installation
 
     app_path = "code/bookshelf"
 
@@ -82,12 +65,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   end
 
   it "generates an app" do
-    expect(bundler).to receive(:install!)
-      .and_return(true)
-
-    expect(command_line).to receive(:call)
-      .with("hanami install")
-      .and_return(successful_system_call_result)
+    stub_installation
 
     subject.call(app_path: app_path)
 
@@ -254,14 +232,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   end
 
   it "respects plural app name" do
+    stub_installation
+
     app_path = "rubygems"
-
-    expect(bundler).to receive(:install!)
-      .and_return(true)
-
-    expect(command_line).to receive(:call)
-      .with("hanami install")
-      .and_return(successful_system_call_result)
 
     subject.call(app_path: app_path)
 

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -77,6 +77,10 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     expect(fs.read("#{app_path}/config/app.rb")).to include("module Bookshelf")
   end
 
+  it "raises an error when / is given" do
+    expect { subject.call(app_path: "/") }.to raise_error(ArgumentError, /root directory is not allowed/)
+  end
+
   it "generates an app" do
     expect(bundler).to receive(:install!)
       .and_return(true)

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   let(:stdout) { StringIO.new }
   let(:fs) { Dry::Files.new(memory: true) }
   let(:inflector) { Dry::Inflector.new }
-  let(:app) { "bookshelf" }
+  let(:app_path) { "bookshelf" }
 
-  it "normalizes app name" do
+  it "creates the app path" do
     expect(bundler).to receive(:install!)
       .at_least(1)
       .and_return(true)
@@ -24,23 +24,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       .at_least(1)
       .and_return(successful_system_call_result)
 
-    app_name = "HanamiTeam"
-    app = "hanami_team"
-    subject.call(app: app_name)
+    subject.call(app_path: app_path)
 
-    expect(fs.directory?(app)).to be(true)
-
-    app_name = "Rubygems"
-    app = "rubygems"
-    subject.call(app: app_name)
-
-    expect(fs.directory?(app)).to be(true)
-
-    app_name = "CodeInsights"
-    app = "code_insights"
-    subject.call(app: app_name)
-
-    expect(fs.directory?(app)).to be(true)
+    expect(fs.directory?(app_path)).to be(true)
   end
 
   it "generates an app" do
@@ -51,11 +37,11 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       .with("hanami install")
       .and_return(successful_system_call_result)
 
-    subject.call(app: app)
+    subject.call(app_path: app_path)
 
-    expect(fs.directory?(app)).to be(true)
+    expect(fs.directory?(app_path)).to be(true)
 
-    fs.chdir(app) do
+    fs.chdir(app_path) do
       # .env
       env = <<~EXPECTED
       EXPECTED
@@ -63,7 +49,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # README.md
       readme = <<~EXPECTED
-        # #{inflector.camelize(app)}
+        # #{inflector.camelize(app_path)}
       EXPECTED
       expect(fs.read("README.md")).to eq(readme)
 
@@ -190,7 +176,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         require "hanami/action"
 
-        module #{inflector.camelize(app)}
+        module #{inflector.camelize(app_path)}
           class Action < Hanami::Action
           end
         end
@@ -203,7 +189,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         require "dry/types"
 
-        module #{inflector.camelize(app)}
+        module #{inflector.camelize(app_path)}
           Types = Dry.Types
 
           module Types
@@ -211,12 +197,12 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           end
         end
       EXPECTED
-      expect(fs.read("lib/#{app}/types.rb")).to eq(types)
+      expect(fs.read("lib/#{app_path}/types.rb")).to eq(types)
     end
   end
 
   it "respects plural app name" do
-    app = "rubygems"
+    app_path = "rubygems"
 
     expect(bundler).to receive(:install!)
       .and_return(true)
@@ -225,14 +211,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       .with("hanami install")
       .and_return(successful_system_call_result)
 
-    subject.call(app: app)
+    subject.call(app_path: app_path)
 
-    expect(fs.directory?(app)).to be(true)
+    expect(fs.directory?(app_path)).to be(true)
 
-    fs.chdir(app) do
+    fs.chdir(app_path) do
       # README.md
       readme = <<~EXPECTED
-        # #{inflector.camelize(app)}
+        # #{inflector.camelize(app_path)}
       EXPECTED
       expect(fs.read("README.md")).to eq(readme)
 
@@ -242,7 +228,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         require "hanami"
 
-        module #{inflector.camelize(app)}
+        module #{inflector.camelize(app_path)}
           class App < Hanami::App
           end
         end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -29,6 +29,54 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     expect(fs.directory?(app_path)).to be(true)
   end
 
+  it "inflects the app name from the app path's basename" do
+    expect(bundler).to receive(:install!)
+      .at_least(1)
+      .and_return(true)
+
+    expect(command_line).to receive(:call)
+      .with("hanami install")
+      .at_least(1)
+      .and_return(successful_system_call_result)
+
+    subject.call(app_path: app_path)
+
+    expect(fs.read("#{app_path}/config/app.rb")).to include("module Bookshelf")
+  end
+
+  it "doesn't fail if the directory already exists", :aggregate_failures do
+    expect(bundler).to receive(:install!)
+      .at_least(1)
+      .and_return(true)
+
+    expect(command_line).to receive(:call)
+      .with("hanami install")
+      .at_least(1)
+      .and_return(successful_system_call_result)
+
+    fs.mkdir(app_path)
+
+    expect { subject.call(app_path: app_path) }.not_to raise_error
+    expect(fs.read("#{app_path}/config/app.rb")).to include("module Bookshelf")
+  end
+
+  it "can create an app in a nested directory" do
+    expect(bundler).to receive(:install!)
+      .at_least(1)
+      .and_return(true)
+
+    expect(command_line).to receive(:call)
+      .with("hanami install")
+      .at_least(1)
+      .and_return(successful_system_call_result)
+
+    app_path = "code/bookshelf"
+
+    subject.call(app_path: app_path)
+
+    expect(fs.read("#{app_path}/config/app.rb")).to include("module Bookshelf")
+  end
+
   it "generates an app" do
     expect(bundler).to receive(:install!)
       .and_return(true)


### PR DESCRIPTION
There're a few benefits in doing so instead of taking the app name:

- Being a CLI command, it feels more natural passing a directory name
  than a ruby module name.
- Simpler code: we were re-inflecting the module name from the inflected
  directory name in the templates.
- More familiar for Ruby developers: it's what Rails does.
- Taking the basename and expanding the path, we allow something like `hanami new .`.
- It allows to create of the app within a nested directory.
- We allow for any combination of upper and lower case letter in the directory.