### PR TITLE
fix: Use app[:settings] in database commands.

### DIFF
--- a/lib/hanami/cli/commands/db/utils/database.rb
+++ b/lib/hanami/cli/commands/db/utils/database.rb
@@ -30,7 +30,7 @@ module Hanami
             }.freeze
 
             def self.[](app)
-              config = DatabaseConfig.new(app.settings.database_url)
+              config = DatabaseConfig.new(app[:settings].database_url)
 
               resolver = SCHEME_MAP.fetch(config.db_type) do
                 raise "#{config.db_type} is not a supported db scheme"


### PR DESCRIPTION
This is so the existing database commands can continue to work (albeit unofficially) with hanami 2.0.0.beta2.

Yes, I realise they're not properly supported with the beta releases, but they have still worked when using a custom `bin/hanami` shim that re-enables them. So, this is just a small change to help that remain the case. 😅