### PR TITLE
Fix routes definition in test app

### DIFF
--- a/spec/fixtures/test/config/routes.rb
+++ b/spec/fixtures/test/config/routes.rb
@@ -4,9 +4,7 @@ require "hanami/routes"
 
 module Test
   class Routes < Hanami::Routes
-    define do
-      get "/", to: "home.index"
-      get "/about", to: "home.about"
-    end
+    get "/", to: "home.index"
+    get "/about", to: "home.about"
   end
 end


### PR DESCRIPTION
No longer needs (or can use) the  block

https://github.com/hanami/hanami/pull/1208


Note that this is different from #45, which is about the apps that this cli generates, whereas this is to make the test suite for this repo green again.