### PR TITLE
Tidy `hanami` help

### DIFF
--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -7,9 +7,10 @@ require "dry/inflector"
 module Hanami
   module CLI
     class Command < Dry::CLI::Command
-      def initialize(out: $stdout, fs: Dry::Files.new, inflector: Dry::Inflector.new)
+      def initialize(out: $stdout, err: $stderr, fs: Dry::Files.new, inflector: Dry::Inflector.new)
         super()
         @out = out
+        @err = err
         @fs = fs
         @inflector = inflector
       end
@@ -17,6 +18,8 @@ module Hanami
       private
 
       attr_reader :out
+
+      attr_reader :err
 
       attr_reader :fs
 

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -10,7 +10,7 @@ module Hanami
         require_relative "app/server"
         require_relative "app/routes"
         require_relative "app/generate"
-        require_relative "app/middlewares"
+        require_relative "app/middleware"
         # require_relative "app/db/create"
         # require_relative "app/db/create_migration"
         # require_relative "app/db/drop"
@@ -30,7 +30,7 @@ module Hanami
             register "console", Commands::App::Console, aliases: ["c"]
             register "server", Commands::App::Server, aliases: ["s"]
             register "routes", Commands::App::Routes
-            register "middlewares", Commands::App::Middlewares
+            register "middleware", Commands::App::Middleware
 
             register "generate", aliases: ["g"] do |prefix|
               prefix.register "slice", Generate::Slice

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -28,6 +28,22 @@ module Hanami
             #                    desc: "Skip view and template generation"
             option :slice, required: false, desc: "Slice name"
 
+            # rubocop:disable Layout/LineLength
+            example [
+              %(books.index               # GET    /books          to: "books.index"    (MyApp::Actions::Books::Index)),
+              %(books.new                 # GET    /books/new      to: "books.new"      (MyApp::Actions::Books::New)),
+              %(books.create              # POST   /books          to: "books.create"   (MyApp::Actions::Books::Create)),
+              %(books.edit                # GET    /books/:id/edit to: "books.edit"     (MyApp::Actions::Books::Edit)),
+              %(books.update              # PATCH  /books/:id      to: "books.update"   (MyApp::Actions::Books::Update)),
+              %(books.show                # GET    /books/:id      to: "books.show"     (MyApp::Actions::Books::Show)),
+              %(books.destroy             # DELETE /books/:id      to: "books.destroy"  (MyApp::Actions::Books::Destroy)),
+              %(books.sale                # GET    /books/sale     to: "books.sale"     (MyApp::Actions::Books::Sale)),
+              %(sessions.new --url=/login # GET    /login          to: "sessions.new"   (MyApp::Actions::Sessions::New)),
+              %(authors.update --http=put # PUT    /authors/:id    to: "authors.update" (MyApp::Actions::Authors::Update)),
+              %(users.index --slice=admin # GET    /admin/users    to: "users.index"    (Admin::Actions::Users::Update))
+            ]
+            # rubocop:enable Layout/LineLength
+
             def initialize(fs: Dry::Files.new, inflector: Dry::Inflector.new,
                            generator: Generators::App::Action.new(fs: fs, inflector: inflector), **)
               @generator = generator

--- a/lib/hanami/cli/commands/app/generate/slice.rb
+++ b/lib/hanami/cli/commands/app/generate/slice.rb
@@ -14,7 +14,12 @@ module Hanami
         module Generate
           class Slice < Command
             argument :name, required: true, desc: "The slice name"
-            option :url_prefix, required: false, type: :string, desc: "The slice URL prefix"
+            option :url, required: false, type: :string, desc: "The slice URL prefix"
+
+            example [
+              "admin          # Admin slice (/admin URL prefix)",
+              "users --url=/u # Users slice (/u URL prefix)",
+            ]
 
             def initialize(fs: Dry::Files.new, inflector: Dry::Inflector.new,
                            generator: Generators::App::Slice.new(fs: fs, inflector: inflector), **)
@@ -22,14 +27,14 @@ module Hanami
               super(fs: fs)
             end
 
-            def call(name:, url_prefix: nil, **)
+            def call(name:, url: nil, **)
               require "hanami/setup"
 
               app = inflector.underscore(Hanami.app.namespace)
               name = inflector.underscore(Shellwords.shellescape(name))
-              url_prefix = sanitize_url_prefix(name, url_prefix)
+              url = sanitize_url_prefix(name, url)
 
-              generator.call(app, name, url_prefix)
+              generator.call(app, name, url)
             end
 
             private
@@ -39,14 +44,14 @@ module Hanami
 
             attr_reader :generator
 
-            def sanitize_url_prefix(name, url_prefix)
-              result = url_prefix
+            def sanitize_url_prefix(name, url)
+              result = url
               result = inflector.underscore(Shellwords.shellescape(result)) unless result.nil?
 
               result ||= DEFAULT_URL_PREFIX + name
               CLI::URL.call(result)
             rescue ArgumentError
-              raise ArgumentError.new("invalid URL prefix: `#{url_prefix}'")
+              raise ArgumentError.new("invalid URL prefix: `#{url}'")
             end
 
             def valid_url?(url)

--- a/lib/hanami/cli/commands/app/install.rb
+++ b/lib/hanami/cli/commands/app/install.rb
@@ -7,6 +7,8 @@ module Hanami
     module Commands
       module App
         class Install < Command
+          desc "Install Hanami third-party plugins"
+
           def call(*)
           end
         end

--- a/lib/hanami/cli/commands/app/middleware.rb
+++ b/lib/hanami/cli/commands/app/middleware.rb
@@ -31,6 +31,11 @@ module Hanami
           option :with_arguments, default: DEFAULT_WITH_ARGUMENTS, required: false,
                                   desc: "Include inspected arguments", type: :boolean
 
+          example [
+            "middleware                  # Print app Rack middleware stack",
+            "middleware --with-arguments # Print app Rack middleware stack, including initialize arguments",
+          ]
+
           # @api private
           def call(with_arguments: DEFAULT_WITH_ARGUMENTS)
             require "hanami/prepare"

--- a/lib/hanami/cli/commands/app/middleware.rb
+++ b/lib/hanami/cli/commands/app/middleware.rb
@@ -7,23 +7,23 @@ module Hanami
   module CLI
     module Commands
       module App
-        # List registered middlewares in the app router
+        # List registered middleware in the app router
         #
-        # It outputs middlewares registered along with the paths where they
+        # It outputs middleware registered along with the paths where they
         # apply:
         #
         # ```
-        # $ bundle exec hanami middlewares
+        # $ bundle exec hanami middleware
         # /    Rack::Session::Cookie
         # ```
         #
         # Given arguments can be inspected:
         #
         # ```
-        # $ bundle exec hanami middlewares --with-arguments
+        # $ bundle exec hanami middleware --with-arguments
         # /    Rack::Session::Cookie args: [{:secret=>"foo"}]
         # ```
-        class Middlewares < Hanami::CLI::Command
+        class Middleware < Hanami::CLI::Command
           desc "Print app Rack middleware stack"
 
           DEFAULT_WITH_ARGUMENTS = false

--- a/lib/hanami/cli/commands/app/middlewares.rb
+++ b/lib/hanami/cli/commands/app/middlewares.rb
@@ -13,18 +13,18 @@ module Hanami
         # apply:
         #
         # ```
-        # $ hanami middlewares
+        # $ bundle exec hanami middlewares
         # /    Rack::Session::Cookie
         # ```
         #
         # Given arguments can be inspected:
         #
         # ```
-        # $ hanami middlewares --with-arguments
+        # $ bundle exec hanami middlewares --with-arguments
         # /    Rack::Session::Cookie args: [{:secret=>"foo"}]
         # ```
         class Middlewares < Hanami::CLI::Command
-          desc "List all the registered middlewares"
+          desc "Print app Rack middleware stack"
 
           DEFAULT_WITH_ARGUMENTS = false
 

--- a/lib/hanami/cli/commands/app/routes.rb
+++ b/lib/hanami/cli/commands/app/routes.rb
@@ -11,14 +11,14 @@ module Hanami
         # All the formatters available from `hanami-router` are available:
         #
         # ```
-        # $ hanami routes --format=csv
+        # $ bundle exec hanami routes --format=csv
         # ```
         #
         # Experimental: You can also use a custom formatter registered in the
         # application container. You can identify it by its key:
         #
         # ```
-        # $ hanami routes --format=custom_routes_formatter
+        # $ bundle exec hanami routes --format=custom_routes_formatter
         # ```
         class Routes < Hanami::CLI::Command
           DEFAULT_FORMAT = "human_friendly"
@@ -30,7 +30,7 @@ module Hanami
           ].freeze
           private_constant :VALID_FORMATS
 
-          desc "Inspect application"
+          desc "Print app routes"
 
           option :format,
                  default: DEFAULT_FORMAT,

--- a/lib/hanami/cli/commands/app/routes.rb
+++ b/lib/hanami/cli/commands/app/routes.rb
@@ -37,6 +37,11 @@ module Hanami
                  required: false,
                  desc: "Output format"
 
+          example [
+            "routes              # Print app routes",
+            "routes --format=csv # Print app routes, using CSV format",
+          ]
+
           # @api private
           def call(format: DEFAULT_FORMAT, **)
             require "hanami/router/inspector"

--- a/lib/hanami/cli/commands/app/server.rb
+++ b/lib/hanami/cli/commands/app/server.rb
@@ -28,13 +28,16 @@ module Hanami
           DEFAULT_PORT = 2300
           private_constant :DEFAULT_PORT
 
-          desc "Start Hanami server"
+          DEFAULT_CONFIG_PATH = "config.ru"
+          private_constant :DEFAULT_CONFIG_PATH
+
+          desc "Start Hanami app server"
 
           option :host, default: nil, required: false,
                         desc: "The host address to bind to (falls back to the rack handler)"
           option :port, default: DEFAULT_PORT, required: false,
                         desc: "The port to run the server on (falls back to the rack handler)"
-          option :config, default: "config.ru", required: false, desc: "Rack configuration file"
+          option :config, default: DEFAULT_CONFIG_PATH, required: false, desc: "Rack configuration file"
           option :debug, default: false, required: false, desc: "Turn on/off debug output", type: :boolean
           option :warn, default: false, required: false, desc: "Turn on/off warnings", type: :boolean
 

--- a/lib/hanami/cli/commands/app/version.rb
+++ b/lib/hanami/cli/commands/app/version.rb
@@ -7,6 +7,8 @@ module Hanami
     module Commands
       module App
         class Version < Command
+          desc "Print Hanami app version"
+
           def call(*)
             require "hanami/version"
             out.puts "v#{Hanami::VERSION}"

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -12,13 +12,21 @@ module Hanami
     module Commands
       module Gem
         class New < Command
-          SKIP_BUNDLE_DEFAULT = false
-          private_constant :SKIP_BUNDLE_DEFAULT
+          SKIP_INSTALL_DEFAULT = false
+          private_constant :SKIP_INSTALL_DEFAULT
+
+          desc "Generate a new Hanami app"
 
           argument :app, required: true, desc: "App name"
 
-          option :skip_bundle, type: :boolean, required: false,
-                               default: SKIP_BUNDLE_DEFAULT, desc: "Skip bundle install"
+          option :skip_install, type: :boolean, required: false,
+                                default: SKIP_INSTALL_DEFAULT,
+                                desc: "Skip app installation (Bundler, third-party Hanami plugins)"
+
+          example [
+            "bookshelf                # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace", # rubocop:disable Layout/LineLength
+            "bookshelf --skip-install # Generate a new Hanami app, but it skips Hanami installation"
+          ]
 
           # rubocop:disable Metrics/ParameterLists
           def initialize(
@@ -36,13 +44,15 @@ module Hanami
           end
           # rubocop:enable Metrics/ParameterLists
 
-          def call(app:, skip_bundle: SKIP_BUNDLE_DEFAULT, **)
+          def call(app:, skip_install: SKIP_INSTALL_DEFAULT, **)
             app = inflector.underscore(app)
 
             fs.mkdir(app)
             fs.chdir(app) do
               generator.call(app) do
-                unless skip_bundle
+                if skip_install
+                  out.puts "Skipping installation, please enter `#{app}' directory and run `bundle exec hanami install'"
+                else
                   bundler.install!
                   run_install_commmand!
                 end

--- a/lib/hanami/cli/commands/gem/version.rb
+++ b/lib/hanami/cli/commands/gem/version.rb
@@ -7,6 +7,8 @@ module Hanami
     module Commands
       module Gem
         class Version < Command
+          desc "Hanami version"
+
           def call(*)
             version = detect_version
             out.puts "v#{version}"

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -14,7 +14,7 @@ module Hanami
             @inflector = inflector
           end
 
-          def call(app, slice, slice_url_prefix, context: SliceContext.new(inflector, app, slice, slice_url_prefix))
+          def call(app, slice, url, context: SliceContext.new(inflector, app, slice, url))
             fs.inject_line_at_class_bottom(
               fs.join("config", "routes.rb"), "class Routes", t("routes.erb", context).chomp
             )

--- a/lib/hanami/cli/generators/app/slice/routes.erb
+++ b/lib/hanami/cli/generators/app/slice/routes.erb
@@ -1,3 +1,3 @@
 
-slice :<%= underscored_slice_name %>, at: "<%= slice_url_prefix %>" do
+slice :<%= underscored_slice_name %>, at: "<%= url %>" do
 end

--- a/lib/hanami/cli/generators/app/slice_context.rb
+++ b/lib/hanami/cli/generators/app/slice_context.rb
@@ -7,9 +7,9 @@ module Hanami
     module Generators
       module App
         class SliceContext < Generators::Context
-          def initialize(inflector, app, slice, slice_url_prefix)
+          def initialize(inflector, app, slice, url)
             @slice = slice
-            @slice_url_prefix = slice_url_prefix
+            @url = url
             super(inflector, app)
           end
 
@@ -25,7 +25,7 @@ module Hanami
 
           attr_reader :slice
 
-          attr_reader :slice_url_prefix
+          attr_reader :url
         end
       end
     end

--- a/lib/hanami/cli/middleware_stack_inspector.rb
+++ b/lib/hanami/cli/middleware_stack_inspector.rb
@@ -11,9 +11,9 @@ module Hanami
       def inspect(include_arguments: false)
         max_path_length = @stack.map { |(path)| path.length }.max
 
-        @stack.map { |path, middlewares|
-          middlewares.map { |(middleware, arguments)|
-            "#{path.ljust(max_path_length + 3)} #{format_middleware(middleware)}".tap { |line|
+        @stack.map { |path, middleware|
+          middleware.map { |(mware, arguments)|
+            "#{path.ljust(max_path_length + 3)} #{format_middleware(mware)}".tap { |line|
               line << " #{format_arguments(arguments)}" if include_arguments
             }
           }

--- a/spec/integration/run_spec.rb
+++ b/spec/integration/run_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "bin/hanami", :app do
     end
 
     context "pry" do
-      let(:args) { ["console --repl pry"] }
+      let(:args) { ["console --engine pry"] }
 
       it "starts pry console" do
         expect(output[0]).to include("test[development]")
@@ -59,14 +59,6 @@ RSpec.describe "bin/hanami", :app do
     describe "hanami environment" do
       context "HANAMI_ENV is present in the environment" do
         let(:hanami_env) { "production" }
-
-        context "forced env option provided" do
-          let(:args) { ["console --env staging"] }
-
-          it "respects the option" do
-            expect(output[0]).to include("test[staging]")
-          end
-        end
 
         context "forced env option absent" do
           let(:args) { ["console"] }
@@ -79,14 +71,6 @@ RSpec.describe "bin/hanami", :app do
 
       context "HANAMI_ENV is absent from the environment" do
         let(:hanami_env) { nil }
-
-        context "forced env option provided" do
-          let(:args) { ["console --env production"] }
-
-          it "respects the provided env" do
-            expect(output[0]).to include("test[production]")
-          end
-        end
 
         context "forced env option absent" do
           let(:args) { ["console"] }

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -74,23 +74,23 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
       expected = %(slice :#{slice_name}, at: "/#{slice_name}" do)
       expect(fs.read("config/routes.rb")).to match(expected)
 
-      subject.call(name: slice_name = SecureRandom.alphanumeric(16).downcase, url_prefix: "/")
+      subject.call(name: slice_name = SecureRandom.alphanumeric(16).downcase, url: "/")
       expected = %(slice :#{slice_name}, at: "/" do)
       expect(fs.read("config/routes.rb")).to match(expected)
 
-      subject.call(name: slice_name = SecureRandom.alphanumeric(16).downcase, url_prefix: "/foo_bar")
+      subject.call(name: slice_name = SecureRandom.alphanumeric(16).downcase, url: "/foo_bar")
       expected = %(slice :#{slice_name}, at: "/foo_bar" do)
       expect(fs.read("config/routes.rb")).to match(expected)
 
-      subject.call(name: slice_name = SecureRandom.alphanumeric(16).downcase, url_prefix: "/FooBar")
+      subject.call(name: slice_name = SecureRandom.alphanumeric(16).downcase, url: "/FooBar")
       expected = %(slice :#{slice_name}, at: "/foo_bar" do)
       expect(fs.read("config/routes.rb")).to match(expected)
 
-      expect { subject.call(name: slice, url_prefix: " ") }.to raise_error(ArgumentError, "invalid URL prefix: ` '")
-      expect { subject.call(name: slice, url_prefix: "a") }.to raise_error(ArgumentError, "invalid URL prefix: `a'")
-      expect { subject.call(name: slice, url_prefix: "//") }.to raise_error(ArgumentError, "invalid URL prefix: `//'")
+      expect { subject.call(name: slice, url: " ") }.to raise_error(ArgumentError, "invalid URL prefix: ` '")
+      expect { subject.call(name: slice, url: "a") }.to raise_error(ArgumentError, "invalid URL prefix: `a'")
+      expect { subject.call(name: slice, url: "//") }.to raise_error(ArgumentError, "invalid URL prefix: `//'")
       expect {
-        subject.call(name: slice, url_prefix: "//FooBar")
+        subject.call(name: slice, url: "//FooBar")
       }.to raise_error(ArgumentError, "invalid URL prefix: `//FooBar'")
     end
   end

--- a/spec/unit/hanami/cli/commands/app/middleware_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/middleware_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require "hanami/cli/commands/app/middlewares"
+require "hanami/cli/commands/app/middleware"
 
-RSpec.describe Hanami::CLI::Commands::App::Middlewares, :app, :command do
+RSpec.describe Hanami::CLI::Commands::App::Middleware, :app, :command do
   # TODO: better Hanami tear down
   after do
     app = Hanami.app
     app.remove_instance_variable(:@_router) if app.instance_variable_defined?(:@_router)
   end
 
-  it "lists registered middlewares" do
+  it "lists registered middleware" do
     command.call
 
     expect(output).to eq <<~OUTPUT


### PR DESCRIPTION
# Enhancement

Tidy `--help` of all the `hanami` commands.

---

# CHANGELOG

* `hanami middlewares` -> `hanami middleware`
* `hanami generate slice --url-prefix` -> `--url` for parity with `hanami generate action`, which accepts a `--url` option
* `hanami new --skip-bundle` --> `--skip-install` to communicate that both Bundler and Hanami installation are skipped 

 
---

# Code Changes

* `Hanami::CLI::Command#initialize` superclass injects `err:` as dependency. It defaults to `$stderr`.
* `Hanami::CLI::Command::App::Console` renamed REPL to Engine to low level adapter like IRB, Pry, etc..

---

# CLI Output

## Gem commands

Outside an application

### `hanami`

```shell
⚡ hanami --help
Commands:
  hanami new APP         # Generate a new Hanami app
  hanami version         # Hanami version
```

### `hanami new`

```shell
⚡ hanami new --help
Command:
  hanami new

Usage:
  hanami new APP

Description:
  Generate a new Hanami app

Arguments:
  APP                               # REQUIRED App name

Options:
  --[no-]skip-install               # Skip app installation (Bundler, third-party Hanami plugins), default: false
  --help, -h                        # Print this help

Examples:
  hanami new bookshelf                # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace
  hanami new bookshelf --skip-install # Generate a new Hanami app, but it skips Hanami installation
```

### `hanami version`

```shell
⚡ hanami version --help
Command:
  hanami version

Usage:
  hanami version

Description:
  Hanami version

Options:
  --help, -h                        # Print this help
```

## App commands

Inside an application

### `hanami`

```shell
⚡ bundle exec hanami --help
Commands:
  hanami console                              # Start app console (REPL)
  hanami generate [SUBCOMMAND]
  hanami install                              # Install Hanami third-party plugins
  hanami middleware                           # Print app Rack middleware stack
  hanami routes                               # Print app routes
  hanami server                               # Start Hanami app server
  hanami version                              # Print Hanami app version
```

### `hanami console`

```shell
⚡ bundle exec hanami console --help
Command:
  hanami console

Usage:
  hanami console

Description:
  Start app console (REPL)

Options:
  --engine=VALUE                    # Console engine: (pry/irb)
  --help, -h                        # Print this help
```

### `hanami generate`

```shell
⚡ bundle exec hanami generate --help
Commands:
  hanami generate action NAME
  hanami generate slice NAME
```

#### `hanami generate action`

```shell
⚡ bundle exec hanami generate action --help
Command:
  hanami generate action

Usage:
  hanami generate action NAME

Arguments:
  NAME                              # REQUIRED Action name

Options:
  --url=VALUE                       # Action URL
  --http=VALUE                      # Action HTTP method
  --slice=VALUE                     # Slice name
  --help, -h                        # Print this help

Examples:
  hanami generate action books.index               # GET    /books          to: "books.index"    (MyApp::Actions::Books::Index)
  hanami generate action books.new                 # GET    /books/new      to: "books.new"      (MyApp::Actions::Books::New)
  hanami generate action books.create              # POST   /books          to: "books.create"   (MyApp::Actions::Books::Create)
  hanami generate action books.edit                # GET    /books/:id/edit to: "books.edit"     (MyApp::Actions::Books::Edit)
  hanami generate action books.update              # PATCH  /books/:id      to: "books.update"   (MyApp::Actions::Books::Update)
  hanami generate action books.show                # GET    /books/:id      to: "books.show"     (MyApp::Actions::Books::Show)
  hanami generate action books.destroy             # DELETE /books/:id      to: "books.destroy"  (MyApp::Actions::Books::Destroy)
  hanami generate action books.sale                # GET    /books/sale     to: "books.sale"     (MyApp::Actions::Books::Sale)
  hanami generate action sessions.new --url=/login # GET    /login          to: "sessions.new"   (MyApp::Actions::Sessions::New)
  hanami generate action authors.update --http=put # PUT    /authors/:id    to: "authors.update" (MyApp::Actions::Authors::Update)
  hanami generate action users.index --slice=admin # GET    /admin/users    to: "users.index"    (Admin::Actions::Users::Update)
```

#### `hanami generate slice`

```shell
⚡ bundle exec hanami generate slice --help
Command:
  hanami generate slice

Usage:
  hanami generate slice NAME

Arguments:
  NAME                              # REQUIRED The slice name

Options:
  --url=VALUE                       # The slice URL prefix
  --help, -h                        # Print this help

Examples:
  hanami generate slice admin          # Admin slice (/admin URL prefix)
  hanami generate slice users --url=/u # Users slice (/u URL prefix)
```

### `hanami install`

```shell
⚡ bundle exec hanami install --help
Command:
  hanami install

Usage:
  hanami install

Description:
  Install Hanami third-party plugins

Options:
  --help, -h                        # Print this help
```

### `hanami middleware`

```shell
⚡ bundle exec hanami middleware --help
Command:
  hanami middleware

Usage:
  hanami middleware

Description:
  Print app Rack middleware stack

Options:
  --[no-]with-arguments             # Include inspected arguments, default: false
  --help, -h                        # Print this help

Examples:
  hanami middleware middleware                  # Print app Rack middleware stack
  hanami middleware middleware --with-arguments # Print app Rack middleware stack, including initialize arguments
```

### `hanami routes`

```shell
⚡ bundle exec hanami routes --help
Command:
  hanami routes

Usage:
  hanami routes

Description:
  Print app routes

Options:
  --format=VALUE                    # Output format, default: "human_friendly"
  --help, -h                        # Print this help

Examples:
  hanami routes routes              # Print app routes
  hanami routes routes --format=csv # Print app routes, using CSV format
```

### `hanami server`

#### with `hanami-reloader`

```shell
⚡ bundle exec hanami server --help
Command:
  hanami server

Usage:
  hanami server

Description:
  Start Hanami app server

Options:
  --host=VALUE                      # The host address to bind to (falls back to the rack handler)
  --port=VALUE                      # The port to run the server on (falls back to the rack handler), default: 2300
  --config=VALUE                    # Rack configuration file, default: "config.ru"
  --[no-]debug                      # Turn on/off debug output, default: false
  --[no-]warn                       # Turn on/off warnings, default: false
  --guardfile=VALUE                 # Path to Guardfile, default: "Guardfile"
  --[no-]code-reloading             # Code reloading, default: true
  --help, -h                        # Print this help

Examples:
  hanami server --no-code-reloading # Disable code reloading
```

#### without `hanami-reloader`

```shell
⚡ bundle exec hanami server --help
Command:
  hanami server

Usage:
  hanami server

Description:
  Start Hanami app server

Options:
  --host=VALUE                      # The host address to bind to (falls back to the rack handler)
  --port=VALUE                      # The port to run the server on (falls back to the rack handler), default: 2300
  --config=VALUE                    # Rack configuration file, default: "config.ru"
  --[no-]debug                      # Turn on/off debug output, default: false
  --[no-]warn                       # Turn on/off warnings, default: false
  --help, -h                        # Print this help
```

### `hanami version`

```shell
⚡ bundle exec hanami version --help
Command:
  hanami version

Usage:
  hanami version

Description:
  Print Hanami app version

Options:
  --help, -h                        # Print this help
```

---

https://trello.com/c/YPTDiK9I