### PR TITLE
Advertise Bundler & Hanami installation while running `hanami new`

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -43,7 +43,9 @@ module Hanami
             fs.chdir(app) do
               generator.call(app) do
                 unless skip_bundle
+                  out.puts "Running Bundler install..."
                   bundler.install!
+                  out.puts "Running Hanami install..."
                   run_install_commmand!
                 end
               end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     expect(fs.directory?(app)).to be(true)
     expect(output).to include("Created #{app}/")
     expect(output).to include("-> Within #{app}/")
+    expect(output).to include("Running Bundler install..")
+    expect(output).to include("Running Hanami install..")
 
     fs.chdir(app) do
       # .env

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     expect(fs.directory?(app)).to be(true)
     expect(output).to include("Created #{app}/")
     expect(output).to include("-> Within #{app}/")
-    expect(output).to include("Running Bundler install..")
-    expect(output).to include("Running Hanami install..")
+    expect(output).to include("Running Bundler install...")
+    expect(output).to include("Running Hanami install...")
 
     fs.chdir(app) do
       # .env

--- a/spec/unit/hanami/cli/middleware_stack_inspector_spec.rb
+++ b/spec/unit/hanami/cli/middleware_stack_inspector_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Hanami::CLI::MiddlewareStackInspector do
 
   describe "#inspect" do
     it "indents from the longest path" do
-      stack.use(Proc.new {})
-      stack.with("/a/really/really/long/path") { stack.use(Proc.new {}) }
+      stack.use(proc {})
+      stack.with("/a/really/really/long/path") { stack.use(proc {}) }
 
       inspected = described_class.new(stack: stack).inspect
 
@@ -20,7 +20,7 @@ RSpec.describe Hanami::CLI::MiddlewareStackInspector do
     end
 
     it "can include inspected arguments" do
-      stack.use(Proc.new {}, "foo")
+      stack.use(proc {}, "foo")
 
       inspected = described_class.new(stack: stack).inspect(include_arguments: true)
 
@@ -31,7 +31,7 @@ RSpec.describe Hanami::CLI::MiddlewareStackInspector do
 
     context "when middleware is a class" do
       it "includes its name when it's named" do
-        stack.use(Proc.new {})
+        stack.use(proc {})
 
         expect(described_class.new(stack: stack).inspect).to include("Proc")
       end
@@ -62,13 +62,13 @@ RSpec.describe Hanami::CLI::MiddlewareStackInspector do
 
     context "when middleware is an instance" do
       it "includes its class name" do
-        stack.use(Proc.new {})
+        stack.use(proc {})
 
         expect(described_class.new(stack: stack).inspect).to include("Proc")
       end
 
       it "includes (instance)" do
-        stack.use(Proc.new {})
+        stack.use(proc {})
 
         expect(described_class.new(stack: stack).inspect).to include("(instance)")
       end


### PR DESCRIPTION
# Enhancement

Advertise Bundler & Hanami installation while running `hanami new`

```shell
⚡ hanami new bookshelf
-> Within bookshelf/
⚡ hanami new bookshelf
Created bookshelf/
-> Within bookshelf/
Created .env
Created README.md
Created Gemfile
Created Rakefile
Created config.ru
Created config/app.rb
Created config/settings.rb
Created config/routes.rb
Created config/puma.rb
Created lib/tasks/.keep
Created lib/bookshelf/types.rb
Created app/actions/.keep
Created app/action.rb
Running Bundler install...
Running Hanami install...
```

👉 The last two lines are the addition of this enhancement.

## Why?

Bundler, and potentially Hanami, installation can be time consuming.

Without advertising their execution, the user has the impression that `hanami new` is stuck at the last file creation (e.g. `Created app/action.rb`).