### PR TITLE
Remove types require from config/settings.rb

### DIFF
--- a/lib/hanami/cli/generators/gem/app/settings.erb
+++ b/lib/hanami/cli/generators/gem/app/settings.erb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "<%= underscored_app_name %>/types"
-
 module <%= camelized_app_name %>
   class Settings < Hanami::Settings
     # Define your app settings here, for example:

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -144,8 +144,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       settings = <<~EXPECTED
         # frozen_string_literal: true
 
-        require "bookshelf/types"
-
         module Bookshelf
           class Settings < Hanami::Settings
             # Define your app settings here, for example:


### PR DESCRIPTION
Given the settings class can be accessed extremely early during app boot (i.e. inside the app class body), we're avoiding any dependencies on other files within the app, and instead auto-generating a Types module nested inside the Settings class for easy access to type checking.