### PR TITLE
Use Hanami.app_path to find if we're in an app

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,8 @@ Naming/HeredocDelimiterNaming:
 Naming/MethodParameterName:
   AllowedNames:
     - fs
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Style/AccessorGrouping:
   Enabled: false
 Style/BlockDelimiters:

--- a/lib/hanami/cli/commands.rb
+++ b/lib/hanami/cli/commands.rb
@@ -12,8 +12,15 @@ module Hanami
     # @api private
     # @since 2.0.0
     def self.within_hanami_app?
-      File.exist?("config/app.rb") ||
-        File.exist?("app.rb")
+      require "hanami"
+
+      !!Hanami.app_path
+    rescue LoadError => e
+      raise e unless e.path == "hanami"
+
+      # If for any reason the hanami gem isn't installed, make a simple best effort to determine
+      # whether we're inside an app.
+      File.exist?("config/app.rb") || File.exist?("app.rb")
     end
 
     # Contains the commands available for the current `hanami` CLI execution, depending on whether


### PR DESCRIPTION
This allows the hanami CLI to expose its app commands even if invoked from a deeper app directory.

Since this may have caused an issue with the CLI properly executing in earlier testing (before our 2.0.0.beta3 release), wrap the call to `Hanami.app_path` in a rescue that will fall back to a simpler mechanism that will still work in the common cases.