### PR TITLE
Raise exception if trying to create Hanami app in existing folder (or file)

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -45,6 +45,8 @@ module Hanami
           def call(app:, skip_install: SKIP_INSTALL_DEFAULT, **)
             app = inflector.underscore(app)
 
+            raise PathAlreadyExistsError.new(app) if fs.exist?(app)
+
             fs.mkdir(app)
             fs.chdir(app) do
               generator.call(app) do

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -22,7 +22,7 @@ module Hanami
 
     class PathAlreadyExistsError < Error
       def initialize(path)
-        super("Cannot create new Hanami app in an existing file or folder: #{path}")
+        super("Cannot create new Hanami app in an existing path: `#{path}'")
       end
     end
 

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -20,6 +20,12 @@ module Hanami
       end
     end
 
+    class PathAlreadyExistsError < Error
+      def initialize(path)
+        super("Cannot create new Hanami app in an existing file or folder: #{path}")
+      end
+    end
+
     class MissingSliceError < Error
       def initialize(slice)
         super("slice `#{slice}' is missing, please generate with `hanami generate slice #{slice}'")

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -261,4 +261,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       expect(fs.read("config/app.rb")).to eq(hanami_app)
     end
   end
+
+  it "doesn't create app in existing folder" do
+    fs.mkdir("bookshelf")
+
+    expect(bundler).to_not receive(:install!)
+    expect(bundler).to_not receive(:exec)
+
+    expect { subject.call(app: app) }.to raise_error(Hanami::CLI::PathAlreadyExistsError)
+  end
 end


### PR DESCRIPTION
Closes #52 (and reported in #59 by someone who is not me)

```bash
% mkdir bookshelf # or `touch bookshelf`
% exe/hanami new bookshelf
Cannot create new Hanami app in an existing folder bookshelf/
```

This is simpler than prompting the user to decide if we should still proceed. They can decide or move folders around.