### PR TITLE
Add missing App namespace for database reference.

### DIFF
--- a/lib/hanami/cli/commands/app/command.rb
+++ b/lib/hanami/cli/commands/app/command.rb
@@ -114,7 +114,7 @@ module Hanami
           #
           # @api private
           def database
-            @database ||= Commands::DB::Utils::Database[app]
+            @database ||= Commands::App::DB::Utils::Database[app]
           end
 
           # This is NOT AVAILABLE as of the 2.0.0 release.


### PR DESCRIPTION
I know this isn't a supported Hanami 2.0.0 issue, but it does help with keeping the database CLI commands working :)