### PR TITLE
Fix 'which' for windows

### DIFF
--- a/lib/hanami/cli/bundler.rb
+++ b/lib/hanami/cli/bundler.rb
@@ -146,6 +146,8 @@ module Hanami
       # @since 2.0.0
       # @api private
       def which(cmd)
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(";") : ['']
+        
         # Adapted from https://stackoverflow.com/a/5471032/498386
         ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
           exe = fs.join(path, cmd)


### PR DESCRIPTION
which("bundler") on windows fails to find bundler because on windows the cmd has a ".bat" extension

This commit changes which(cmd) to loop throught PATHEXTS if they exist to find the correct cmd on windows.
