### PR TITLE
Fix which function for windows

### DIFF
--- a/lib/hanami/cli/bundler.rb
+++ b/lib/hanami/cli/bundler.rb
@@ -146,10 +146,13 @@ module Hanami
       # @since 2.0.0
       # @api private
       def which(cmd)
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
         # Adapted from https://stackoverflow.com/a/5471032/498386
         ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
-          exe = fs.join(path, cmd)
-          return exe if fs.executable?(exe) && !fs.directory?(exe)
+          exts.each do |ext|
+            exe = fs.join(path, "#{cmd}#{ext}")
+            return exe if fs.executable?(exe) && !fs.directory?(exe)
+          end
         end
 
         nil


### PR DESCRIPTION
Which on windows doesn't find the cmd becuase they have extensions [.bat, .cmd] .  This enables which to find cmds on windows