### PR TITLE
Fix: allow to generate deeply nested action with correct container key

### DIFF
--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -3,6 +3,7 @@
 require "dry/inflector"
 require "dry/files"
 require "shellwords"
+require_relative "../../../naming"
 require_relative "../../../errors"
 
 module Hanami
@@ -48,7 +49,9 @@ module Hanami
             # @since 2.0.0
             # @api private
             def initialize(fs: Hanami::CLI::Files.new, inflector: Dry::Inflector.new,
+                           naming: Naming.new(inflector: inflector),
                            generator: Generators::App::Action.new(fs: fs, inflector: inflector), **)
+              @naming = naming
               @generator = generator
               super(fs: fs)
             end
@@ -59,7 +62,7 @@ module Hanami
             # @api private
             def call(name:, url: nil, http: nil, format: DEFAULT_FORMAT, skip_view: DEFAULT_SKIP_VIEW, slice: nil, **)
               slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
-              name = inflector.underscore(Shellwords.shellescape(name))
+              name = naming.action_name(name)
               *controller, action = name.split(ACTION_SEPARATOR)
 
               if controller.empty?
@@ -73,7 +76,7 @@ module Hanami
 
             private
 
-            attr_reader :generator
+            attr_reader :naming, :generator
           end
         end
       end

--- a/lib/hanami/cli/naming.rb
+++ b/lib/hanami/cli/naming.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+module Hanami
+  module CLI
+    class Naming
+      def initialize(inflector:)
+        @inflector = inflector
+      end
+
+      def action_name(name)
+        inflector.underscore(escape(name)).gsub("/", ".")
+      end
+
+      private
+
+      attr_reader :inflector
+
+      def escape(name)
+        Shellwords.shellescape(name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/hanami/cli/issues/69

---

This is the bare minimum code to fix the issue.
I'm already working locally to refactor to expand the usage of `Hanami::CLI::Naming` in the entire codebase.