### PR TITLE
Fix rollback command

### DIFF
--- a/lib/hanami/cli/commands/app/db/rollback.rb
+++ b/lib/hanami/cli/commands/app/db/rollback.rb
@@ -32,6 +32,8 @@ module Hanami
 
               measure "database #{database.name} rolled back to #{migration_name}" do
                 database.run_migrations(target: Integer(migration_code))
+
+                true
               end
 
               run_command Structure::Dump if dump

--- a/lib/hanami/cli/commands/app/db/rollback.rb
+++ b/lib/hanami/cli/commands/app/db/rollback.rb
@@ -20,7 +20,13 @@ module Hanami
               migration_code, migration_name = find_migration(target)
 
               if migration_name.nil?
-                out.puts "==> migration file for target #{target} was not found"
+                output = if target
+                  "==> migration file for target #{target} was not found"
+                else
+                  "==> no migrations to rollback"
+                end
+
+                out.puts output
                 return
               end
 
@@ -34,13 +40,29 @@ module Hanami
             private
 
             def find_migration(code)
-              migration = database.applied_migrations.then { |migrations|
+              applied_migrations = database.applied_migrations
+
+              return if applied_migrations.empty?
+
+              # Rollback to initial state if we have only one migration and
+              # no target is specified. In this case the rollback target
+              # will be the current migration timestamp minus 1
+              if applied_migrations.one? && code.nil?
+                migration = applied_migrations.first
+
+                migration_code = Integer(migration.split("_").first) - 1
+                migration_name = "initial state"
+
+                return [migration_code, migration_name]
+              end
+
+              # Otherwise rollback to target or to previous migration
+              migration =
                 if code
-                  migrations.detect { |m| m.split("_").first == code }
+                  applied_migrations.detect { |m| m.split("_").first == code }
                 else
-                  migrations.last
+                  applied_migrations[-2]
                 end
-              }
 
               return unless migration
 

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -139,7 +139,11 @@ module Hanami
                 @sequel_migrator ||= begin
                   require "sequel"
                   Sequel.extension :migration
-                  Sequel::TimestampMigrator.new(migrator.connection, migrations_path, {})
+
+                  require "rom/sql"
+                  ROM::SQL.with_gateway(gateway) do
+                    Sequel::TimestampMigrator.new(migrator.connection, migrations_path, {})
+                  end
                 end
               end
 

--- a/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
@@ -1,26 +1,78 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app, :command, :db do
-  it "rolls back to specified migration" do
-    expect(database).to receive(:applied_migrations).and_return(["312_create_users"])
+  context "given no target is specified" do
+    context "there a no previous migrations" do
+      it "rolls back to one before the current migration" do
+        expect(database).to receive(:applied_migrations).and_return([])
+        expect(database).to_not receive(:run_migrations)
 
-    if RUBY_VERSION > "3.2"
-      expect(database).to receive(:run_migrations).with({target: 312}).and_return(true)
-    else
-      expect(database).to receive(:run_migrations).with(target: 312).and_return(true)
+        command.call(dump: false)
+
+        expect(output).to include("no migrations to rollback")
+      end
     end
 
-    command.call(target: "312", dump: false)
+    context "there is one previous migration" do
+      it "rolls back to the initial state" do
+        expect(database).to receive(:applied_migrations).and_return(["312_create_users"])
 
-    expect(output).to include("database test rolled back to 312_create_users")
+        if RUBY_VERSION > "3.2"
+          expect(database).to receive(:run_migrations).with({target: 311}).and_return(true)
+        else
+          expect(database).to receive(:run_migrations).with(target: 311).and_return(true)
+        end
+
+        command.call(dump: false)
+
+        expect(output).to include("database test rolled back to initial state")
+      end
+    end
+
+    context "there are multiple previous migrations" do
+      it "rolls back to one before the current migration" do
+        expect(database).to receive(:applied_migrations).and_return(
+          [
+            "312_create_users",
+            "313_create_books",
+          ]
+        )
+
+        if RUBY_VERSION > "3.2"
+          expect(database).to receive(:run_migrations).with({target: 312}).and_return(true)
+        else
+          expect(database).to receive(:run_migrations).with(target: 312).and_return(true)
+        end
+
+        command.call(dump: false)
+
+        expect(output).to include("database test rolled back to 312_create_users")
+      end
+    end
   end
 
-  it "warns if target migration is not found" do
-    expect(database).to receive(:applied_migrations).and_return([])
-    expect(database).to_not receive(:run_migrations)
+  context "given a target is specified" do
+    it "rolls back to specified migration" do
+      expect(database).to receive(:applied_migrations).and_return(["312_create_users"])
 
-    command.call(target: "312", dump: false)
+      if RUBY_VERSION > "3.2"
+        expect(database).to receive(:run_migrations).with({target: 312}).and_return(true)
+      else
+        expect(database).to receive(:run_migrations).with(target: 312).and_return(true)
+      end
 
-    expect(output).to include("migration file for target 312 was not found")
+      command.call(target: "312", dump: false)
+
+      expect(output).to include("database test rolled back to 312_create_users")
+    end
+
+    it "warns if target migration is not found" do
+      expect(database).to receive(:applied_migrations).and_return([])
+      expect(database).to_not receive(:run_migrations)
+
+      command.call(target: "312", dump: false)
+
+      expect(output).to include("migration file for target 312 was not found")
+    end
   end
 end


### PR DESCRIPTION
## Purpose

Fix rollback command as its currently not working correctly.

## Context

* The current implementation of rollback is passing the incorrect target to the `database` class. It's passing the target version of the latest migration instead of the previous one. This is resulting in no rollback occurring. 
* Another issue is that the block being passed to `measure` does not return true if successful, resulting in a failure message displaying all the time, even on successful rollbacks.

## Change

* Make the rollback command a bit smarter by allowing it to figure out correctly what the applied migrations are and what the intention is based on if a target is provided or not.
* Pass the `latest_migration - 1` in to ensure the rollback target is one prior to the latest applied migration
* Wrap ` Sequel::TimestampMigrator.new(migrator.connection, migrations_path, {})` in `ROM::SQL.with_gateway(gateway)` to prevent reoccurring error