### PR TITLE
Update psql drop_command to force dropdb

### DIFF
--- a/lib/hanami/cli/commands/app/db/drop.rb
+++ b/lib/hanami/cli/commands/app/db/drop.rb
@@ -13,7 +13,7 @@ module Hanami
 
             # @api private
             def call(force: false)
-              if database.drop_command(force)
+              if database.drop_command(force:)
                 out.puts "=> database #{database.name} dropped"
               else
                 out.puts "=> failed to drop #{database.name}"

--- a/lib/hanami/cli/commands/app/db/drop.rb
+++ b/lib/hanami/cli/commands/app/db/drop.rb
@@ -12,8 +12,8 @@ module Hanami
             desc "Delete database"
 
             # @api private
-            def call(**)
-              if database.drop_command
+            def call(force: false)
+              if database.drop_command(force)
                 out.puts "=> database #{database.name} dropped"
               else
                 out.puts "=> failed to drop #{database.name}"

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -68,7 +68,7 @@ module Hanami
               end
 
               # @api private
-              def drop_command
+              def drop_command(force: false)
                 raise Hanami::CLI::NotImplementedError
               end
 

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -23,7 +23,7 @@ module Hanami
 
               # @api private
               def drop_command
-                system(cli_env_vars, "dropdb #{escaped_name}")
+                system(cli_env_vars, "dropdb --force #{escaped_name}")
               end
 
               # @api private

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -22,8 +22,10 @@ module Hanami
               end
 
               # @api private
-              def drop_command
-                system(cli_env_vars, "dropdb --force #{escaped_name}")
+              def drop_command(force: false)
+                command = force ? "dropdb --force" : "dropdb"
+
+                system(cli_env_vars, "#{command} #{escaped_name}")
               end
 
               # @api private

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -17,7 +17,7 @@ module Hanami
               end
 
               # @api private
-              def drop_command
+              def drop_command(**)
                 file_path.unlink
                 true
               end


### PR DESCRIPTION
**Context:**

The reason behind it is to improve developer experience, as right now when running a command like `hanami db reset` it will fail if the user has any other ongoing connection, like a connection to db client(like dbeaver), or a `hanami console` session.

![image](https://user-images.githubusercontent.com/10784051/229680065-fbd05716-2d47-4f35-8cf8-7c58203d720e.png)


Couple other possible approaches are:

```ruby
              # create a dedicated method for force drop
              def force_drop_command
                system(cli_env_vars, "dropdb --force #{escaped_name}")
              end
```
```ruby
              # force as an option/param
              def drop_command(force=false)
              command_prefix =  force ? "dropdb --force" : "dropdb"
              
                system(cli_env_vars, "#{command_prefix} #{escaped_name}")
              end
```

**Reference:** 
https://www.postgresql.org/docs/current/sql-dropdatabase.html#id-1.9.3.108.6