### PR TITLE
View generators

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -22,6 +22,7 @@ module Hanami
             register "generate", aliases: ["g"] do |prefix|
               prefix.register "slice", Generate::Slice
               prefix.register "action", Generate::Action
+              prefix.register "view", Generate::View
             end
           end
         end

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -26,8 +26,8 @@ module Hanami
             option :url, required: false, type: :string, desc: "Action URL"
             option :http, required: false, type: :string, desc: "Action HTTP method"
             # option :format, required: false, type: :string, default: DEFAULT_FORMAT, desc: "Template format"
-            # option :skip_view, required: false, type: :boolean, default: DEFAULT_SKIP_VIEW,
-            #                    desc: "Skip view and template generation"
+            option :skip_view, required: false, type: :boolean, default: DEFAULT_SKIP_VIEW,
+                               desc: "Skip view and template generation"
             option :slice, required: false, desc: "Slice name"
 
             # rubocop:disable Layout/LineLength

--- a/lib/hanami/cli/commands/app/generate/view.rb
+++ b/lib/hanami/cli/commands/app/generate/view.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "dry/inflector"
+require "dry/files"
+require "shellwords"
+require_relative "../../../naming"
+require_relative "../../../errors"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Generate
+          # @since 2.0.0
+          # @api private
+          class View < App::Command
+            # TODO: make this configurable
+            DEFAULT_FORMAT = "html"
+            private_constant :DEFAULT_FORMAT
+
+            # TODO: make engine configurable
+
+            argument :name, required: true, desc: "View name"
+            option :slice, required: false, desc: "Slice name"
+
+            # rubocop:disable Layout/LineLength
+            example [
+              %(books.index               (MyApp::Actions::Books::Index)),
+              %(books.index --slice=admin (Admin::Actions::Books::Index)),
+            ]
+            # rubocop:enable Layout/LineLength
+
+            attr_reader :generator
+            private :generator
+
+            # @since 2.0.0
+            # @api private
+            def initialize(
+              fs: Hanami::CLI::Files.new,
+              inflector: Dry::Inflector.new,
+              generator: Generators::App::View.new(fs: fs, inflector: inflector),
+              **
+            )
+              @generator = generator
+              super(fs: fs)
+            end
+
+            # rubocop:disable Metrics/ParameterLists
+
+            # @since 2.0.0
+            # @api private
+            def call(name:, format: DEFAULT_FORMAT, slice: nil, **)
+              slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
+
+              generator.call(app.namespace, name, format, slice)
+            end
+
+            # rubocop:enable Metrics/ParameterLists
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/action/slice_template.html.erb
+++ b/lib/hanami/cli/generators/app/action/slice_template.html.erb
@@ -1,0 +1,1 @@
+<h1><%= camelized_slice_name %>::Views::<%= camelized_controller_name %>::<%= camelized_action_name %></h1>

--- a/lib/hanami/cli/generators/app/action/slice_view.erb
+++ b/lib/hanami/cli/generators/app/action/slice_view.erb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module <%= camelized_app_name %>
+module <%= camelized_slice_name %>
   module Views
 <%= module_controller_declaration %>
-<%= module_controller_offset %>class <%= camelized_action_name %> < <%= camelized_app_name %>::View
+<%= module_controller_offset %>class <%= camelized_action_name %> < <%= camelized_slice_name %>::View
 <%= module_controller_offset %>end
 <%= module_controller_end %>
   end

--- a/lib/hanami/cli/generators/app/action/template.html.erb
+++ b/lib/hanami/cli/generators/app/action/template.html.erb
@@ -1,2 +1,1 @@
-<h1><%= camelized_slice_name %>::Views::<%= camelized_controller_name %>::<%= camelized_action_name %></h1>
-<h2><%= template_path %></h2>
+<h1><%= camelized_app_name %>::Views::<%= camelized_controller_name %>::<%= camelized_action_name %></h1>

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -28,14 +28,14 @@ module Hanami
 
             # fs.write("#{directory}/config/slice.rb", t("slice.erb", context))
             fs.write(fs.join(directory, "action.rb"), t("action.erb", context))
-            # fs.write(fs.join(directory, "/view.rb"), t("view.erb", context))
+            fs.write(fs.join(directory, "/view.rb"), t("view.erb", context))
             # fs.write(fs.join(directory, "/entities.rb"), t("entities.erb", context))
             # fs.write(fs.join(directory, "/repository.rb"), t("repository.erb", context))
 
             fs.write(fs.join(directory, "actions/.keep"), t("keep.erb", context))
-            # fs.write(fs.join(directory, views/.keep"), t("keep.erb", context))
-            # fs.write(fs.join(directory, templates/.keep"), t("keep.erb", context))
-            # fs.write(fs.join(directory, templates/layouts/.keep"), t("keep.erb", context))
+            fs.write(fs.join(directory, "views/.keep"), t("keep.erb", context))
+            fs.write(fs.join(directory, "templates/.keep"), t("keep.erb", context))
+            fs.write(fs.join(directory, "templates/layouts/.keep"), t("keep.erb", context))
             # fs.write(fs.join(directory, entities/.keep"), t("keep.erb", context))
             # fs.write(fs.join(directory, repositories/.keep"), t("keep.erb", context))
           end

--- a/lib/hanami/cli/generators/app/slice/view.erb
+++ b/lib/hanami/cli/generators/app/slice/view.erb
@@ -1,8 +1,6 @@
 # auto_register: false
 # frozen_string_literal: true
 
-require "<%= underscored_app_name %>/view"
-
 module <%= camelized_slice_name %>
   class View < <%= camelized_app_name %>::View
   end

--- a/lib/hanami/cli/generators/app/view.rb
+++ b/lib/hanami/cli/generators/app/view.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "erb"
+require "dry/files"
+require_relative "../../errors"
+
+# rubocop:disable Metrics/ParameterLists
+module Hanami
+  module CLI
+    module Generators
+      module App
+        # @since 2.0.0
+        # @api private
+        class View
+          # @since 2.0.0
+          # @api private
+          def initialize(fs:, inflector:)
+            @fs = fs
+            @inflector = inflector
+          end
+
+          # rubocop:disable Layout/LineLength
+
+          # @since 2.0.0
+          # @api private
+          def call(app, key, format, slice)
+            context = ViewContext.new(inflector, app, slice, key)
+
+            if slice
+              generate_for_slice(context, format, slice)
+            else
+              generate_for_app(context, format, slice)
+            end
+          end
+
+          # rubocop:enable Layout/LineLength
+
+          private
+
+          attr_reader :fs
+
+          attr_reader :inflector
+
+          # rubocop:disable Metrics/AbcSize
+
+          def generate_for_slice(context, format, slice)
+            slice_directory = fs.join("slices", slice)
+            raise MissingSliceError.new(slice) unless fs.directory?(slice_directory)
+
+            fs.mkdir(directory = fs.join(slice_directory, "views", context.namespaces))
+            fs.write(fs.join(directory, "#{context.name}.rb"), t("slice_view.erb", context))
+
+            fs.mkdir(directory = fs.join(slice_directory, "templates", context.namespaces))
+            fs.write(fs.join(directory, "#{context.name}.#{format}.erb"), t(template_with_format_ext("slice_template", format), context))
+          end
+
+          def generate_for_app(context, format, slice)
+            fs.mkdir(directory = fs.join("app", "views", context.namespaces))
+            fs.write(fs.join(directory, "#{context.name}.rb"), t("app_view.erb", context))
+
+            fs.mkdir(directory = fs.join("app", "templates", context.namespaces))
+            fs.write(fs.join(directory, "#{context.name}.#{format}.erb"), t(template_with_format_ext("app_template", format), context))
+          end
+
+          # rubocop:enable Metrics/AbcSize
+
+          def template_with_format_ext(name, format)
+            ext =
+              case format.to_sym
+              when :html
+                ".html.erb"
+              else
+                ".erb"
+              end
+
+            "#{name}#{ext}"
+          end
+
+          def template(path, context)
+            require "erb"
+
+            ERB.new(
+              File.read(__dir__ + "/view/#{path}")
+            ).result(context.ctx)
+          end
+
+          alias_method :t, :template
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/ParameterLists

--- a/lib/hanami/cli/generators/app/view/app_template.html.erb
+++ b/lib/hanami/cli/generators/app/view/app_template.html.erb
@@ -1,0 +1,1 @@
+<h1><%= camelized_app_name %>::Views::<%= camelized_namespace %>::<%= camelized_name %></h1>

--- a/lib/hanami/cli/generators/app/view/app_view.erb
+++ b/lib/hanami/cli/generators/app/view/app_view.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module <%= camelized_app_name %>
+  module Views
+<%= module_namespace_declaration %>
+<%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_app_name %>::View
+<%= module_namespace_offset %>end
+<%= module_namespace_end %>
+  end
+end

--- a/lib/hanami/cli/generators/app/view/slice_template.html.erb
+++ b/lib/hanami/cli/generators/app/view/slice_template.html.erb
@@ -1,0 +1,1 @@
+<h1><%= camelized_slice_name %>::Views::<%= camelized_namespace %>::<%= camelized_name %></h1>

--- a/lib/hanami/cli/generators/app/view/slice_view.erb
+++ b/lib/hanami/cli/generators/app/view/slice_view.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module <%= camelized_slice_name %>
+  module Views
+<%= module_namespace_declaration %>
+<%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_slice_name %>::View
+<%= module_namespace_offset %>end
+<%= module_namespace_end %>
+  end
+end

--- a/lib/hanami/cli/generators/app/view_context.rb
+++ b/lib/hanami/cli/generators/app/view_context.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative "./slice_context"
+require "dry/files/path"
+
+module Hanami
+  module CLI
+    module Generators
+      # @since 2.1.0
+      # @api private
+      module App
+        # @since 2.1.0
+        # @api private
+        class ViewContext < SliceContext
+          # TODO: move these constants somewhere that will let us reuse them
+          KEY_SEPARATOR = "."
+          private_constant :KEY_SEPARATOR
+
+          NAMESPACE_SEPARATOR = "::"
+          private_constant :NAMESPACE_SEPARATOR
+
+          INDENTATION = "  "
+          private_constant :INDENTATION
+
+          OFFSET = INDENTATION * 2
+          private_constant :OFFSET
+
+          # @since 2.1.0
+          # @api private
+          attr_reader :key
+
+          # @since 2.1.0
+          # @api private
+          def initialize(inflector, app, slice, key)
+            @key = key
+            super(inflector, app, slice, nil)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def namespaces
+            @namespaces ||= key.split(KEY_SEPARATOR)[..-2]
+          end
+
+          # @since 2.1.0
+          # @api private
+          def name
+            @name ||= key.split(KEY_SEPARATOR)[-1]
+          end
+
+          # @since 2.1.0
+          # @api private
+          def camelized_namespace
+            namespaces.map { inflector.camelize(_1) }.join(NAMESPACE_SEPARATOR)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def camelized_name
+            inflector.camelize(name)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def underscored_namespace
+            namespaces.map { inflector.underscore(_1) }
+          end
+
+          # @since 2.1.0
+          # @api private
+          def underscored_name
+            inflector.underscore(name)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def module_namespace_declaration
+            namespaces.each_with_index.map { |token, i|
+              "#{OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
+            }.join($/)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def module_namespace_end
+            namespaces.each_with_index.map { |_, i|
+              "#{OFFSET}#{INDENTATION * i}end"
+            }.reverse.join($/)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def module_namespace_offset
+            "#{OFFSET}#{INDENTATION * namespaces.count}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -52,6 +52,7 @@ module Hanami
 
             fs.write("app/actions/.keep", t("keep.erb", context))
             fs.write("app/action.rb", t("action.erb", context))
+            fs.write("app/view.rb", t("view.erb", context))
           end
 
           def template(path, context)

--- a/lib/hanami/cli/generators/gem/app/view.erb
+++ b/lib/hanami/cli/generators/gem/app/view.erb
@@ -1,0 +1,9 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "hanami/view"
+
+module <%= camelized_app_name %>
+  class View < Hanami::View
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         expect(fs.read("config/routes.rb")).to eq(routes)
         expect(output).to include("Updated config/routes.rb")
 
+        # action
         action_file = <<~EXPECTED
           # frozen_string_literal: true
 
@@ -62,34 +63,32 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         expect(fs.read("app/actions/#{controller}/#{action}.rb")).to eq(action_file)
         expect(output).to include("Created app/actions/#{controller}/#{action}.rb")
 
-        # # view
-        # view_file = <<~EXPECTED
-        #   # auto_register: false
-        #   # frozen_string_literal: true
-        #
-        #   require "#{inflector.underscore(slice)}/view"
-        #
-        #   module #{inflector.camelize(slice)}
-        #     module Views
-        #       module #{inflector.camelize(controller)}
-        #         class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
-        #         end
-        #       end
-        #     end
-        #   end
-        # EXPECTED
-        # expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
-        # expect(output).to include("Created slices/#{slice}/views/#{controller}/#{action}.rb")
+        # view
+        view_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module #{inflector.camelize(app)}
+            module Views
+              module #{inflector.camelize(controller)}
+                class #{inflector.camelize(action)} < #{inflector.camelize(app)}::View
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/views/#{controller}/#{action}.rb")).to eq(view_file)
+        expect(output).to include("Created app/views/#{controller}/#{action}.rb")
 
         # template
-        # expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
-        #
-        # template_file = <<~EXPECTED
-        #   <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
-        #   <h2>slices/#{slice}/templates/#{controller}/#{action}.html.erb</h2>
-        # EXPECTED
-        # expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-        # expect(output).to include("Created slices/#{slice}/views/#{controller}/#{action}.rb")
+        expect(fs.directory?("app/templates/#{controller}")).to be(true)
+
+        template_file = <<~EXPECTED
+          <h1>#{inflector.camelize(app)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
+        EXPECTED
+
+        expect(fs.read("app/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
+        expect(output).to include("Created app/views/#{controller}/#{action}.rb")
       end
     end
 
@@ -213,7 +212,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       end
     end
 
-    xit "can skip view creation" do
+    it "can skip view creation" do
       within_application_directory do
         subject.call(name: action_name, skip_view: true)
 
@@ -373,38 +372,34 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           EXPECTED
           expect(fs.read("slices/#{slice}/actions/books/bestsellers/nonfiction/#{action}.rb")).to eq(action_file)
 
-          # # view
-          # expect(fs.directory?("slices/#{slice}/views/books/bestsellers/nonfiction")).to be(true)
-          #
-          # view_file = <<~EXPECTED
-          #   # auto_register: false
-          #   # frozen_string_literal: true
-          #
-          #   require "#{inflector.underscore(slice)}/view"
-          #
-          #   module #{inflector.camelize(slice)}
-          #     module Views
-          #       module Books
-          #         module Bestsellers
-          #           module Nonfiction
-          #             class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
-          #             end
-          #           end
-          #         end
-          #       end
-          #     end
-          #   end
-          # EXPECTED
-          # expect(fs.read("slices/#{slice}/views/books/bestsellers/nonfiction/#{action}.rb")).to eq(view_file)
+          # view
+          expect(fs.directory?("slices/#{slice}/views/books/bestsellers/nonfiction")).to be(true)
 
-          # # template
-          # expect(fs.directory?("slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
-          #
-          # template_file = <<~EXPECTED
-          #   <h1>#{inflector.camelize(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
-          #   <h2>slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb</h2>
-          # EXPECTED
-          # expect(fs.read("slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb")).to eq(template_file)
+          view_file = <<~EXPECTED
+            # frozen_string_literal: true
+
+            module #{inflector.camelize(slice)}
+              module Views
+                module Books
+                  module Bestsellers
+                    module Nonfiction
+                      class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          EXPECTED
+          expect(fs.read("slices/#{slice}/views/books/bestsellers/nonfiction/#{action}.rb")).to eq(view_file)
+
+          # template
+          expect(fs.directory?("slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
+
+          template_file = <<~EXPECTED
+            <h1>#{inflector.camelize(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
+          EXPECTED
+          expect(fs.read("slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb")).to eq(template_file)
         end
       end
     end

--- a/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "ostruct"
+
+RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
+  subject { described_class.new(fs: fs, inflector: inflector, generator: generator) }
+
+  let(:out) { StringIO.new }
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+  let(:inflector) { Dry::Inflector.new }
+  let(:generator) { Hanami::CLI::Generators::App::View.new(fs: fs, inflector: inflector) }
+  let(:app) { Hanami.app.namespace }
+  let(:dir) { inflector.underscore(app) }
+
+  def output
+    out.rewind && out.read.chomp
+  end
+
+  # it "raises error if action name doesn't respect the convention" do
+  #   expect {
+  #     subject.call(name: "foo")
+  #   }.to raise_error(Hanami::CLI::InvalidActionNameError, "cannot parse controller and action name: `foo'\n\texample: `hanami generate action users.show'")
+  # end
+
+  context "generating for app" do
+    it "generates a view in a top-level namespace" do
+      within_application_directory do
+        subject.call(name: "users.index")
+
+        # view
+        view_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Views
+              module Users
+                class Index < Test::View
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/views/users/index.rb")).to eq(view_file)
+        expect(output).to include("Created app/views/users/index.rb")
+
+        # template
+        expect(fs.directory?("app/templates/users")).to be(true)
+
+        template_file = <<~EXPECTED
+          <h1>Test::Views::Users::Index</h1>
+        EXPECTED
+
+        expect(fs.read("app/templates/users/index.html.erb")).to eq(template_file)
+        expect(output).to include("Created app/views/users/index.rb")
+      end
+    end
+
+    it "generates a view in a deeper namespace" do
+      within_application_directory do
+        subject.call(name: "special.users.index")
+
+        # view
+        view_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Views
+              module Special
+                module Users
+                  class Index < Test::View
+                  end
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/views/special/users/index.rb")).to eq(view_file)
+        expect(output).to include("Created app/views/special/users/index.rb")
+
+        # template
+        expect(fs.directory?("app/templates/special/users")).to be(true)
+
+        template_file = <<~EXPECTED
+          <h1>Test::Views::Special::Users::Index</h1>
+        EXPECTED
+
+        expect(fs.read("app/templates/special/users/index.html.erb")).to eq(template_file)
+        expect(output).to include("Created app/views/special/users/index.rb")
+      end
+    end
+  end
+
+  context "generating for a slice" do
+    it "generates a view in a top-level namespace" do
+      within_application_directory do
+        fs.mkdir("slices/main")
+        subject.call(name: "users.index", slice: "main")
+
+        # view
+        view_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Main
+            module Views
+              module Users
+                class Index < Main::View
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("slices/main/views/users/index.rb")).to eq(view_file)
+        expect(output).to include("Created slices/main/views/users/index.rb")
+
+        # template
+        expect(fs.directory?("slices/main/templates/users")).to be(true)
+
+        template_file = <<~EXPECTED
+          <h1>Main::Views::Users::Index</h1>
+        EXPECTED
+
+        expect(fs.read("slices/main/templates/users/index.html.erb")).to eq(template_file)
+        expect(output).to include("Created slices/main/views/users/index.rb")
+      end
+    end
+  end
+
+  private
+
+  def within_application_directory
+    fs.mkdir(dir)
+    fs.chdir(dir) do
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            root { "Hello from Hanami" }
+          end
+        end
+      CODE
+
+      fs.write("config/routes.rb", routes)
+
+      yield
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -217,6 +217,21 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       expect(fs.read("app/action.rb")).to eq(action)
       expect(output).to include("Created app/action.rb")
 
+      # app/view.rb
+      view = <<~RUBY
+        # auto_register: false
+        # frozen_string_literal: true
+
+        require "hanami/view"
+
+        module #{inflector.camelize(app)}
+          class View < Hanami::View
+          end
+        end
+      RUBY
+      expect(fs.read("app/view.rb")).to eq(view)
+      expect(output).to include("Created app/view.rb")
+
       # lib/bookshelf/types.rb
       types = <<~EXPECTED
         # frozen_string_literal: true


### PR DESCRIPTION
Add support for generating views:

- When generating a new app, via `hanami new`
- When generating an action, via `hanami generate action`
- Independently, via `hanami generate view`