### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/cli"
 

--- a/exe/hanami
+++ b/exe/hanami
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami/cli"
 

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "lib/hanami/cli/version"
 
 Gem::Specification.new do |spec|

--- a/lib/hanami-cli.rb
+++ b/lib/hanami-cli.rb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 require_relative "hanami/cli"

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/cli"
 require "zeitwerk"
 

--- a/lib/hanami/cli/bundler.rb
+++ b/lib/hanami/cli/bundler.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "bundler"
 require "open3"
 require "etc"

--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/cli"
 require "dry/files"
 require "dry/inflector"

--- a/lib/hanami/cli/commands.rb
+++ b/lib/hanami/cli/commands.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     # Returns true if the CLI is being called from inside an Hanami app.

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     module Commands

--- a/lib/hanami/cli/commands/app/command.rb
+++ b/lib/hanami/cli/commands/app/command.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/files"
 require "hanami/env"
 require_relative "db/utils/database"

--- a/lib/hanami/cli/commands/app/console.rb
+++ b/lib/hanami/cli/commands/app/console.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/console/context"
 
 require_relative "../app/command"

--- a/lib/hanami/cli/commands/app/db/create.rb
+++ b/lib/hanami/cli/commands/app/db/create.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/db/create_migration.rb
+++ b/lib/hanami/cli/commands/app/db/create_migration.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 require_relative "structure/dump"
 

--- a/lib/hanami/cli/commands/app/db/drop.rb
+++ b/lib/hanami/cli/commands/app/db/drop.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 require_relative "structure/dump"
 

--- a/lib/hanami/cli/commands/app/db/reset.rb
+++ b/lib/hanami/cli/commands/app/db/reset.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 require_relative "create"
 require_relative "drop"

--- a/lib/hanami/cli/commands/app/db/rollback.rb
+++ b/lib/hanami/cli/commands/app/db/rollback.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 require_relative "structure/dump"
 

--- a/lib/hanami/cli/commands/app/db/sample_data.rb
+++ b/lib/hanami/cli/commands/app/db/sample_data.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 require_relative "structure/dump"
 

--- a/lib/hanami/cli/commands/app/db/seed.rb
+++ b/lib/hanami/cli/commands/app/db/seed.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 require_relative "structure/dump"
 

--- a/lib/hanami/cli/commands/app/db/setup.rb
+++ b/lib/hanami/cli/commands/app/db/setup.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 require_relative "create"
 require_relative "migrate"

--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../../app/command"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "database_config"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/db/utils/database_config.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database_config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "uri"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "database"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "shellwords"
 require "open3"
 require_relative "database"

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "database"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/db/version.rb
+++ b/lib/hanami/cli/commands/app/db/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../../app/command"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/generate.rb
+++ b/lib/hanami/cli/commands/app/generate.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     module Commands

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/inflector"
 require "dry/files"
 require "shellwords"

--- a/lib/hanami/cli/commands/app/generate/slice.rb
+++ b/lib/hanami/cli/commands/app/generate/slice.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/inflector"
 require "dry/files"
 require "shellwords"

--- a/lib/hanami/cli/commands/app/install.rb
+++ b/lib/hanami/cli/commands/app/install.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     module Commands

--- a/lib/hanami/cli/commands/app/middleware.rb
+++ b/lib/hanami/cli/commands/app/middleware.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/routes.rb
+++ b/lib/hanami/cli/commands/app/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 module Hanami

--- a/lib/hanami/cli/commands/app/server.rb
+++ b/lib/hanami/cli/commands/app/server.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack"
 require "hanami/port"
 require_relative "../app"

--- a/lib/hanami/cli/commands/app/version.rb
+++ b/lib/hanami/cli/commands/app/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     module Commands

--- a/lib/hanami/cli/commands/gem.rb
+++ b/lib/hanami/cli/commands/gem.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     module Commands

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/inflector"
 require_relative "../../errors"
 

--- a/lib/hanami/cli/commands/gem/version.rb
+++ b/lib/hanami/cli/commands/gem/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     module Commands

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     class Error < StandardError

--- a/lib/hanami/cli/files.rb
+++ b/lib/hanami/cli/files.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     # @since 2.0.0

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "erb"
 require "dry/files"
 require_relative "../../errors"

--- a/lib/hanami/cli/generators/app/action/action.erb
+++ b/lib/hanami/cli/generators/app/action/action.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module <%= camelized_app_name %>
   module Actions
 <%= module_controller_declaration %>

--- a/lib/hanami/cli/generators/app/action/slice_action.erb
+++ b/lib/hanami/cli/generators/app/action/slice_action.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module <%= camelized_slice_name %>
   module Actions
 <%= module_controller_declaration %>

--- a/lib/hanami/cli/generators/app/action/view.erb
+++ b/lib/hanami/cli/generators/app/action/view.erb
@@ -1,6 +1,4 @@
 # auto_register: false
-# frozen_string_literal: true
-
 require "<%= underscored_slice_name %>/view"
 
 module <%= camelized_slice_name %>

--- a/lib/hanami/cli/generators/app/action_context.rb
+++ b/lib/hanami/cli/generators/app/action_context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "./slice_context"
 require "dry/files/path"
 

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "erb"
 require "dry/files"
 

--- a/lib/hanami/cli/generators/app/slice/action.erb
+++ b/lib/hanami/cli/generators/app/slice/action.erb
@@ -1,6 +1,4 @@
 # auto_register: false
-# frozen_string_literal: true
-
 module <%= camelized_slice_name %>
   class Action < <%= camelized_app_name %>::Action
   end

--- a/lib/hanami/cli/generators/app/slice/entities.erb
+++ b/lib/hanami/cli/generators/app/slice/entities.erb
@@ -1,6 +1,4 @@
 # auto_register: false
-# frozen_string_literal: true
-
 module <%= camelized_slice_name %>
   module Entities
   end

--- a/lib/hanami/cli/generators/app/slice/repository.erb
+++ b/lib/hanami/cli/generators/app/slice/repository.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "<%= underscored_app_name %>/repository"
 require_relative "entities"
 

--- a/lib/hanami/cli/generators/app/slice/slice.erb
+++ b/lib/hanami/cli/generators/app/slice/slice.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module <%= camelized_slice_name %>
   class Slice < Hanami::Slice
   end

--- a/lib/hanami/cli/generators/app/slice/view.erb
+++ b/lib/hanami/cli/generators/app/slice/view.erb
@@ -1,6 +1,4 @@
 # auto_register: false
-# frozen_string_literal: true
-
 require "<%= underscored_app_name %>/view"
 
 module <%= camelized_slice_name %>

--- a/lib/hanami/cli/generators/app/slice_context.rb
+++ b/lib/hanami/cli/generators/app/slice_context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "../context"
 
 module Hanami

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "./version"
 
 module Hanami

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "erb"
 require "shellwords"
 

--- a/lib/hanami/cli/generators/gem/app/action.erb
+++ b/lib/hanami/cli/generators/gem/app/action.erb
@@ -1,6 +1,4 @@
 # auto_register: false
-# frozen_string_literal: true
-
 require "hanami/action"
 
 module <%= camelized_app_name %>

--- a/lib/hanami/cli/generators/gem/app/app.erb
+++ b/lib/hanami/cli/generators/gem/app/app.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 module <%= camelized_app_name %>

--- a/lib/hanami/cli/generators/gem/app/config_ru.erb
+++ b/lib/hanami/cli/generators/gem/app/config_ru.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/boot"
 
 run Hanami.app

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 
 gem "hanami", "<%= hanami_version %>"

--- a/lib/hanami/cli/generators/gem/app/puma.erb
+++ b/lib/hanami/cli/generators/gem/app/puma.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
 min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count

--- a/lib/hanami/cli/generators/gem/app/rakefile.erb
+++ b/lib/hanami/cli/generators/gem/app/rakefile.erb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 require "hanami/rake_tasks"

--- a/lib/hanami/cli/generators/gem/app/routes.erb
+++ b/lib/hanami/cli/generators/gem/app/routes.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module <%= camelized_app_name %>
   class Routes < Hanami::Routes
     root { "Hello from Hanami" }

--- a/lib/hanami/cli/generators/gem/app/settings.erb
+++ b/lib/hanami/cli/generators/gem/app/settings.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module <%= camelized_app_name %>
   class Settings < Hanami::Settings
     # Define your app settings here, for example:

--- a/lib/hanami/cli/generators/gem/app/types.erb
+++ b/lib/hanami/cli/generators/gem/app/types.erb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/types"
 
 module <%= camelized_app_name %>

--- a/lib/hanami/cli/generators/gem/app/validator.erb
+++ b/lib/hanami/cli/generators/gem/app/validator.erb
@@ -1,6 +1,4 @@
 # auto_register: false
-# frozen_string_literal: true
-
 require "dry/validation"
 require "dry/schema/messages/i18n"
 

--- a/lib/hanami/cli/generators/version.rb
+++ b/lib/hanami/cli/generators/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     module Generators

--- a/lib/hanami/cli/middleware_stack_inspector.rb
+++ b/lib/hanami/cli/middleware_stack_inspector.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     # @since 2.0.0

--- a/lib/hanami/cli/naming.rb
+++ b/lib/hanami/cli/naming.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "shellwords"
 
 module Hanami

--- a/lib/hanami/cli/rake_tasks.rb
+++ b/lib/hanami/cli/rake_tasks.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 
 module Hanami

--- a/lib/hanami/cli/repl/core.rb
+++ b/lib/hanami/cli/repl/core.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/console/context"
 require_relative "../errors"
 

--- a/lib/hanami/cli/repl/irb.rb
+++ b/lib/hanami/cli/repl/irb.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "irb"
 require_relative "core"
 

--- a/lib/hanami/cli/repl/pry.rb
+++ b/lib/hanami/cli/repl/pry.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pry"
 require_relative "core"
 

--- a/lib/hanami/cli/server.rb
+++ b/lib/hanami/cli/server.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     # @since 2.0.0

--- a/lib/hanami/cli/system_call.rb
+++ b/lib/hanami/cli/system_call.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # SystemCall#call is adapted from hanami-devtools as well as the Bundler source code. Bundler is
 # released under the MIT license: https://github.com/bundler/bundler/blob/master/LICENSE.md.
 #

--- a/lib/hanami/cli/url.rb
+++ b/lib/hanami/cli/url.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "uri"
 require_relative "./errors"
 

--- a/lib/hanami/cli/version.rb
+++ b/lib/hanami/cli/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module CLI
     # The current hanami-cli version.

--- a/lib/hanami/console/context.rb
+++ b/lib/hanami/console/context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "plugins/slice_readers"
 
 module Hanami

--- a/lib/hanami/console/plugins/slice_readers.rb
+++ b/lib/hanami/console/plugins/slice_readers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "delegate"
 
 module Hanami

--- a/spec/fixtures/test/config.ru
+++ b/spec/fixtures/test/config.ru
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 
 app = ->(_env) { [200, {}, ["Hello, world! (#{Hanami.env})"]] }

--- a/spec/fixtures/test/config/app.rb
+++ b/spec/fixtures/test/config/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # FIXME: require "hanami/app" should work but it fails
 #       due to missing Hanami.env
 require "hanami"

--- a/spec/fixtures/test/config/routes.rb
+++ b/spec/fixtures/test/config/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/routes"
 
 module Test

--- a/spec/integration/hanami/cli/commands/app/server_spec.rb
+++ b/spec/integration/hanami/cli/commands/app/server_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "open-uri"
 require "puma"
 

--- a/spec/integration/run_spec.rb
+++ b/spec/integration/run_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "open3"
 
 RSpec.describe "bin/hanami", :app do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/cli"
 
 RSpec.configure do |config|

--- a/spec/support/system_call.rb
+++ b/spec/support/system_call.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     module SystemCall

--- a/spec/unit/hanami/cli/commands/app/command_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/command_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::Command do
   context "#call" do
     subject { cmd.new }

--- a/spec/unit/hanami/cli/commands/app/db/create_migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_migration_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::CreateMigration, :app, :command, :db do
   let(:migrator) do
     double(:migrator, generate_version: 312)

--- a/spec/unit/hanami/cli/commands/app/db/create_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app, :command do
   let(:database) do
     instance_double(Hanami::CLI::Commands::App::DB::Utils::Database, name: "test")

--- a/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/drop_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Drop, :app, :command, :db do
   it "drops a database" do
     expect(database).to receive(:drop_command).and_return(true)

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app, :command, :db do
   it "runs migrations" do
     expect(database).to receive(:run_migrations)

--- a/spec/unit/hanami/cli/commands/app/db/reset_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/reset_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Reset, :app, :command, :db do
   it "drops, creates and migrates a database" do
     pending "ugh too much to mock"

--- a/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/rollback_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Rollback, :app, :command, :db do
   context "given no target is specified" do
     context "there a no previous migrations" do

--- a/spec/unit/hanami/cli/commands/app/db/sample_data_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/sample_data_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::SampleData, :app, :command, :db do
   it "loads sample data file" do
     command.call

--- a/spec/unit/hanami/cli/commands/app/db/seed_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/seed_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Seed, :app, :command, :db do
   it "loads sample data file" do
     command.call

--- a/spec/unit/hanami/cli/commands/app/db/setup_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/setup_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Setup, :app, :command do
   let(:database) do
     instance_double(Hanami::CLI::Commands::DB::Utils::Database, name: "test")

--- a/spec/unit/hanami/cli/commands/app/db/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app, :command, :db do
   it "outputs schema version" do
     expect(database).to receive(:applied_migrations).and_return(["312_create_users"])

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 require "ostruct"
 
@@ -27,8 +25,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
         # Route
         routes = <<~CODE
-          # frozen_string_literal: true
-
           require "hanami/routes"
 
           module #{app}
@@ -44,8 +40,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         expect(output).to include("Updated config/routes.rb")
 
         action_file = <<~EXPECTED
-          # frozen_string_literal: true
-
           module #{inflector.camelize(app)}
             module Actions
               module #{inflector.camelize(controller)}
@@ -176,8 +170,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         expect(output).to include("Updated config/routes.rb")
 
         action_file = <<~EXPECTED
-          # frozen_string_literal: true
-
           module #{inflector.camelize(app)}
             module Actions
               module API
@@ -240,8 +232,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
         # Route
         routes = <<~CODE
-          # frozen_string_literal: true
-
           require "hanami/routes"
 
           module #{app}
@@ -265,8 +255,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
 
         action_file = <<~EXPECTED
-          # frozen_string_literal: true
-
           module #{inflector.camelize(slice)}
             module Actions
               module #{inflector.camelize(controller)}
@@ -331,8 +319,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
           # Route
           routes = <<~CODE
-            # frozen_string_literal: true
-
             require "hanami/routes"
 
             module #{app}
@@ -353,8 +339,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           expect(fs.directory?("slices/#{slice}/actions/books/bestsellers/nonfiction")).to be(true)
 
           action_file = <<~EXPECTED
-            # frozen_string_literal: true
-
             module #{inflector.camelize(slice)}
               module Actions
                 module Books
@@ -415,8 +399,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         fs.mkdir("slices/api")
 
         routes_contents = <<~CODE
-          # frozen_string_literal: true
-
           require "hanami/routes"
 
           module #{app}
@@ -436,8 +418,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
         fs.write("config/routes.rb", routes_contents)
 
         expected = <<~CODE
-          # frozen_string_literal: true
-
           require "hanami/routes"
 
           module #{app}
@@ -475,8 +455,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
     fs.mkdir(dir)
     fs.chdir(dir) do
       routes = <<~CODE
-        # frozen_string_literal: true
-
         require "hanami/routes"
 
         module #{app}
@@ -495,8 +473,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
   def prepare_slice!
     fs.mkdir("slices/#{slice}")
     routes = <<~CODE
-      # frozen_string_literal: true
-
       require "hanami/routes"
 
       module #{app}

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami"
 require "securerandom"
 
@@ -25,8 +23,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
 
       # Route
       routes = <<~CODE
-        # frozen_string_literal: true
-
         require "hanami/routes"
 
         module #{app}
@@ -60,8 +56,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
       # Action
       action = <<~CODE
         # auto_register: false
-        # frozen_string_literal: true
-
         module Admin
           class Action < #{app}::Action
           end
@@ -112,8 +106,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
 
       # Route
       routes = <<~CODE
-        # frozen_string_literal: true
-
         require "hanami/routes"
 
         module #{app}
@@ -145,8 +137,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
     fs.mkdir(dir)
     fs.chdir(dir) do
       routes = <<~CODE
-        # frozen_string_literal: true
-
         require "hanami/routes"
 
         module #{app}

--- a/spec/unit/hanami/cli/commands/app/install_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/install_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::Install do
   subject { described_class.new(out: stdout) }
   let(:stdout) { StringIO.new }

--- a/spec/unit/hanami/cli/commands/app/middleware_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/middleware_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::Middleware, :app, :command do
   # TODO: better Hanami tear down
   after do

--- a/spec/unit/hanami/cli/commands/app/routes_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/routes_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::Routes, :app, :command do # see fixture app for the defined routes
   # TODO: better Hanami tear down
   after do

--- a/spec/unit/hanami/cli/commands/app/server_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/server_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::Server do
   subject { described_class.new(server: server) }
   let(:server) { proc { |**| } }

--- a/spec/unit/hanami/cli/commands/app/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::App::Version do
   subject { described_class.new(out: stdout) }
   let(:stdout) { StringIO.new }

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::Gem::New do
   subject {
     described_class.new(bundler: bundler, out: out, fs: fs, inflector: inflector)
@@ -83,8 +81,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       # Gemfile
       hanami_version = Hanami::CLI::Generators::Version.gem_requirement
       gemfile = <<~EXPECTED
-        # frozen_string_literal: true
-
         source "https://rubygems.org"
 
         gem "hanami", "#{hanami_version}"
@@ -113,8 +109,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # Rakefile
       rakefile = <<~EXPECTED
-        # frozen_string_literal: true
-
         require "hanami/rake_tasks"
       EXPECTED
       expect(fs.read("Rakefile")).to eq(rakefile)
@@ -122,8 +116,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # config.ru
       config_ru = <<~EXPECTED
-        # frozen_string_literal: true
-
         require "hanami/boot"
 
         run Hanami.app
@@ -133,8 +125,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # config/app.rb
       hanami_app = <<~EXPECTED
-        # frozen_string_literal: true
-
         require "hanami"
 
         module Bookshelf
@@ -147,8 +137,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # config/settings.rb
       settings = <<~EXPECTED
-        # frozen_string_literal: true
-
         module Bookshelf
           class Settings < Hanami::Settings
             # Define your app settings here, for example:
@@ -162,8 +150,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # config/routes.rb
       routes = <<~EXPECTED
-        # frozen_string_literal: true
-
         module Bookshelf
           class Routes < Hanami::Routes
             root { "Hello from Hanami" }
@@ -175,8 +161,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # config/puma.rb
       puma = <<~EXPECTED
-        # frozen_string_literal: true
-
         max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
         min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
         threads min_threads_count, max_threads_count
@@ -203,8 +187,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       # app/action.rb
       action = <<~EXPECTED
         # auto_register: false
-        # frozen_string_literal: true
-
         require "hanami/action"
 
         module #{inflector.camelize(app)}
@@ -217,8 +199,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # lib/bookshelf/types.rb
       types = <<~EXPECTED
-        # frozen_string_literal: true
-
         require "dry/types"
 
         module #{inflector.camelize(app)}
@@ -257,8 +237,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # config/app.rb
       hanami_app = <<~EXPECTED
-        # frozen_string_literal: true
-
         require "hanami"
 
         module #{inflector.camelize(app)}

--- a/spec/unit/hanami/cli/commands/gem/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Commands::Gem::Version do
   subject { described_class.new(out: stdout) }
   let(:stdout) { StringIO.new }

--- a/spec/unit/hanami/cli/middleware_stack_inspector_spec.rb
+++ b/spec/unit/hanami/cli/middleware_stack_inspector_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/slice/routing/middleware/stack"
 
 RSpec.describe Hanami::CLI::MiddlewareStackInspector do

--- a/spec/unit/hanami/cli/server_spec.rb
+++ b/spec/unit/hanami/cli/server_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::CLI::Server do
   describe "#call" do
     subject { described_class.new(rack_server: rack_server) }

--- a/spec/unit/hanami/cli/version_spec.rb
+++ b/spec/unit/hanami/cli/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::CLI::VERSION" do
   it "returns version" do
     expect(Hanami::CLI::VERSION).to eq("2.0.3")


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.