### PR TITLE
Start puma in `single-mode` by default.

### DIFF
--- a/lib/hanami/cli/generators/gem/app/puma.erb
+++ b/lib/hanami/cli/generators/gem/app/puma.erb
@@ -6,10 +6,12 @@ threads min_threads_count, max_threads_count
 
 port        ENV.fetch("<%= Hanami::Port::ENV_VAR %>", <%= Hanami::Port::DEFAULT %>)
 environment ENV.fetch("HANAMI_ENV", "development")
-workers     ENV.fetch("HANAMI_WEB_CONCURRENCY", 2)
+workers     ENV.fetch("HANAMI_WEB_CONCURRENCY", 0)
 
-on_worker_boot do
-  Hanami.shutdown
+if ENV.fetch("HANAMI_WEB_CONCURRENCY", 0) > 0
+  on_worker_boot do
+    Hanami.shutdown
+  end
 end
 
 preload_app!

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -183,10 +183,12 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         port        ENV.fetch("HANAMI_PORT", 2300)
         environment ENV.fetch("HANAMI_ENV", "development")
-        workers     ENV.fetch("HANAMI_WEB_CONCURRENCY", 2)
+        workers     ENV.fetch("HANAMI_WEB_CONCURRENCY", 0)
 
-        on_worker_boot do
-          Hanami.shutdown
+        if ENV.fetch("HANAMI_WEB_CONCURRENCY", 0) > 0
+          on_worker_boot do
+            Hanami.shutdown
+          end
         end
 
         preload_app!


### PR DESCRIPTION
We want to ensure that Hanami runs using the lowest memory footprint by
default.