### PR TITLE
fix: special characters with `new` command

### DIFF
--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -32,7 +32,7 @@ module Hanami
         # @since 2.0.0
         # @api private
         def camelized_app_name
-          inflector.camelize(app)
+          inflector.camelize(app).gsub(/[^\p{Alnum}]/, "")
         end
 
         # @since 2.0.0

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -25,21 +25,35 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
     app_name = "HanamiTeam"
     app = "hanami_team"
+    module_name = "HanamiTeam"
     subject.call(app: app_name)
 
     expect(fs.directory?(app)).to be(true)
+    expect(fs.read("#{app}/config/app.rb")).to include("module #{module_name}")
 
     app_name = "Rubygems"
     app = "rubygems"
+    module_name = "Rubygems"
     subject.call(app: app_name)
 
     expect(fs.directory?(app)).to be(true)
+    expect(fs.read("#{app}/config/app.rb")).to include("module #{module_name}")
 
     app_name = "CodeInsights"
     app = "code_insights"
+    module_name = "CodeInsights"
     subject.call(app: app_name)
 
     expect(fs.directory?(app)).to be(true)
+    expect(fs.read("#{app}/config/app.rb")).to include("module #{module_name}")
+
+    app_name = "hanamirb.org"
+    app = "hanamirb.org"
+    module_name = "Hanamirborg"
+    subject.call(app: app_name)
+
+    expect(fs.directory?(app)).to be(true)
+    expect(fs.read("#{app}/config/app.rb")).to include("module #{module_name}")
   end
 
   it "generates an app" do


### PR DESCRIPTION
Hi Hanami maintainers! First off, I just wanted to say thank you for this lovely project. I'm really grateful for the existence of alternative frameworks in the Ruby ecosystem, and I'm particularly excited for the `v2.*.*` releases that are in the works for Hanami.

# Motivation for PR

I recently tried making a new `v2.1.0.beta1` project following the commands in [this article](https://hanamirb.org/blog/2023/06/29/hanami-210beta1/). However, the command that I used had a special character in it:

```bash
hanami new mynew.app
```

This caused generated files to have invalid Ruby module names because of the `.` in my given example. When trying to run `bundle exec hanami server`, I ran into a `SyntaxError`, causing me to think that something was perhaps broken in Hanami core.

# Proposed solution

This PR is a first stab at addressing this. This updates `Hanami::CLI::Generators::Context#camelized_app_name` to strip characters that don't fit under Unicode alphanumeric characters. The reason why I picked Unicode alphanumeric over standard alphanumeric was because [Ruby now supports non-ASCII constant names](https://bugs.ruby-lang.org/issues/13770).

I've updated tests to also cover this case.