### PR TITLE
Use Irb as default engine for hanami console.

### DIFF
--- a/lib/hanami/cli/commands/app/console.rb
+++ b/lib/hanami/cli/commands/app/console.rb
@@ -37,7 +37,7 @@ module Hanami
 
           # @since 2.0.0
           # @api private
-          def call(engine: nil, **opts)
+          def call(engine: DEFAULT_ENGINE, **opts)
             console_engine = resolve_engine(engine, opts)
 
             if console_engine.nil?

--- a/spec/unit/hanami/cli/commands/app/console_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/console_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Commands::App::Console do
+  subject { described_class.new }
+
+  context "#call" do
+    context "with engine provided" do
+      let(:pry) do
+        instance_double(Hanami::CLI::Repl::Pry, name: "pry")
+      end
+
+      it "invokes pry" do
+        allow(Hanami::CLI::Repl::Pry).to receive(:new).and_return(pry)
+
+        expect(pry).to receive(:start)
+        subject.call(engine: 'pry')
+      end
+    end
+
+    context "with default engine" do
+      let(:irb) do
+        instance_double(Hanami::CLI::Repl::Irb, name: "irb")
+      end
+
+      it "invokes irb" do
+        allow(Hanami::CLI::Repl::Irb).to receive(:new).and_return(irb)
+
+        expect(irb).to receive(:start)
+
+        subject.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
without this fix I'm getting following error when running `hanami console`:

```
From: /usr/local/bundle/gems/hanami-cli-2.0.3/lib/hanami/cli/commands/app/console.rb:49 Hanami::CLI::Commands::App::Command::Environment#call:

    44:               err.puts "`#{engine}' is not bundled. Please run `bundle add #{engine}' and retry."
    45:               exit(1)
    46:             end
    47:
    48:             console_engine.start
 => 49:           end
    50:
    51:           private
    52:
    53:           def resolve_engine(engine, opts)
    54:             if engine
```