### PR TITLE
Introduce `hanami assets` commands

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -18,6 +18,9 @@ module Hanami
             register "server", Commands::App::Server, aliases: ["s"]
             register "routes", Commands::App::Routes
             register "middleware", Commands::App::Middleware
+            register "assets" do |prefix|
+              prefix.register "watch", Assets::Watch
+            end
 
             register "generate", aliases: ["g"] do |prefix|
               prefix.register "slice", Generate::Slice

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -19,6 +19,7 @@ module Hanami
             register "routes", Commands::App::Routes
             register "middleware", Commands::App::Middleware
             register "assets" do |prefix|
+              prefix.register "compile", Assets::Compile
               prefix.register "watch", Assets::Watch
             end
 

--- a/lib/hanami/cli/commands/app/assets.rb
+++ b/lib/hanami/cli/commands/app/assets.rb
@@ -7,6 +7,7 @@ module Hanami
         # @since 2.1.0
         # @api private
         module Assets
+          require_relative "assets/compile"
           require_relative "assets/watch"
         end
       end

--- a/lib/hanami/cli/commands/app/assets.rb
+++ b/lib/hanami/cli/commands/app/assets.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        # @since 2.1.0
+        # @api private
+        module Assets
+          require_relative "assets/watch"
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../../../system_call"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Assets
+          # @since 2.1.0
+          # @api private
+          class Compile < App::Command
+            desc "Compile assets for deployments"
+
+            # @since 2.1.0
+            # @api private
+            #
+            # TODO: Take `executable` from Hanami::Assets::Config
+            def initialize(system_call: SystemCall.new, executable: File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js"), **)
+              @system_call = system_call
+              @executable = executable
+              super()
+            end
+
+            # @since 2.1.0
+            # @api private
+            def call(**)
+              system_call.call(executable)
+            end
+
+            private
+
+            # @since 2.1.0
+            # @api private
+            attr_reader :system_call, :executable
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -15,6 +15,8 @@ module Hanami
             WATCH_OPTION = "--watch"
             private_constant :WATCH_OPTION
 
+            desc "Start assets watch mode"
+
             # @since 2.1.0
             # @api private
             #

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "../../../interactive_system_call"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Assets
+          # @since 2.1.0
+          # @api private
+          class Watch < App::Command
+            # @since 2.1.0
+            # @api private
+            WATCH_OPTION = "--watch"
+            private_constant :WATCH_OPTION
+
+            # @since 2.1.0
+            # @api private
+            #
+            # TODO: Take `executable` from Hanami::Assets::Config
+            def initialize(interactive_system_call: InteractiveSystemCall.new, executable: File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js"), **)
+              @interactive_system_call = interactive_system_call
+              @executable = executable
+              super()
+            end
+
+            # @since 2.1.0
+            # @api private
+            def call(**)
+              interactive_system_call.call(executable, WATCH_OPTION)
+            end
+
+            private
+
+            # @since 2.1.0
+            # @api private
+            attr_reader :interactive_system_call, :executable
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/interactive_system_call.rb
+++ b/lib/hanami/cli/interactive_system_call.rb
@@ -4,13 +4,19 @@ require "open3"
 
 module Hanami
   module CLI
+    # @api private
+    # @since 2.1.0
     class InteractiveSystemCall
+      # @api private
+      # @since 2.1.0
       def initialize(out: $stdout, err: $stderr)
         @out = out
         @err = err
         super()
       end
 
+      # @api private
+      # @since 2.1.0
       def call(executable, *args)
         ::Bundler.with_unbundled_env do
           threads = []
@@ -42,6 +48,8 @@ module Hanami
 
       private
 
+      # @api private
+      # @since 2.1.0
       attr_reader :out, :err
     end
   end

--- a/lib/hanami/cli/interactive_system_call.rb
+++ b/lib/hanami/cli/interactive_system_call.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module Hanami
+  module CLI
+    class InteractiveSystemCall
+      def initialize(out: $stdout, err: $stderr)
+        @out = out
+        @err = err
+        super()
+      end
+
+      def call(executable, *args)
+        ::Bundler.with_unbundled_env do
+          threads = []
+          exit_status = 0
+
+          Open3.popen3(executable, *args) do |stdin, stdout, stderr, wait_thr|
+            threads << Thread.new do
+              stdout.each_line do |line|
+                out.puts(line)
+              end
+            rescue IOError # FIXME: Check if this is legit
+            end
+
+            threads << Thread.new do
+              stderr.each_line do |line|
+                err.puts(line)
+              end
+            rescue IOError # FIXME: Check if this is legit
+            end
+
+            threads.each(&:join)
+
+            exit_status = wait_thr.value
+          end
+
+          exit(exit_status)
+        end
+      end
+
+      private
+
+      attr_reader :out, :err
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Commands::App::Assets::Compile do
+  subject { described_class.new(system_call: system_call) }
+  let(:system_call) { proc { |**| } }
+  let(:executable) { File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js") }
+
+  context "#call" do
+    it "invokes hanami-assets executable" do
+      expect(system_call).to receive(:call).with(executable)
+
+      subject.call
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Commands::App::Assets::Watch do
+  subject { described_class.new(interactive_system_call: interactive_system_call) }
+  let(:interactive_system_call) { proc { |**| } }
+  let(:executable) { File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js") }
+
+  context "#call" do
+    it "invokes hanami-assets executable" do
+      expect(interactive_system_call).to receive(:call).with(executable, "--watch")
+
+      subject.call
+    end
+  end
+end


### PR DESCRIPTION
## Features

Introduce two new commands:

* `hanami assets compile` to compile the assets during deployments
* `hanami assets watch` to watch and lazily compile assets during development

---

Ref https://github.com/hanami/assets/pull/120