### PR TITLE
Introduce `hanami dev`

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -14,6 +14,7 @@ module Hanami
           base.module_eval do
             register "version", Commands::App::Version, aliases: ["v", "-v", "--version"]
             register "install", Commands::App::Install
+            register "dev", Commands::App::Dev
             register "console", Commands::App::Console, aliases: ["c"]
             register "server", Commands::App::Server, aliases: ["s"]
             register "routes", Commands::App::Routes

--- a/lib/hanami/cli/commands/app/dev.rb
+++ b/lib/hanami/cli/commands/app/dev.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "../../interactive_system_call"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        # @since 2.1.0
+        # @api private
+        class Dev < App::Command
+          # @since 2.1.0
+          # @api private
+          def initialize(interactive_system_call: InteractiveSystemCall.new, **)
+            @interactive_system_call = interactive_system_call
+            super()
+          end
+
+          # @since 2.1.0
+          # @api private
+          def call(**)
+            bin, args = executable
+            interactive_system_call.call(bin, *args)
+          end
+
+          private
+
+          # @since 2.1.0
+          # @api private
+          attr_reader :interactive_system_call
+
+          # @since 2.1.0
+          # @api private
+          def executable
+            # TODO: support other implementations of Foreman
+            # See: https://github.com/ddollar/foreman#ports
+            ["foreman", ["start", "-f", "Procfile.dev"]]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/commands/app/dev.rb
+++ b/lib/hanami/cli/commands/app/dev.rb
@@ -11,6 +11,20 @@ module Hanami
         class Dev < App::Command
           # @since 2.1.0
           # @api private
+          desc "Start the application in development mode"
+
+          # @since 2.1.0
+          # @api private
+          option :procfile, type: :string, desc: "Path to Procfile", aliases: ["-f"]
+
+          # @since 2.1.0
+          # @api private
+          example [
+            "-f /path/to/Procfile",
+          ]
+
+          # @since 2.1.0
+          # @api private
           def initialize(interactive_system_call: InteractiveSystemCall.new, **)
             @interactive_system_call = interactive_system_call
             super()
@@ -18,8 +32,8 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          def call(**)
-            bin, args = executable
+          def call(procfile: nil, **)
+            bin, args = executable(procfile: procfile)
             interactive_system_call.call(bin, *args)
           end
 
@@ -31,10 +45,10 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          def executable
+          def executable(procfile: nil)
             # TODO: support other implementations of Foreman
             # See: https://github.com/ddollar/foreman#ports
-            ["foreman", ["start", "-f", "Procfile.dev"]]
+            ["foreman", ["start", "-f", procfile || "Procfile.dev"]]
           end
         end
       end

--- a/spec/unit/hanami/cli/commands/app/dev_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/dev_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Commands::App::Dev do
+  subject { described_class.new(interactive_system_call: interactive_system_call) }
+  let(:interactive_system_call) { proc { |**| } }
+  let(:bin) { "foreman" }
+  let(:args) { ["start", "-f", "Procfile.dev"] }
+
+  context "#call" do
+    it "invokes external command to start Procfile based session" do
+      expect(interactive_system_call).to receive(:call).with(bin, *args)
+
+      subject.call
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/dev_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/dev_spec.rb
@@ -12,5 +12,16 @@ RSpec.describe Hanami::CLI::Commands::App::Dev do
 
       subject.call
     end
+
+    context "with custom Procfile" do
+      let(:args) { ["start", "-f", procfile] }
+      let(:procfile) { "Procfile.test" }
+
+      it "invokes external command to start Procfile based session" do
+        expect(interactive_system_call).to receive(:call).with(bin, *args)
+
+        subject.call(procfile: procfile)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Feature

Introduce a new command for development: `hanami dev`.

It's a convenient wrapper around Foreman.
Our goal is to provide an easy-to-remember command to start a development session.

By default, it will look at `Procfile.dev`.
You can customize the path to find the file with:

```bash
$ bundle exec hanami dev -f /path/to/your/Procfile
```