### PR TITLE
Use app's configured assets exe_path for commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,10 @@ unless ENV["CI"]
 end
 
 gem "hanami", github: "hanami/hanami", branch: "main"
-gem "hanami-utils", github: "hanami/utils", branch: "main"
-gem "hanami-router", github: "hanami/router", branch: "main"
+gem "hanami-assets", github: "hanami/assets", branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
+gem "hanami-router", github: "hanami/router", branch: "main"
+gem "hanami-utils", github: "hanami/utils", branch: "main"
 
 gem "rack"
 

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -16,10 +16,9 @@ module Hanami
             # @api private
             #
             # TODO: Take `executable` from Hanami::Assets::Config
-            def initialize(system_call: SystemCall.new,
-                           executable: File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js"), **)
+            def initialize(system_call: SystemCall.new, executable: nil, **)
               @system_call = system_call
-              @executable = executable
+              @executable = executable || app.config.assets.exe_path
               super()
             end
 

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -21,10 +21,9 @@ module Hanami
             # @api private
             #
             # TODO: Take `executable` from Hanami::Assets::Config
-            def initialize(interactive_system_call: InteractiveSystemCall.new,
-                           executable: File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js"), **)
+            def initialize(interactive_system_call: InteractiveSystemCall.new, executable: nil, **)
               @interactive_system_call = interactive_system_call
-              @executable = executable
+              @executable = executable || app.config.assets.exe_path
               super()
             end
 

--- a/spec/fixtures/test/config/app.rb
+++ b/spec/fixtures/test/config/app.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# FIXME: require "hanami/app" should work but it fails
-#       due to missing Hanami.env
 require "hanami"
 
 module Test

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::CLI::Commands::App::Assets::Compile do
+RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, :app do
   subject { described_class.new(system_call: system_call) }
   let(:system_call) { proc { |**| } }
-  let(:executable) { File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js") }
 
   context "#call" do
     it "invokes hanami-assets executable" do
-      expect(system_call).to receive(:call).with(executable)
+      expect(system_call).to receive(:call).with(Hanami.app.config.assets.exe_path)
 
       subject.call
     end

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::CLI::Commands::App::Assets::Watch do
+RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, :app do
   subject { described_class.new(interactive_system_call: interactive_system_call) }
   let(:interactive_system_call) { proc { |**| } }
-  let(:executable) { File.join("node_modules", "hanami-assets", "dist", "hanami-assets.js") }
 
   context "#call" do
     it "invokes hanami-assets executable" do
-      expect(interactive_system_call).to receive(:call).with(executable, "--watch")
+      expect(interactive_system_call).to receive(:call).with(Hanami.app.config.assets.exe_path, "--watch")
 
       subject.call
     end


### PR DESCRIPTION
For the `assets compile` and `assets watch` commands, instead of hardcoding a default path to the `hanami-assets.js` command, use the configured exe path at `Hanami.app.assets.exe_path`.

Resolves #96.