### PR TITLE
`hanami new` generates a `Gemfile` with `hanami-webconsole` in `:development` group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Hanami Command Line Interface
 - [Luca Guidi] `hanami assets watch` to watch and compile assets at the development time
 - [Luca Guidi] `hanami dev` to start the processes in `Procfile.dev`
 
+### Fixed
+
+- [Luca Guidi] `hanami new` generates a `Gemfile` with `hanami-webconsole` in `:development` group
+
 ## v2.1.0.beta1 - 2023-06-29
 
 ### Added

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -10,11 +10,14 @@ gem "hanami-view", "<%= hanami_version %>"
 <%- if generate_assets? -%>
 gem "hanami-assets", "<%= hanami_version %>"
 <%- end -%>
-gem "hanami-webconsole", "<%= hanami_version %>"
 
 gem "dry-types", "~> 1.0", ">= 1.6.1"
 gem "puma"
 gem "rake"
+
+group :development do
+  gem "hanami-webconsole", "<%= hanami_version %>"
+end
 
 group :development, :test do
   gem "dotenv"

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -97,11 +97,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gem "hanami-validations", "#{hanami_version}"
         gem "hanami-view", "#{hanami_version}"
         gem "hanami-assets", "#{hanami_version}"
-        gem "hanami-webconsole", "#{hanami_version}"
 
         gem "dry-types", "~> 1.0", ">= 1.6.1"
         gem "puma"
         gem "rake"
+
+        group :development do
+          gem "hanami-webconsole", "#{hanami_version}"
+        end
 
         group :development, :test do
           gem "dotenv"


### PR DESCRIPTION
This is the [recommended](https://github.com/BetterErrors/better_errors#installation) way to use `better_errors`, the engine that powers `hanami-webconsole`.