### PR TITLE
Generate Hanami app using HEAD version from GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Hanami Command Line Interface
 
 - [Luca Guidi] `hanami new` generates `Procfile.dev`
 - [Luca Guidi] `hanami new` generates basic app assets, if `hanami-assets` is bundled by the app
+- [Luca Guidi] `hanami new` accepts `--head` to generate the app using Hanami HEAD version from GitHub
 - [Luca Guidi] `hanami generate slice` generates basic slice assets, if `hanami-assets` is bundled by the app
 - [Ryan Bigg] `hanami generate action` generates corresponding view, if `hanami-view` is bundled by the app
 - [Luca Guidi] `hanami assets compile` to compile assets at the deploy time
@@ -17,6 +18,7 @@ Hanami Command Line Interface
 ### Fixed
 
 - [Luca Guidi] `hanami new` generates a `Gemfile` with `hanami-webconsole` in `:development` group
+- [Luca Guidi] `hanami new` generates a `Gemfile` with versioned `hanami-webconsole`, `hanami-rspec`, and `hanami-reloader`
 
 ## v2.1.0.beta1 - 2023-06-29
 

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -17,6 +17,11 @@ module Hanami
 
           # @since 2.1.0
           # @api private
+          HEAD_DEFAULT = false
+          private_constant :HEAD_DEFAULT
+
+          # @since 2.1.0
+          # @api private
           SKIP_ASSETS_DEFAULT = false
           private_constant :SKIP_ASSETS_DEFAULT
 
@@ -34,15 +39,24 @@ module Hanami
 
           # @since 2.1.0
           # @api private
+          option :head, type: :boolean, required: false,
+                        default: HEAD_DEFAULT,
+                        desc: "Use Hanami HEAD version (from GitHub `main` branches)"
+
+          # @since 2.1.0
+          # @api private
           option :skip_assets, type: :boolean, required: false,
                                default: SKIP_ASSETS_DEFAULT,
                                desc: "Skip assets"
 
+          # rubocop:disable Layout/LineLength
           example [
-            "bookshelf                # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace", # rubocop:disable Layout/LineLength
+            "bookshelf                # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
+            "bookshelf --head         # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
             "bookshelf --skip-install # Generate a new Hanami app, but it skips Hanami installation",
             "bookshelf --skip-assets  # Generate a new Hanami app without assets"
           ]
+          # rubocop:enable Layout/LineLength
 
           # @since 2.0.0
           # @api private
@@ -60,14 +74,14 @@ module Hanami
 
           # @since 2.0.0
           # @api private
-          def call(app:, skip_install: SKIP_INSTALL_DEFAULT, skip_assets: SKIP_ASSETS_DEFAULT, **)
+          def call(app:, head: HEAD_DEFAULT, skip_install: SKIP_INSTALL_DEFAULT, skip_assets: SKIP_ASSETS_DEFAULT, **)
             app = inflector.underscore(app)
 
             raise PathAlreadyExistsError.new(app) if fs.exist?(app)
 
             fs.mkdir(app)
             fs.chdir(app) do
-              context = Generators::Context.new(inflector, app, skip_assets: skip_assets)
+              context = Generators::Context.new(inflector, app, head: head, skip_assets: skip_assets)
               generator.call(app, context: context) do
                 if skip_install
                   out.puts "Skipping installation, please enter `#{app}' directory and run `bundle exec hanami install'"

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -27,7 +27,9 @@ module Hanami
         # @since 2.0.0
         # @api private
         def hanami_version
-          Version.gem_requirement
+          unless hanami_head?
+            %("#{Version.gem_requirement}")
+          end
         end
 
         # @since 2.0.0
@@ -46,6 +48,12 @@ module Hanami
         # @api private
         def humanized_app_name
           inflector.humanize(app)
+        end
+
+        # @since 2.1.0
+        # @api private
+        def hanami_head?
+          options.fetch(:head)
         end
 
         # @since 2.1.0

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -24,10 +24,18 @@ module Hanami
           binding
         end
 
+        def hanami_gem(name)
+          gem_name = name == "hanami" ? "hanami" : "hanami-#{name}"
+
+          %(gem "#{gem_name}", #{hanami_version(name)})
+        end
+
         # @since 2.0.0
         # @api private
-        def hanami_version
-          unless hanami_head?
+        def hanami_version(gem_name)
+          if hanami_head?
+            %(github: "hanami/#{gem_name}", branch: "main")
+          else
             %("#{Version.gem_requirement}")
           end
         end

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -2,13 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "hanami", "<%= hanami_version %>"
-gem "hanami-router", "<%= hanami_version %>"
-gem "hanami-controller", "<%= hanami_version %>"
-gem "hanami-validations", "<%= hanami_version %>"
-gem "hanami-view", "<%= hanami_version %>"
+gem "hanami", <%= hanami_version %>
+gem "hanami-router", <%= hanami_version %>
+gem "hanami-controller", <%= hanami_version %>
+gem "hanami-validations", <%= hanami_version %>
+gem "hanami-view", <%= hanami_version %>
 <%- if generate_assets? -%>
-gem "hanami-assets", "<%= hanami_version %>"
+gem "hanami-assets", <%= hanami_version %>
 <%- end -%>
 
 gem "dry-types", "~> 1.0", ">= 1.6.1"
@@ -16,7 +16,7 @@ gem "puma"
 gem "rake"
 
 group :development do
-  gem "hanami-webconsole", "<%= hanami_version %>"
+  gem "hanami-webconsole", <%= hanami_version %>
 end
 
 group :development, :test do
@@ -24,9 +24,9 @@ group :development, :test do
 end
 
 group :cli, :development do
-  gem "hanami-reloader"
+  gem "hanami-reloader", <%= hanami_version %>
 end
 
 group :cli, :development, :test do
-  gem "hanami-rspec"
+  gem "hanami-rspec", <%= hanami_version %>
 end

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -2,13 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "hanami", <%= hanami_version %>
-gem "hanami-router", <%= hanami_version %>
-gem "hanami-controller", <%= hanami_version %>
-gem "hanami-validations", <%= hanami_version %>
-gem "hanami-view", <%= hanami_version %>
+<%= hanami_gem("hanami") %>
+<%= hanami_gem("router") %>
+<%= hanami_gem("controller") %>
+<%= hanami_gem("validations") %>
+<%= hanami_gem("view") %>
 <%- if generate_assets? -%>
-gem "hanami-assets", <%= hanami_version %>
+<%= hanami_gem("assets") %>
 <%- end -%>
 
 gem "dry-types", "~> 1.0", ">= 1.6.1"
@@ -16,7 +16,7 @@ gem "puma"
 gem "rake"
 
 group :development do
-  gem "hanami-webconsole", <%= hanami_version %>
+  <%= hanami_gem("webconsole") %>
 end
 
 group :development, :test do
@@ -24,9 +24,9 @@ group :development, :test do
 end
 
 group :cli, :development do
-  gem "hanami-reloader", <%= hanami_version %>
+  <%= hanami_gem("reloader") %>
 end
 
 group :cli, :development, :test do
-  gem "hanami-rspec", <%= hanami_version %>
+  <%= hanami_gem("rspec") %>
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   context "with head" do
     let(:hanami_head) { true }
 
-    xit "generates a new app with Gemfile pointing to hanami HEAD" do
+    it "generates a new app with Gemfile pointing to hanami HEAD" do
       expect(bundler).to receive(:install!)
         .and_return(true)
 
@@ -354,12 +354,12 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           source "https://rubygems.org"
 
-          gem "hanami",             github: "hanami/hanami",      branch: "main"
-          gem "hanami-router",      github: "hanami/router",      branch: "main"
-          gem "hanami-controller",  github: "hanami/controller",  branch: "main"
+          gem "hanami", github: "hanami/hanami", branch: "main"
+          gem "hanami-router", github: "hanami/router", branch: "main"
+          gem "hanami-controller", github: "hanami/controller", branch: "main"
           gem "hanami-validations", github: "hanami/validations", branch: "main"
-          gem "hanami-view",        github: "hanami/view",        branch: "main"
-          gem "hanami-assets",      github: "hanami/assets",      branch: "main"
+          gem "hanami-view", github: "hanami/view", branch: "main"
+          gem "hanami-assets", github: "hanami/assets", branch: "main"
 
           gem "dry-types", "~> 1.0", ">= 1.6.1"
           gem "puma"


### PR DESCRIPTION
## Enhancement

Example:

```
$ hanami new bookshelf --head
```

This command will generate a new app using the Hanami HEAD version from GitHub's `main` branches.

The `Gemfile` will look like this:

```ruby
gem "hanami", github: "hanami/hanami", branch: "main"
gem "hanami-router", github: "hanami/router", branch: "main"
# ....
```

## Fix

`hanami new` to generate a `Gemifile` with versioned Hanami development gems like `hanami-webconsole`, `hanami-reloader`, `hanami-rspec`.

`Gemfile` Example

```ruby
gem "hanami-webconsole", "~> 2.1"
```