### PR TITLE
Generate and install new assets arrangement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ unless ENV["CI"]
 end
 
 gem "hanami", github: "hanami/hanami", branch: "main"
-gem "hanami-assets", github: "hanami/assets", branch: "main"
+gem "hanami-assets", github: "hanami/assets", branch: "update-config-for-new-assets-runner"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -23,7 +23,7 @@ module Hanami
             def call(**)
               cmd, *args = cmd_with_args
 
-              system_call.call(cmd, *args, env: env)
+              system_call.call(cmd, *args)
             end
 
             private
@@ -39,20 +39,7 @@ module Hanami
             # @since 2.1.0
             # @api private
             def cmd_with_args
-              [
-                config.package_manager_executable,
-                config.package_manager_command,
-                config.executable
-              ]
-            end
-
-            # @since 2.1.0
-            # @api private
-            def env
-              ENV.to_h.merge(
-                "ESBUILD_ENTRY_POINTS" => entry_points,
-                "ESBUILD_OUTDIR" => destination
-              )
+              [config.package_manager_run_command, "assets"]
             end
 
             # @since 2.1.0

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -22,11 +22,7 @@ module Hanami
             # @since 2.1.0
             # @api private
             def cmd_with_args
-              super +
-                [
-                  "--",
-                  "--watch"
-                ]
+              super + ["--", "--watch"]
             end
           end
         end

--- a/lib/hanami/cli/commands/app/install.rb
+++ b/lib/hanami/cli/commands/app/install.rb
@@ -33,37 +33,9 @@ module Hanami
           # @api private
           option :head, type: :boolean, desc: "Install head deps", default: DEFAULT_HEAD
 
-          # @since 2.1.0
-          # @api private
-          def initialize(system_call: SystemCall.new, **)
-            @system_call = system_call
-            super()
-          end
-
           # @since 2.0.0
           # @api private
           def call(head: DEFAULT_HEAD, **)
-            install_hanami_assets!(head: head)
-          end
-
-          private
-
-          # @since 2.1.0
-          # @api private
-          attr_reader :system_call
-
-          # @since 2.1.0
-          # @api private
-          def install_hanami_assets!(head:)
-            return unless Hanami.bundled?("hanami-assets")
-
-            system_call.call("npm", ["init", "-y"])
-
-            if head
-              system_call.call("npm", %w[install https://github.com/hanami/assets-js])
-            else
-              system_call.call("npm", %w[install hanami-assets])
-            end
           end
         end
       end

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -58,6 +58,8 @@ module Hanami
           ]
           # rubocop:enable Layout/LineLength
 
+          # rubocop:disable Metrics/ParameterLists
+
           # @since 2.0.0
           # @api private
           def initialize(
@@ -65,12 +67,18 @@ module Hanami
             inflector: Dry::Inflector.new,
             bundler: CLI::Bundler.new(fs: fs),
             generator: Generators::Gem::App.new(fs: fs, inflector: inflector),
+            system_call: SystemCall.new,
             **other
           )
             @bundler = bundler
             @generator = generator
+            @system_call = system_call
             super(fs: fs, inflector: inflector, **other)
           end
+
+          # rubocop:enable Metrics/ParameterLists
+
+          # rubocop:disable Metrics/AbcSize
 
           # @since 2.0.0
           # @api private
@@ -88,17 +96,25 @@ module Hanami
                 else
                   out.puts "Running Bundler install..."
                   bundler.install!
+
+                  unless skip_assets
+                    out.puts "Running npm install..."
+                    system_call.call("npm", ["install"])
+                  end
+
                   out.puts "Running Hanami install..."
                   run_install_commmand!(head: head)
                 end
               end
             end
           end
+          # rubocop:enable Metrics/AbcSize
 
           private
 
           attr_reader :bundler
           attr_reader :generator
+          attr_reader :system_call
 
           def run_install_commmand!(head:)
             head_flag = head ? " --head" : ""

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -27,16 +27,26 @@ module Hanami
         def hanami_gem(name)
           gem_name = name == "hanami" ? "hanami" : "hanami-#{name}"
 
-          %(gem "#{gem_name}", #{hanami_version(name)})
+          %(gem "#{gem_name}", #{hanami_gem_version(name)})
         end
 
         # @since 2.0.0
         # @api private
-        def hanami_version(gem_name)
+        def hanami_gem_version(gem_name)
           if hanami_head?
             %(github: "hanami/#{gem_name}", branch: "main")
           else
             %("#{Version.gem_requirement}")
+          end
+        end
+
+        # @since 2.1.0
+        # @api private
+        def hanami_assets_npm_package
+          if hanami_head?
+            %("hanami-assets": "hanami/assets-js#main")
+          else
+            %("hanami-assets": "#{Version.npm_package_requirement}")
           end
         end
 

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -58,13 +58,15 @@ module Hanami
             fs.write("app/templates/layouts/app.html.erb", t("app_layout.erb", context))
 
             if context.generate_assets?
+              fs.write("package.json", t("package.json.erb", context))
+              fs.write("config/assets.mjs", file("assets.mjs"))
               fs.write("app/assets/js/app.js", t("app_js.erb", context))
               fs.write("app/assets/css/app.css", t("app_css.erb", context))
-              fs.write("app/assets/images/favicon.ico", File.read(File.join(__dir__, "app", "favicon.ico")))
+              fs.write("app/assets/images/favicon.ico", file("favicon.ico"))
             end
 
-            fs.write("public/404.html", File.read(File.join(__dir__, "app", "404.html")))
-            fs.write("public/500.html", File.read(File.join(__dir__, "app", "500.html")))
+            fs.write("public/404.html", file("404.html"))
+            fs.write("public/500.html", file("500.html"))
           end
 
           def template(path, context)
@@ -77,6 +79,10 @@ module Hanami
           end
 
           alias_method :t, :template
+
+          def file(path)
+            File.read(File.join(__dir__, "app", path))
+          end
         end
       end
     end

--- a/lib/hanami/cli/generators/gem/app/assets.mjs
+++ b/lib/hanami/cli/generators/gem/app/assets.mjs
@@ -1,0 +1,14 @@
+import * as assets from "hanami-assets";
+
+await assets.run();
+
+// To provide additional esbuild (https://esbuild.github.io) options, use the following:
+//
+// await assets.run({
+//   esbuildOptionsFn: (args, esbuildOptions) => {
+//     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
+//     // compile vs watch.
+//
+//     return esbuildOptions;
+//   }
+// });

--- a/lib/hanami/cli/generators/gem/app/package.json.erb
+++ b/lib/hanami/cli/generators/gem/app/package.json.erb
@@ -4,7 +4,7 @@
   "scripts": {
     "assets": "node config/assets.mjs"
   },
-  "devDependencies": {
+  "dependencies": {
     <%= hanami_assets_npm_package %>
   }
 }

--- a/lib/hanami/cli/generators/gem/app/package.json.erb
+++ b/lib/hanami/cli/generators/gem/app/package.json.erb
@@ -1,0 +1,10 @@
+{
+  "name": "<%= underscored_app_name %>",
+  "private": true,
+  "scripts": {
+    "assets": "node config/assets.mjs"
+  },
+  "devDependencies": {
+    <%= hanami_assets_npm_package %>
+  }
+}

--- a/lib/hanami/cli/generators/version.rb
+++ b/lib/hanami/cli/generators/version.rb
@@ -26,6 +26,18 @@ module Hanami
           "~> #{result}"
         end
 
+        def self.npm_package_requirement
+          result = version
+          # Change "2.1.0.beta2.1" to "2.1.0-beta.2" (the only format tolerable by `npm install`)
+          if prerelease?
+            result = result
+              .sub(/\.(alpha|beta|rc)/, '-\1')
+              .sub(/(alpha|beta|rc)(.+)\.(.+)$/, '\1.\2')
+          end
+
+          "^#{result}"
+        end
+
         # @since 2.0.0
         # @api private
         def self.prerelease?

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, :app do
 
   context "#call" do
     it "invokes hanami-assets executable" do
-      env = {"ESBUILD_ENTRY_POINTS" => "", "ESBUILD_OUTDIR" => File.join(Dir.pwd, "public", "assets")}
-      expect(system_call).to receive(:call).with("npm", "exec", "hanami-assets", env: hash_including(env))
+      expect(system_call).to receive(:call).with("npm run --silent", "assets")
 
       subject.call
     end

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, :app do
 
   context "#call" do
     it "invokes hanami-assets executable" do
-      env = {"ESBUILD_ENTRY_POINTS" => "", "ESBUILD_OUTDIR" => File.join(Dir.pwd, "public", "assets")}
-      expect(interactive_system_call).to receive(:call).with("npm", "exec", "hanami-assets", "--", "--watch", env: hash_including(env))
+      expect(interactive_system_call).to receive(:call).with("npm run --silent", "assets", "--", "--watch")
 
       subject.call
     end

--- a/spec/unit/hanami/cli/commands/app/install_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/install_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Install do
-  subject { described_class.new(system_call: system_call, out: stdout) }
+  subject { described_class.new(out: stdout) }
   let(:stdout) { StringIO.new }
-  let(:system_call) { instance_double(Hanami::CLI::SystemCall, call: successful_system_call_result) }
 
   describe "#call" do
     it "installs third-party plugins" do
@@ -11,23 +10,6 @@ RSpec.describe Hanami::CLI::Commands::App::Install do
 
       stdout.rewind
       expect(stdout.read.chomp).to eq("")
-    end
-
-    context "when hanami-assets is bundled" do
-      before do
-        allow(Hanami).to receive(:bundled?)
-        allow(Hanami).to receive(:bundled?).with("hanami-assets").and_return(true)
-
-        allow(system_call).to receive(:call).with("npm", ["init", "-y"])
-        allow(system_call).to receive(:call).with("npm", %w[install hanami-assets])
-      end
-
-      it "installs JavaScript deps" do
-        subject.call
-
-        stdout.rewind
-        expect(stdout.read.chomp).to eq("")
-      end
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -2,13 +2,14 @@
 
 RSpec.describe Hanami::CLI::Commands::Gem::New do
   subject do
-    described_class.new(bundler: bundler, out: out, fs: fs, inflector: inflector)
+    described_class.new(bundler: bundler, out: out, fs: fs, inflector: inflector, system_call: system_call)
   end
 
   let(:bundler) { Hanami::CLI::Bundler.new(fs: fs) }
   let(:out) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
+  let(:system_call) { instance_double(Hanami::CLI::SystemCall, call: successful_system_call_result) }
   let(:app) { "bookshelf" }
   let(:kwargs) { {head: hanami_head, skip_assets: skip_assets} }
 
@@ -53,6 +54,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     expect(bundler).to receive(:exec)
       .with("hanami install")
       .and_return(successful_system_call_result)
+
+    expect(system_call).to receive(:call).with("npm", ["install"])
 
     subject.call(app: app, **kwargs)
 
@@ -123,6 +126,23 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       expect(fs.read("Gemfile")).to eq(gemfile)
       expect(output).to include("Created Gemfile")
 
+      # package.json
+      hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
+      package_json = <<~EXPECTED
+        {
+          "name": "#{app}",
+          "private": true,
+          "scripts": {
+            "assets": "node config/assets.mjs"
+          },
+          "devDependencies": {
+            "hanami-assets": "#{hanami_npm_version}"
+          }
+        }
+      EXPECTED
+      expect(fs.read("package.json")).to eq(package_json)
+      expect(output).to include("Created package.json")
+
       # Procfile
       procfile = <<~EXPECTED
         web: bundle exec hanami server
@@ -164,6 +184,26 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       EXPECTED
       expect(fs.read("config/app.rb")).to eq(hanami_app)
       expect(output).to include("Created config/app.rb")
+
+      # config/assets.mjs
+      assets = <<~EXPECTED
+        import * as assets from "hanami-assets";
+
+        await assets.run();
+
+        // To provide additional esbuild (https://esbuild.github.io) options, use the following:
+        //
+        // await assets.run({
+        //   esbuildOptionsFn: (args, esbuildOptions) => {
+        //     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
+        //     // compile vs watch.
+        //
+        //     return esbuildOptions;
+        //   }
+        // });
+      EXPECTED
+      expect(fs.read("config/assets.mjs")).to eq(assets)
+      expect(output).to include("Created config/assets.mjs")
 
       # config/settings.rb
       settings = <<~EXPECTED
@@ -428,6 +468,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         .with("hanami install")
         .and_return(successful_system_call_result)
 
+      expect(system_call).not_to receive(:call).with("npm", ["install"])
+
       subject.call(app: app, **kwargs)
 
       expect(fs.directory?(app)).to be(true)
@@ -441,8 +483,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         # Gemfile
         expect(fs.read("Gemfile")).to_not match(/hanami-assets/)
 
+        # package.json
+        expect(fs.exist?("package.json")).to be(false)
+
         # Procfile.dev
         expect(fs.read("Procfile.dev")).to_not match(/hanami assets watch/)
+
+        # config/assets.mjs
+        expect(fs.exist?("config/assets.mjs")).to be(false)
 
         # app/templates/layouts/app.html.erb
         app_layout = fs.read("app/templates/layouts/app.html.erb")

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           "scripts": {
             "assets": "node config/assets.mjs"
           },
-          "devDependencies": {
+          "dependencies": {
             "hanami-assets": "#{hanami_npm_version}"
           }
         }


### PR DESCRIPTION
Prepare for our updated approach to assets chiefly introduced with https://github.com/hanami/assets-js/pull/10.

Update `hanami new`:

- Generate a new `config/assets.mjs` that will be needed for our new way of running the assets commands (see https://github.com/hanami/assets-js/pull/10)
- - Generate a leaner `package.json`, including an `"assets"` entry in the `"scripts"` section, referencing the above `config/assets.mjs` file.

Update the `hanami assets compile` and `hanami assets watch` commands:

- Expect to run assets via `npm run assets`, as generated in the new `package.json` above.
- Have these use a single hanami-assets setting for running these commands: `package_manager_run_command` (introduced in https://github.com/hanami/assets/pull/131), which defaults to `npm run`.