### PR TITLE
Stop generating a default root route

### DIFF
--- a/lib/hanami/cli/generators/gem/app/routes.erb
+++ b/lib/hanami/cli/generators/gem/app/routes.erb
@@ -2,6 +2,6 @@
 
 module <%= camelized_app_name %>
   class Routes < Hanami::Routes
-    root { "Hello from Hanami" }
+    # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
   end
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         module Bookshelf
           class Routes < Hanami::Routes
-            root { "Hello from Hanami" }
+            # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
           end
         end
       EXPECTED


### PR DESCRIPTION
Provide an explanatory comment inside the routes class instead.

This root route is no longer needed now that we’ll be providing a welcome view when no routes are defined (see https://github.com/hanami/hanami/pull/1353).