### PR TITLE
Include MethodOverride middleware in test output

### DIFF
--- a/spec/unit/hanami/cli/commands/app/middleware_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/middleware_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Hanami::CLI::Commands::App::Middleware, :app, :command do
     expect(output).to eq <<~OUTPUT
       /    Dry::Monitor::Rack::Middleware (instance)
       /    Hanami::Middleware::RenderErrors
+      /    Rack::MethodOverride
       /    Hanami::Middleware::Assets
     OUTPUT
   end


### PR DESCRIPTION
This is a new default middleware, as of https://github.com/hanami/hanami/pull/1344.

Update the tests to include this middleware to keep the build green here.