### PR TITLE
Generate bin/dev that installs foreman, and call from it from `hanami dev`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 
-gem "dry-files", github: "dry-rb/dry-files", branch: "add-chmod-support-to-file-system"
+gem "dry-files", github: "dry-rb/dry-files", branch: "main"
 
 gem "rack"
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 
+gem "dry-files", github: "dry-rb/dry-files", branch: "add-chmod-support-to-file-system"
+
 gem "rack"
 
 group :test do

--- a/lib/hanami/cli/commands/app/dev.rb
+++ b/lib/hanami/cli/commands/app/dev.rb
@@ -36,7 +36,7 @@ module Hanami
           # @since 2.1.0
           # @api private
           def executable
-            ["bin/dev"]
+            [::File.join("bin", "dev")]
           end
         end
       end

--- a/lib/hanami/cli/commands/app/dev.rb
+++ b/lib/hanami/cli/commands/app/dev.rb
@@ -15,16 +15,6 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          option :procfile, type: :string, desc: "Path to Procfile", aliases: ["-f"]
-
-          # @since 2.1.0
-          # @api private
-          example [
-            "-f /path/to/Procfile",
-          ]
-
-          # @since 2.1.0
-          # @api private
           def initialize(interactive_system_call: InteractiveSystemCall.new, **)
             @interactive_system_call = interactive_system_call
             super()
@@ -32,8 +22,8 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          def call(procfile: nil, **)
-            bin, args = executable(procfile: procfile)
+          def call(**)
+            bin, args = executable
             interactive_system_call.call(bin, *args)
           end
 
@@ -45,10 +35,8 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          def executable(procfile: nil)
-            # TODO: support other implementations of Foreman
-            # See: https://github.com/ddollar/foreman#ports
-            ["foreman", ["start", "-f", procfile || "Procfile.dev"]]
+          def executable
+            ["bin/dev"]
           end
         end
       end

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -43,6 +43,9 @@ module Hanami
             fs.write("Procfile.dev", t("procfile.erb", context))
             fs.write("config.ru", t("config_ru.erb", context))
 
+            fs.write("bin/dev", file("dev"))
+            fs.chmod("bin/dev", 0o755)
+
             fs.write("config/app.rb", t("app.erb", context))
             fs.write("config/settings.rb", t("settings.erb", context))
             fs.write("config/routes.rb", t("routes.erb", context))

--- a/lib/hanami/cli/generators/gem/app/dev
+++ b/lib/hanami/cli/generators/gem/app/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/spec/unit/hanami/cli/commands/app/dev_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/dev_spec.rb
@@ -3,25 +3,13 @@
 RSpec.describe Hanami::CLI::Commands::App::Dev do
   subject { described_class.new(interactive_system_call: interactive_system_call) }
   let(:interactive_system_call) { proc { |**| } }
-  let(:bin) { "foreman" }
-  let(:args) { ["start", "-f", "Procfile.dev"] }
+  let(:bin) { "bin/dev" }
 
   context "#call" do
     it "invokes external command to start Procfile based session" do
-      expect(interactive_system_call).to receive(:call).with(bin, *args)
+      expect(interactive_system_call).to receive(:call).with(bin)
 
       subject.call
-    end
-
-    context "with custom Procfile" do
-      let(:args) { ["start", "-f", procfile] }
-      let(:procfile) { "Procfile.test" }
-
-      it "invokes external command to start Procfile based session" do
-        expect(interactive_system_call).to receive(:call).with(bin, *args)
-
-        subject.call(procfile: procfile)
-      end
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -171,6 +171,21 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       expect(fs.read("config.ru")).to eq(config_ru)
       expect(output).to include("Created config.ru")
 
+      # bin/dev
+      bin_dev = <<~EXPECTED
+        #!/usr/bin/env sh
+
+        if ! gem list foreman -i --silent; then
+          echo "Installing foreman..."
+          gem install foreman
+        fi
+
+        exec foreman start -f Procfile.dev "$@"
+      EXPECTED
+      expect(fs.read("bin/dev")).to eq(bin_dev)
+      expect(fs.executable?("bin/dev")).to be(true)
+      expect(output).to include("Created bin/dev")
+
       # config/app.rb
       hanami_app = <<~EXPECTED
         # frozen_string_literal: true

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -143,13 +143,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       expect(fs.read("package.json")).to eq(package_json)
       expect(output).to include("Created package.json")
 
-      # Procfile
+      # Procfile.dev
       procfile = <<~EXPECTED
         web: bundle exec hanami server
         assets: bundle exec hanami assets watch
       EXPECTED
       expect(fs.read("Procfile.dev")).to eq(procfile)
-      expect(output).to include("Created Procfile")
+      expect(output).to include("Created Procfile.dev")
 
       # Rakefile
       rakefile = <<~EXPECTED


### PR DESCRIPTION
When generating a new app, create an executable `bin/dev` file with the following contents:

```sh
#!/usr/bin/env sh

if ! gem list foreman -i --silent; then
  echo "Installing foreman..."
  gem install foreman
fi

exec foreman start -f Procfile.dev "$@"
```

This ensures that the `foreman` gem is installed as part of the first start of Hanami without requiring any explicit user action.

From here, update `hanami dev` to become a simple wrapper for calling `bin/dev`.

This is in keeping with our recently adjusted approach for `hanami assets`, with its `compile` and `watch` subcommands are just simple wrappers for calling `npm run assets`.

From this arrangement, we get a few benefits:

1. As above, the user no longer has to explicitly install foreman, which streamlines the Hanami first run experience.
2. The user can now directly update their `bin/dev` to use a different process runner, if they prefer, or even add some other additional steps as required, all without us having to codify this or support our own adapters for different process runners.
3. After all of this, we still keep `hanami dev` as the “official” way of running the dev servers, which reserves us the opportunity to adjust how this works in future releases.

This change requires https://github.com/dry-rb/dry-files/pull/18 to be merged and a new dry-files release made before the next Hanami release.

Resolves #107.

### Verification

I tested this by manually installing dry-files and hanami-cli gems from my local source checkouts, and then running `hanami new two_one --head`.

Everything worked as expected:

```
❯ hanami new two_one --head
Created two_one/
-> Within two_one/
Created .gitignore
Created .env
Created README.md
Created Gemfile
Created Rakefile
Created Procfile.dev
Created config.ru
Created bin/dev
Created config/app.rb
Created config/settings.rb
Created config/routes.rb
Created config/puma.rb
Created lib/tasks/.keep
Created lib/two_one/types.rb
Created app/actions/.keep
Created app/action.rb
Created app/view.rb
Created app/views/helpers.rb
Created app/templates/layouts/app.html.erb
Created package.json
Created config/assets.mjs
Created app/assets/js/app.js
Created app/assets/css/app.css
Created app/assets/images/favicon.ico
Created public/404.html
Created public/500.html
Running Bundler install...
Running npm install...
Running Hanami install...

~/src/scratch
❯ cd two_one/

~/src/scratch/two_one
❯ be hanami dev
Installing foreman...
Successfully installed foreman-0.87.2
Parsing documentation for foreman-0.87.2
Installing ri documentation for foreman-0.87.2
Done installing documentation for foreman after 0 seconds
1 gem installed
15:59:44 web.1    | started with pid 56773
15:59:44 assets.1 | started with pid 56774
15:59:45 web.1    | 15:59:45 - INFO - Using Guardfile at /Users/tim/Source/scratch/two_one/Guardfile.
15:59:45 web.1    | 15:59:45 - INFO - Puma starting on port 2300 in development environment.
15:59:45 web.1    | 15:59:45 - INFO - Guard is now watching at '/Users/tim/Source/scratch/two_one'
15:59:45 assets.1 | [watch] build finished, watching for changes...
15:59:45 web.1    | Puma starting in single mode...
15:59:45 web.1    | * Puma version: 6.4.0 (ruby 3.2.0-p0) ("The Eagle of Durango")
15:59:45 web.1    | *  Min threads: 5
15:59:45 web.1    | *  Max threads: 5
15:59:45 web.1    | *  Environment: development
15:59:45 web.1    | *          PID: 56799
15:59:46 web.1    | * Listening on http://0.0.0.0:2300
15:59:46 web.1    | * Starting control server on http://127.0.0.1:9293
15:59:46 web.1    | * Starting control server on http://[::1]:9293
15:59:46 web.1    | Use Ctrl-C to stop
15:59:51 web.1    | [two_one] [INFO] [2023-10-16 15:59:51 +1100] GET 200 104µs 127.0.0.1 / -
```