### PR TITLE
Skip view RESTful view generation

### DIFF
--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -105,12 +105,15 @@ module Hanami
             fs.mkdir(directory = fs.join("app", "actions", controller))
             fs.write(fs.join(directory, "#{action}.rb"), t("action.erb", context))
 
-            if generate_view?(skip_view, action, directory)
-              fs.mkdir(directory = fs.join("app", "views", controller))
-              fs.write(fs.join(directory, "#{action}.rb"), t("view.erb", context))
+            view = action
+            view_directory = fs.join("app", "views", controller)
 
-              fs.mkdir(directory = fs.join("app", "templates", controller))
-              fs.write(fs.join(directory, "#{action}.#{format}.erb"),
+            if generate_view?(skip_view, view, view_directory)
+              fs.mkdir(view_directory)
+              fs.write(fs.join(view_directory, "#{view}.rb"), t("view.erb", context))
+
+              fs.mkdir(template_directory = fs.join("app", "templates", controller))
+              fs.write(fs.join(template_directory, "#{view}.#{format}.erb"),
                        t(template_with_format_ext("template", format), context))
             end
           end
@@ -127,31 +130,31 @@ module Hanami
 
           # @api private
           # @since 2.1.0
-          def generate_view?(skip_view, action, directory)
+          def generate_view?(skip_view, view, directory)
             return false if skip_view
-            return generate_restful_view?(action, directory) if rest_view?(action)
+            return generate_restful_view?(view, directory) if rest_view?(view)
 
             true
           end
 
           # @api private
           # @since 2.1.0
-          def generate_restful_view?(action, directory)
-            corresponding_action = corresponding_restful_action(action)
+          def generate_restful_view?(view, directory)
+            corresponding_action = corresponding_restful_view(view)
 
             !fs.exist?(fs.join(directory, "#{corresponding_action}.rb"))
           end
 
           # @api private
           # @since 2.1.0
-          def rest_view?(action)
-            RESTFUL_COUNTERPART_VIEWS.keys.include?(action)
+          def rest_view?(view)
+            RESTFUL_COUNTERPART_VIEWS.keys.include?(view)
           end
 
           # @api private
           # @since 2.1.0
-          def corresponding_restful_action(action)
-            RESTFUL_COUNTERPART_VIEWS.fetch(action, nil)
+          def corresponding_restful_view(view)
+            RESTFUL_COUNTERPART_VIEWS.fetch(view, nil)
           end
 
           def template_with_format_ext(name, format)

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -97,7 +97,7 @@ module Hanami
             fs.mkdir(directory = fs.join("app", "actions", controller))
             fs.write(fs.join(directory, "#{action}.rb"), t("action.erb", context))
 
-            unless skip_view
+            if generate_view?(skip_view, action, directory)
               fs.mkdir(directory = fs.join("app", "views", controller))
               fs.write(fs.join(directory, "#{action}.rb"), t("view.erb", context))
 
@@ -115,6 +115,34 @@ module Hanami
           def route(controller, action, url, http)
             %(#{route_http(action,
                            http)} "#{route_url(controller, action, url)}", to: "#{controller.join('.')}.#{action}")
+          end
+
+          def generate_view?(skip_view, action, directory)
+            return false if skip_view
+            return generate_restful_view?(action, directory) if rest_view?(action)
+
+            true
+          end
+
+          def generate_restful_view?(action, directory)
+            corresponding_action = corresponding_restful_action(action)
+
+            !fs.exist?(fs.join(directory, "#{corresponding_action}.rb"))
+          end
+
+          # TODO: refactor
+          def rest_view?(action)
+            %w[create update].include?(action)
+          end
+
+          # TODO: refactor
+          def corresponding_restful_action(action)
+            case action
+            when "create"
+              "new"
+            when "update"
+              "edit"
+            end
           end
 
           def template_with_format_ext(name, format)

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -56,6 +56,14 @@ module Hanami
           }.freeze
           private_constant :ROUTE_RESTFUL_URL_SUFFIXES
 
+          # @api private
+          # @since 2.1.0
+          RESTFUL_ACTIONS = {
+            "create" => "new",
+            "update" => "edit"
+          }.freeze
+          private_constant :RESTFUL_ACTIONS
+
           PATH_SEPARATOR = "/"
           private_constant :PATH_SEPARATOR
 
@@ -130,19 +138,16 @@ module Hanami
             !fs.exist?(fs.join(directory, "#{corresponding_action}.rb"))
           end
 
-          # TODO: refactor
+          # @api private
+          # @since 2.1.0
           def rest_view?(action)
-            %w[create update].include?(action)
+            RESTFUL_ACTIONS.keys.include?(action)
           end
 
-          # TODO: refactor
+          # @api private
+          # @since 2.1.0
           def corresponding_restful_action(action)
-            case action
-            when "create"
-              "new"
-            when "update"
-              "edit"
-            end
+            RESTFUL_ACTIONS.fetch(action, nil)
           end
 
           def template_with_format_ext(name, format)

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -85,7 +85,7 @@ module Hanami
             fs.mkdir(directory = fs.join(slice_directory, "actions", controller))
             fs.write(fs.join(directory, "#{action}.rb"), t("slice_action.erb", context))
 
-            unless skip_view
+            if generate_view?(skip_view, action, directory)
               fs.mkdir(directory = fs.join(slice_directory, "views", controller))
               fs.write(fs.join(directory, "#{action}.rb"), t("slice_view.erb", context))
 
@@ -125,6 +125,8 @@ module Hanami
                            http)} "#{route_url(controller, action, url)}", to: "#{controller.join('.')}.#{action}")
           end
 
+          # @api private
+          # @since 2.1.0
           def generate_view?(skip_view, action, directory)
             return false if skip_view
             return generate_restful_view?(action, directory) if rest_view?(action)
@@ -132,6 +134,8 @@ module Hanami
             true
           end
 
+          # @api private
+          # @since 2.1.0
           def generate_restful_view?(action, directory)
             corresponding_action = corresponding_restful_action(action)
 

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -58,11 +58,11 @@ module Hanami
 
           # @api private
           # @since 2.1.0
-          RESTFUL_ACTIONS = {
+          RESTFUL_COUNTERPART_VIEWS = {
             "create" => "new",
             "update" => "edit"
           }.freeze
-          private_constant :RESTFUL_ACTIONS
+          private_constant :RESTFUL_COUNTERPART_VIEWS
 
           PATH_SEPARATOR = "/"
           private_constant :PATH_SEPARATOR
@@ -145,13 +145,13 @@ module Hanami
           # @api private
           # @since 2.1.0
           def rest_view?(action)
-            RESTFUL_ACTIONS.keys.include?(action)
+            RESTFUL_COUNTERPART_VIEWS.keys.include?(action)
           end
 
           # @api private
           # @since 2.1.0
           def corresponding_restful_action(action)
-            RESTFUL_ACTIONS.fetch(action, nil)
+            RESTFUL_COUNTERPART_VIEWS.fetch(action, nil)
           end
 
           def template_with_format_ext(name, format)

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -435,83 +435,149 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           end
         end
 
-        it "generates view when New view is NOT present" do
-          context = Hanami::CLI::Generators::App::ActionContext.new(inflector, app, nil, [controller], action)
-          allow(context).to receive(:bundled_views?) { true }
+        context "when New view is NOT present" do
+          it "generates view" do
+            context = Hanami::CLI::Generators::App::ActionContext.new(inflector, app, nil, [controller], action)
+            allow(context).to receive(:bundled_views?) { true }
 
-          within_application_directory do
-            # Prepare
-            routes = <<~CODE
-              # frozen_string_literal: true
+            within_application_directory do
+              # Prepare
+              routes = <<~CODE
+                # frozen_string_literal: true
 
-              require "hanami/routes"
+                require "hanami/routes"
 
-              module #{app}
-                class Routes < Hanami::Routes
+                module #{app}
+                  class Routes < Hanami::Routes
+                  end
                 end
-              end
-            CODE
+              CODE
 
-            fs.write("config/routes.rb", routes)
+              fs.write("config/routes.rb", routes)
 
-            # Invoke the generator
-            subject.call(name: action_name, context: context)
+              # Invoke the generator
+              subject.call(name: action_name, context: context)
 
-            # Verify
-            expected_routes = <<~CODE
-              # frozen_string_literal: true
+              # Verify
+              expected_routes = <<~CODE
+                # frozen_string_literal: true
 
-              require "hanami/routes"
+                require "hanami/routes"
 
-              module #{app}
-                class Routes < Hanami::Routes
-                  post "/users", to: "users.create"
+                module #{app}
+                  class Routes < Hanami::Routes
+                    post "/users", to: "users.create"
+                  end
                 end
-              end
-            CODE
+              CODE
 
-            # route
-            expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("Updated config/routes.rb")
+              # route
+              expect(fs.read("config/routes.rb")).to eq(expected_routes)
+              expect(output).to include("Updated config/routes.rb")
 
-            expected_action = <<~CODE
-              # frozen_string_literal: true
+              expected_action = <<~CODE
+                # frozen_string_literal: true
 
-              module #{app}
-                module Actions
-                  module Users
-                    class Create < #{app}::Action
-                      def handle(request, response)
+                module #{app}
+                  module Actions
+                    module Users
+                      class Create < #{app}::Action
+                        def handle(request, response)
+                        end
                       end
                     end
                   end
                 end
-              end
-            CODE
-            expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
-            expect(output).to include("Created app/actions/users/create.rb")
+              CODE
+              expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
+              expect(output).to include("Created app/actions/users/create.rb")
 
-            expected_view = <<~CODE
-              # frozen_string_literal: true
+              expected_view = <<~CODE
+                # frozen_string_literal: true
 
-              module #{app}
-                module Views
-                  module Users
-                    class Create < #{app}::View
+                module #{app}
+                  module Views
+                    module Users
+                      class Create < #{app}::View
+                      end
                     end
                   end
                 end
-              end
-            CODE
-            expect(fs.read("app/views/users/create.rb")).to eq(expected_view)
-            expect(output).to include("Created app/views/users/create.rb")
+              CODE
+              expect(fs.read("app/views/users/create.rb")).to eq(expected_view)
+              expect(output).to include("Created app/views/users/create.rb")
 
-            expected_template = <<~EXPECTED
-              <h1>#{inflector.camelize(app)}::Views::Users::Create</h1>
-            EXPECTED
+              expected_template = <<~EXPECTED
+                <h1>#{inflector.camelize(app)}::Views::Users::Create</h1>
+              EXPECTED
 
-            expect(fs.read("app/templates/users/create.html.erb")).to eq(expected_template)
-            expect(output).to include("Created app/templates/users/create.html.erb")
+              expect(fs.read("app/templates/users/create.html.erb")).to eq(expected_template)
+              expect(output).to include("Created app/templates/users/create.html.erb")
+            end
+          end
+
+          it "skips view generation if --skip-view is used" do
+            context = Hanami::CLI::Generators::App::ActionContext.new(inflector, app, nil, [controller], action)
+            allow(context).to receive(:bundled_views?) { true }
+
+            within_application_directory do
+              # Prepare
+              routes = <<~CODE
+                # frozen_string_literal: true
+
+                require "hanami/routes"
+
+                module #{app}
+                  class Routes < Hanami::Routes
+                  end
+                end
+              CODE
+
+              fs.write("config/routes.rb", routes)
+
+              # Invoke the generator
+              subject.call(name: action_name, skip_view: true, context: context)
+
+              # Verify
+              expected_routes = <<~CODE
+                # frozen_string_literal: true
+
+                require "hanami/routes"
+
+                module #{app}
+                  class Routes < Hanami::Routes
+                    post "/users", to: "users.create"
+                  end
+                end
+              CODE
+
+              # route
+              expect(fs.read("config/routes.rb")).to eq(expected_routes)
+              expect(output).to include("Updated config/routes.rb")
+
+              expected_action = <<~CODE
+                # frozen_string_literal: true
+
+                module #{app}
+                  module Actions
+                    module Users
+                      class Create < #{app}::Action
+                        def handle(request, response)
+                        end
+                      end
+                    end
+                  end
+                end
+              CODE
+              expect(fs.read("app/actions/users/create.rb")).to eq(expected_action)
+              expect(output).to include("Created app/actions/users/create.rb")
+
+              expect(fs.exist?("app/views/users/create.rb")).to be(false)
+              expect(fs.exist?("app/templates/users/create.html.erb")).to be(false)
+
+              expect(output).to_not include("Created app/views/users/create.rb")
+              expect(output).to_not include("Created app/templates/users/create.html.erb")
+            end
           end
         end
       end
@@ -617,83 +683,149 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           end
         end
 
-        it "generates view when Edit view is NOT present" do
-          context = Hanami::CLI::Generators::App::ActionContext.new(inflector, app, nil, [controller], action)
-          allow(context).to receive(:bundled_views?) { true }
+        context "when Edit view is NOT present" do
+          it "generates view" do
+            context = Hanami::CLI::Generators::App::ActionContext.new(inflector, app, nil, [controller], action)
+            allow(context).to receive(:bundled_views?) { true }
 
-          within_application_directory do
-            # Prepare
-            routes = <<~CODE
-              # frozen_string_literal: true
+            within_application_directory do
+              # Prepare
+              routes = <<~CODE
+                # frozen_string_literal: true
 
-              require "hanami/routes"
+                require "hanami/routes"
 
-              module #{app}
-                class Routes < Hanami::Routes
+                module #{app}
+                  class Routes < Hanami::Routes
+                  end
                 end
-              end
-            CODE
+              CODE
 
-            fs.write("config/routes.rb", routes)
+              fs.write("config/routes.rb", routes)
 
-            # Invoke the generator
-            subject.call(name: action_name, context: context)
+              # Invoke the generator
+              subject.call(name: action_name, context: context)
 
-            # Verify
-            expected_routes = <<~CODE
-              # frozen_string_literal: true
+              # Verify
+              expected_routes = <<~CODE
+                # frozen_string_literal: true
 
-              require "hanami/routes"
+                require "hanami/routes"
 
-              module #{app}
-                class Routes < Hanami::Routes
-                  patch "/users/:id", to: "users.update"
+                module #{app}
+                  class Routes < Hanami::Routes
+                    patch "/users/:id", to: "users.update"
+                  end
                 end
-              end
-            CODE
+              CODE
 
-            # route
-            expect(fs.read("config/routes.rb")).to eq(expected_routes)
-            expect(output).to include("Updated config/routes.rb")
+              # route
+              expect(fs.read("config/routes.rb")).to eq(expected_routes)
+              expect(output).to include("Updated config/routes.rb")
 
-            expected_action = <<~CODE
-              # frozen_string_literal: true
+              expected_action = <<~CODE
+                # frozen_string_literal: true
 
-              module #{app}
-                module Actions
-                  module Users
-                    class Update < #{app}::Action
-                      def handle(request, response)
+                module #{app}
+                  module Actions
+                    module Users
+                      class Update < #{app}::Action
+                        def handle(request, response)
+                        end
                       end
                     end
                   end
                 end
-              end
-            CODE
-            expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
-            expect(output).to include("Created app/actions/users/update.rb")
+              CODE
+              expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
+              expect(output).to include("Created app/actions/users/update.rb")
 
-            expected_view = <<~CODE
-              # frozen_string_literal: true
+              expected_view = <<~CODE
+                # frozen_string_literal: true
 
-              module #{app}
-                module Views
-                  module Users
-                    class Update < #{app}::View
+                module #{app}
+                  module Views
+                    module Users
+                      class Update < #{app}::View
+                      end
                     end
                   end
                 end
-              end
-            CODE
-            expect(fs.read("app/views/users/update.rb")).to eq(expected_view)
-            expect(output).to include("Created app/views/users/update.rb")
+              CODE
+              expect(fs.read("app/views/users/update.rb")).to eq(expected_view)
+              expect(output).to include("Created app/views/users/update.rb")
 
-            expected_template = <<~EXPECTED
-              <h1>#{inflector.camelize(app)}::Views::Users::Update</h1>
-            EXPECTED
+              expected_template = <<~EXPECTED
+                <h1>#{inflector.camelize(app)}::Views::Users::Update</h1>
+              EXPECTED
 
-            expect(fs.read("app/templates/users/update.html.erb")).to eq(expected_template)
-            expect(output).to include("Created app/templates/users/update.html.erb")
+              expect(fs.read("app/templates/users/update.html.erb")).to eq(expected_template)
+              expect(output).to include("Created app/templates/users/update.html.erb")
+            end
+          end
+
+          it "skips view if --skip-view is used" do
+            context = Hanami::CLI::Generators::App::ActionContext.new(inflector, app, nil, [controller], action)
+            allow(context).to receive(:bundled_views?) { true }
+
+            within_application_directory do
+              # Prepare
+              routes = <<~CODE
+                # frozen_string_literal: true
+
+                require "hanami/routes"
+
+                module #{app}
+                  class Routes < Hanami::Routes
+                  end
+                end
+              CODE
+
+              fs.write("config/routes.rb", routes)
+
+              # Invoke the generator
+              subject.call(name: action_name, skip_view: true, context: context)
+
+              # Verify
+              expected_routes = <<~CODE
+                # frozen_string_literal: true
+
+                require "hanami/routes"
+
+                module #{app}
+                  class Routes < Hanami::Routes
+                    patch "/users/:id", to: "users.update"
+                  end
+                end
+              CODE
+
+              # route
+              expect(fs.read("config/routes.rb")).to eq(expected_routes)
+              expect(output).to include("Updated config/routes.rb")
+
+              expected_action = <<~CODE
+                # frozen_string_literal: true
+
+                module #{app}
+                  module Actions
+                    module Users
+                      class Update < #{app}::Action
+                        def handle(request, response)
+                        end
+                      end
+                    end
+                  end
+                end
+              CODE
+              expect(fs.read("app/actions/users/update.rb")).to eq(expected_action)
+              expect(output).to include("Created app/actions/users/update.rb")
+
+              expect(fs.exist?("app/views/users/update.rb")).to be(false)
+              expect(fs.exist?("app/templates/users/update.html.erb")).to be(false)
+
+              expect(output).to_not include("Created app/views/users/update.rb")
+              expect(output).to_not include("Created app/templates/users/update.html.erb")
+            end
           end
         end
       end

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -837,102 +837,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
     before { prepare_slice! }
 
-    it "generates action" do
-      within_application_directory do
-        prepare_slice!
-
-        subject.call(name: action_name, slice: slice)
-
-        # Route
-        routes = <<~CODE
-          # frozen_string_literal: true
-
-          require "hanami/routes"
-
-          module #{app}
-            class Routes < Hanami::Routes
-              root { "Hello from Hanami" }
-
-              slice :#{slice}, at: "/#{slice}" do
-                get "/users", to: "users.index"
-              end
-            end
-          end
-        CODE
-
-        # route
-        expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include("Updated config/routes.rb")
-        expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
-
-        # action
-        expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
-        expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
-
-        action_file = <<~EXPECTED
-          # frozen_string_literal: true
-
-          module #{inflector.camelize(slice)}
-            module Actions
-              module #{inflector.camelize(controller)}
-                class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
-                  def handle(request, response)
-                    response.body = self.class.name
-                  end
-                end
-              end
-            end
-          end
-        EXPECTED
-        expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
-        expect(output).to include("Created slices/#{slice}/actions/#{controller}/#{action}.rb")
-
-        # # view
-        # expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(true)
-        # expect(output).to include("Created slices/#{slice}/views/#{controller}/")
-        #
-        # view_file = <<~EXPECTED
-        #   # auto_register: false
-        #   # frozen_string_literal: true
-        #
-        #   require "#{inflector.underscore(slice)}/view"
-        #
-        #   module #{inflector.camelize(slice)}
-        #     module Views
-        #       module #{inflector.camelize(controller)}
-        #         class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
-        #         end
-        #       end
-        #     end
-        #   end
-        # EXPECTED
-        # expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
-        # expect(output).to include("Created slices/#{slice}/views/#{controller}/#{action}.rb")
-
-        # template
-        # expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
-        # expect(output).to include("Created slices/#{slice}/templates/#{controller}/")
-        #
-        # template_file = <<~EXPECTED
-        #   <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
-        #   <h2>slices/#{slice}/templates/#{controller}/#{action}.html.erb</h2>
-        # EXPECTED
-        # expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
-        # expect(output).to include("Created slices/#{slice}/templates/#{controller}/#{action}.html.erb")
-      end
-    end
-
-    context "deeply nested action" do
-      let(:controller) { %w[books bestsellers nonfiction] }
-      let(:controller_name) { controller.join(".") }
-      let(:action) { "index" }
-      let(:action_name) { "#{controller_name}.#{action}" }
-
+    context "without hanami view bundled" do
       it "generates action" do
         within_application_directory do
           prepare_slice!
 
-          subject.call(slice: slice, name: action_name)
+          subject.call(name: action_name, slice: slice)
 
           # Route
           routes = <<~CODE
@@ -945,7 +855,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
                 root { "Hello from Hanami" }
 
                 slice :#{slice}, at: "/#{slice}" do
-                  get "/books/bestsellers/nonfiction", to: "books.bestsellers.nonfiction.index"
+                  get "/users", to: "users.index"
                 end
               end
             end
@@ -953,120 +863,380 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
           # route
           expect(fs.read("config/routes.rb")).to eq(routes)
+          expect(output).to include("Updated config/routes.rb")
+          expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
 
           # action
-          expect(fs.directory?("slices/#{slice}/actions/books/bestsellers/nonfiction")).to be(true)
+          expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
+          expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
 
           action_file = <<~EXPECTED
             # frozen_string_literal: true
 
             module #{inflector.camelize(slice)}
               module Actions
-                module Books
-                  module Bestsellers
-                    module Nonfiction
-                      class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
-                        def handle(request, response)
-                          response.body = self.class.name
-                        end
-                      end
+                module #{inflector.camelize(controller)}
+                  class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
+                    def handle(request, response)
+                      response.body = self.class.name
                     end
                   end
                 end
               end
             end
           EXPECTED
-          expect(fs.read("slices/#{slice}/actions/books/bestsellers/nonfiction/#{action}.rb")).to eq(action_file)
+          expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
+          expect(output).to include("Created slices/#{slice}/actions/#{controller}/#{action}.rb")
 
           # view
-          expect(fs.directory?("slices/#{slice}/views/books/bestsellers/nonfiction")).to be(true)
+          expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(true)
+          expect(output).to include("Created slices/#{slice}/views/#{controller}/")
 
           view_file = <<~EXPECTED
             # frozen_string_literal: true
 
             module #{inflector.camelize(slice)}
               module Views
-                module Books
-                  module Bestsellers
-                    module Nonfiction
-                      class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
-                      end
-                    end
+                module #{inflector.camelize(controller)}
+                  class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
                   end
                 end
               end
             end
           EXPECTED
-          expect(fs.read("slices/#{slice}/views/books/bestsellers/nonfiction/#{action}.rb")).to eq(view_file)
+          expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
+          expect(output).to include("Created slices/#{slice}/views/#{controller}/#{action}.rb")
 
           # template
-          expect(fs.directory?("slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
+          expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
+          expect(output).to include("Created slices/#{slice}/templates/#{controller}/")
 
           template_file = <<~EXPECTED
-            <h1>#{inflector.camelize(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
+            <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
           EXPECTED
-          expect(fs.read("slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb")).to eq(template_file)
+          expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
+          expect(output).to include("Created slices/#{slice}/templates/#{controller}/#{action}.html.erb")
         end
       end
-    end
 
-    it "appends routes within the proper slice block" do
-      within_application_directory do
-        prepare_slice!
-        fs.mkdir("slices/api")
+      context "deeply nested action" do
+        let(:controller) { %w[books bestsellers nonfiction] }
+        let(:controller_name) { controller.join(".") }
+        let(:action) { "index" }
+        let(:action_name) { "#{controller_name}.#{action}" }
 
-        routes_contents = <<~CODE
-          # frozen_string_literal: true
+        it "generates action" do
+          within_application_directory do
+            prepare_slice!
 
-          require "hanami/routes"
+            subject.call(slice: slice, name: action_name)
 
-          module #{app}
-            class Routes < Hanami::Routes
-              root { "Hello from Hanami" }
+            # Route
+            routes = <<~CODE
+              # frozen_string_literal: true
 
-              slice :#{slice}, at: "/#{slice}" do
-                root to: "home.index"
+              require "hanami/routes"
+
+              module #{app}
+                class Routes < Hanami::Routes
+                  root { "Hello from Hanami" }
+
+                  slice :#{slice}, at: "/#{slice}" do
+                    get "/books/bestsellers/nonfiction", to: "books.bestsellers.nonfiction.index"
+                  end
+                end
               end
+            CODE
 
-              slice :api, at: "/api" do
-                root to: "home.index"
+            # route
+            expect(fs.read("config/routes.rb")).to eq(routes)
+
+            # action
+            expect(fs.directory?("slices/#{slice}/actions/books/bestsellers/nonfiction")).to be(true)
+
+            action_file = <<~EXPECTED
+              # frozen_string_literal: true
+
+              module #{inflector.camelize(slice)}
+                module Actions
+                  module Books
+                    module Bestsellers
+                      module Nonfiction
+                        class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
+                          def handle(request, response)
+                            response.body = self.class.name
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
               end
-            end
+            EXPECTED
+            expect(fs.read("slices/#{slice}/actions/books/bestsellers/nonfiction/#{action}.rb")).to eq(action_file)
+
+            # view
+            expect(fs.directory?("slices/#{slice}/views/books/bestsellers/nonfiction")).to be(true)
+
+            view_file = <<~EXPECTED
+              # frozen_string_literal: true
+
+              module #{inflector.camelize(slice)}
+                module Views
+                  module Books
+                    module Bestsellers
+                      module Nonfiction
+                        class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            EXPECTED
+            expect(fs.read("slices/#{slice}/views/books/bestsellers/nonfiction/#{action}.rb")).to eq(view_file)
+
+            # template
+            expect(fs.directory?("slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
+
+            template_file = <<~EXPECTED
+              <h1>#{inflector.camelize(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
+            EXPECTED
+            expect(fs.read("slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb")).to eq(template_file)
           end
-        CODE
-        fs.write("config/routes.rb", routes_contents)
-
-        expected = <<~CODE
-          # frozen_string_literal: true
-
-          require "hanami/routes"
-
-          module #{app}
-            class Routes < Hanami::Routes
-              root { "Hello from Hanami" }
-
-              slice :#{slice}, at: "/#{slice}" do
-                root to: "home.index"
-                get "/users", to: "users.index"
-              end
-
-              slice :api, at: "/api" do
-                root to: "home.index"
-                get "/users/:id", to: "users.show"
-              end
-            end
-          end
-        CODE
-
-        subject.call(slice: slice, name: "users.index")
-        subject.call(slice: "api", name: "users.show")
-
-        expect(fs.read("config/routes.rb")).to eq(expected)
+        end
       end
-    end
 
-    it "raises error if slice is unexisting" do
-      expect { subject.call(slice: "foo", name: action_name) }.to raise_error(Hanami::CLI::MissingSliceError, "slice `foo' is missing, please generate with `hanami generate slice foo'")
+      context "with hanami view bundled" do
+        it "generates action with view" do
+          within_application_directory do
+            prepare_slice!
+            context = Hanami::CLI::Generators::App::ActionContext.new(inflector, app, slice, [controller], action)
+            allow(context).to receive(:bundled_views?) { true }
+
+            subject.call(name: action_name, slice: slice, context: context)
+
+            # Route
+            routes = <<~CODE
+              # frozen_string_literal: true
+
+              require "hanami/routes"
+
+              module #{app}
+                class Routes < Hanami::Routes
+                  root { "Hello from Hanami" }
+
+                  slice :#{slice}, at: "/#{slice}" do
+                    get "/users", to: "users.index"
+                  end
+                end
+              end
+            CODE
+
+            # route
+            expect(fs.read("config/routes.rb")).to eq(routes)
+            expect(output).to include("Updated config/routes.rb")
+            expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
+
+            # action
+            expect(fs.directory?("slices/#{slice}/actions/#{controller}")).to be(true)
+            expect(output).to include("Created slices/#{slice}/actions/#{controller}/")
+
+            action_file = <<~EXPECTED
+              # frozen_string_literal: true
+
+              module #{inflector.camelize(slice)}
+                module Actions
+                  module #{inflector.camelize(controller)}
+                    class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
+                      def handle(request, response)
+                      end
+                    end
+                  end
+                end
+              end
+            EXPECTED
+            expect(fs.read("slices/#{slice}/actions/#{controller}/#{action}.rb")).to eq(action_file)
+            expect(output).to include("Created slices/#{slice}/actions/#{controller}/#{action}.rb")
+
+            # view
+            expect(fs.directory?("slices/#{slice}/views/#{controller}")).to be(true)
+            expect(output).to include("Created slices/#{slice}/views/#{controller}/")
+
+            view_file = <<~EXPECTED
+              # frozen_string_literal: true
+
+              module #{inflector.camelize(slice)}
+                module Views
+                  module #{inflector.camelize(controller)}
+                    class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
+                    end
+                  end
+                end
+              end
+            EXPECTED
+            expect(fs.read("slices/#{slice}/views/#{controller}/#{action}.rb")).to eq(view_file)
+            expect(output).to include("Created slices/#{slice}/views/#{controller}/#{action}.rb")
+
+            # template
+            expect(fs.directory?("slices/#{slice}/templates/#{controller}")).to be(true)
+            expect(output).to include("Created slices/#{slice}/templates/#{controller}/")
+
+            template_file = <<~EXPECTED
+              <h1>#{inflector.camelize(slice)}::Views::#{inflector.camelize(controller)}::#{inflector.camelize(action)}</h1>
+            EXPECTED
+            expect(fs.read("slices/#{slice}/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
+            expect(output).to include("Created slices/#{slice}/templates/#{controller}/#{action}.html.erb")
+          end
+        end
+      end
+
+      context "deeply nested action" do
+        let(:controller) { %w[books bestsellers nonfiction] }
+        let(:controller_name) { controller.join(".") }
+        let(:action) { "index" }
+        let(:action_name) { "#{controller_name}.#{action}" }
+
+        it "generates action" do
+          within_application_directory do
+            prepare_slice!
+
+            subject.call(slice: slice, name: action_name)
+
+            # Route
+            routes = <<~CODE
+              # frozen_string_literal: true
+
+              require "hanami/routes"
+
+              module #{app}
+                class Routes < Hanami::Routes
+                  root { "Hello from Hanami" }
+
+                  slice :#{slice}, at: "/#{slice}" do
+                    get "/books/bestsellers/nonfiction", to: "books.bestsellers.nonfiction.index"
+                  end
+                end
+              end
+            CODE
+
+            # route
+            expect(fs.read("config/routes.rb")).to eq(routes)
+
+            # action
+            expect(fs.directory?("slices/#{slice}/actions/books/bestsellers/nonfiction")).to be(true)
+
+            action_file = <<~EXPECTED
+              # frozen_string_literal: true
+
+              module #{inflector.camelize(slice)}
+                module Actions
+                  module Books
+                    module Bestsellers
+                      module Nonfiction
+                        class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::Action
+                          def handle(request, response)
+                            response.body = self.class.name
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            EXPECTED
+            expect(fs.read("slices/#{slice}/actions/books/bestsellers/nonfiction/#{action}.rb")).to eq(action_file)
+
+            # view
+            expect(fs.directory?("slices/#{slice}/views/books/bestsellers/nonfiction")).to be(true)
+
+            view_file = <<~EXPECTED
+              # frozen_string_literal: true
+
+              module #{inflector.camelize(slice)}
+                module Views
+                  module Books
+                    module Bestsellers
+                      module Nonfiction
+                        class #{inflector.camelize(action)} < #{inflector.camelize(slice)}::View
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            EXPECTED
+            expect(fs.read("slices/#{slice}/views/books/bestsellers/nonfiction/#{action}.rb")).to eq(view_file)
+
+            # template
+            expect(fs.directory?("slices/#{slice}/templates/books/bestsellers/nonfiction")).to be(true)
+
+            template_file = <<~EXPECTED
+              <h1>#{inflector.camelize(slice)}::Views::Books::Bestsellers::Nonfiction::Index</h1>
+            EXPECTED
+            expect(fs.read("slices/#{slice}/templates/books/bestsellers/nonfiction/#{action}.html.erb")).to eq(template_file)
+          end
+        end
+      end
+
+      it "appends routes within the proper slice block" do
+        within_application_directory do
+          prepare_slice!
+          fs.mkdir("slices/api")
+
+          routes_contents = <<~CODE
+            # frozen_string_literal: true
+
+            require "hanami/routes"
+
+            module #{app}
+              class Routes < Hanami::Routes
+                root { "Hello from Hanami" }
+
+                slice :#{slice}, at: "/#{slice}" do
+                  root to: "home.index"
+                end
+
+                slice :api, at: "/api" do
+                  root to: "home.index"
+                end
+              end
+            end
+          CODE
+          fs.write("config/routes.rb", routes_contents)
+
+          expected = <<~CODE
+            # frozen_string_literal: true
+
+            require "hanami/routes"
+
+            module #{app}
+              class Routes < Hanami::Routes
+                root { "Hello from Hanami" }
+
+                slice :#{slice}, at: "/#{slice}" do
+                  root to: "home.index"
+                  get "/users", to: "users.index"
+                end
+
+                slice :api, at: "/api" do
+                  root to: "home.index"
+                  get "/users/:id", to: "users.show"
+                end
+              end
+            end
+          CODE
+
+          subject.call(slice: slice, name: "users.index")
+          subject.call(slice: "api", name: "users.show")
+
+          expect(fs.read("config/routes.rb")).to eq(expected)
+        end
+      end
+
+      it "raises error if slice is unexisting" do
+        expect { subject.call(slice: "foo", name: action_name) }.to raise_error(Hanami::CLI::MissingSliceError, "slice `foo' is missing, please generate with `hanami generate slice foo'")
+      end
     end
   end
 


### PR DESCRIPTION
## Enhancement

When generating Create and Update actions, skip the view generation if the corresponding RESTful actions are there.

| Action | Corresponding RESTFul Action |
|--------|--------|
| Create | New |
| Update | Edit | 

This behavior is replicated for slices as well.

### Case 1. Generating Create when New is present

Skips the view creation:

```shell
⚡ bundle exec hanami generate action books.create
Updated config/routes.rb
Created app/actions/books/create.rb
Created spec/actions/books/create_spec.rb
```

### Case 2. Generating Create when New is NOT present

It generates the view:

```shell
⚡ bundle exec hanami generate action authors.create
Updated config/routes.rb
Created app/actions/authors/
Created app/actions/authors/create.rb
Created app/views/authors/
Created app/views/authors/create.rb
Created app/templates/authors/
Created app/templates/authors/create.html.erb
Created spec/actions/authors/create_spec.rb
```

### Case 3. Generating Create when New is NOT present, but using `--skip-view`

It respects the `--skip-view` flag and forces the view creation skip.

```shell
⚡ bundle exec hanami generate action chapters.create --skip-view
Updated config/routes.rb
Created app/actions/chapters/
Created app/actions/chapters/create.rb
Created spec/actions/chapters/create_spec.rb
```

---

Closes https://github.com/hanami/cli/issues/105