### PR TITLE
Add new error page designs

### DIFF
--- a/lib/hanami/cli/generators/gem/app/404.html
+++ b/lib/hanami/cli/generators/gem/app/404.html
@@ -1,11 +1,82 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>The page you were looking for doesn’t exist (404)</title>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The page you were looking for doesn’t exist (404)</title>
+  <style>
+    :root {
+      --foreground-rgb: 0, 0, 0;
+      --background-rgb: 255, 255, 255;
+      --font-sans: ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --foreground-rgb: 255, 255, 255;
+        --background-rgb: 0, 0, 0;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body,
+    html {
+      max-width: 100vw;
+      overflow-x: hidden;
+      font-size: 100%;
+    }
+
+    body {
+      color: rgb(var(--foreground-rgb));
+      background: rgb(var(--background-rgb));
+      font-family: var(--font-sans);
+      font-style: normal;
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      padding: 0 4vw;
+    }
+
+    .message {
+      display: flex;
+      gap: 1rem;
+      flex-direction: column;
+      text-align: center;
+    }
+
+    .message h1 {
+      font-size: 2rem;
+      font-weight: 500;
+    }
+
+    p {
+      line-height: 1.6;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      html {
+        color-scheme: dark;
+      }
+    }
+  </style>
   </head>
   <body>
     <!-- This file lives in public/404.html -->
-    <h1>The page you were looking for doesn’t exist.</h1>
-    <p>You may have mistyped the address or the page may have moved.</p>
+    <main>
+      <div class="message">
+        <h1>404</h1>
+        <p>The page you were looking for doesn’t exist.</p>
+      </div>
+    </main>
   </body>
 </html>

--- a/lib/hanami/cli/generators/gem/app/500.html
+++ b/lib/hanami/cli/generators/gem/app/500.html
@@ -1,11 +1,82 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>We’re sorry, but something went wrong (500)</title>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>We’re sorry, but something went wrong (500)</title>
+  <style>
+    :root {
+      --foreground-rgb: 0, 0, 0;
+      --background-rgb: 255, 255, 255;
+      --font-sans: ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --foreground-rgb: 255, 255, 255;
+        --background-rgb: 0, 0, 0;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body,
+    html {
+      max-width: 100vw;
+      overflow-x: hidden;
+      font-size: 100%;
+    }
+
+    body {
+      color: rgb(var(--foreground-rgb));
+      background: rgb(var(--background-rgb));
+      font-family: var(--font-sans);
+      font-style: normal;
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      padding: 0 4vw;
+    }
+
+    .message {
+      display: flex;
+      gap: 1rem;
+      flex-direction: column;
+      text-align: center;
+    }
+
+    .message h1 {
+      font-size: 2rem;
+      font-weight: 500;
+    }
+
+    p {
+      line-height: 1.6;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      html {
+        color-scheme: dark;
+      }
+    }
+  </style>
   </head>
   <body>
     <!-- This file lives in public/500.html -->
-    <h1>We’re sorry, but something went wrong.</h1>
-    <p>If you are the application owner, check the logs for more information.</p>
+    <main>
+      <div class="message">
+        <h1>500</h1>
+        <p>We’re sorry, but something went wrong.</p>
+      </div>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
Add the lovely new error page designs from @aaronmoodie. Thank you again Aaron for bringing this touch of class to new Hanami apps!

This includes both 404 and 500 error pages. Here’s the 404 page as an example for you to feast your eyes upon:

<img width="1295" alt="Screenshot 2023-10-20 at 8 15 23 pm" src="https://github.com/hanami/cli/assets/3134/c765bb2d-2cb5-4939-8101-58c1c5ae8cbd">

<img width="1295" alt="Screenshot 2023-10-20 at 8 15 31 pm" src="https://github.com/hanami/cli/assets/3134/00149f99-21ea-4a29-ad52-611952ebe09a">

Light, elegant, and informative. A great default that new Hanami apps could very happily live with until they're ready to provide their own designs!

Resolves #115