### PR TITLE
Introduce `hanami generate part` CLI command

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -31,6 +31,7 @@ module Hanami
               prefix.register "slice", Generate::Slice
               prefix.register "action", Generate::Action
               prefix.register "view", Generate::View
+              prefix.register "part", Generate::Part
             end
           end
         end

--- a/lib/hanami/cli/commands/app/generate/part.rb
+++ b/lib/hanami/cli/commands/app/generate/part.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "dry/inflector"
+require "dry/files"
+require "shellwords"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Generate
+          # @since 2.1.0
+          # @api private
+          class Part < App::Command
+            argument :name, required: true, desc: "Part name"
+            option :slice, required: false, desc: "Slice name"
+
+            example [
+              %(book               (MyApp::Views::Parts::Book)),
+              %(book --slice=admin (Admin::Views::Parts::Book)),
+            ]
+            attr_reader :generator
+            private :generator
+
+            # @since 2.0.0
+            # @api private
+            def initialize(
+              fs: Hanami::CLI::Files.new,
+              inflector: Dry::Inflector.new,
+              generator: Generators::App::Part.new(fs: fs, inflector: inflector),
+              **
+            )
+              @generator = generator
+              super(fs: fs)
+            end
+
+            # @since 2.0.0
+            # @api private
+            def call(name:, slice: nil, **)
+              slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
+
+              generator.call(app.namespace, name, slice)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/part.rb
+++ b/lib/hanami/cli/generators/app/part.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "erb"
+require "dry/files"
+require_relative "../../errors"
+
+module Hanami
+  module CLI
+    module Generators
+      module App
+        # @since 2.0.0
+        # @api private
+        class Part
+          # @since 2.0.0
+          # @api private
+          def initialize(fs:, inflector:)
+            @fs = fs
+            @inflector = inflector
+          end
+
+          # @since 2.0.0
+          # @api private
+          def call(app, key, slice)
+            context = PartContext.new(inflector, app, slice, key)
+
+            if slice
+              generate_for_slice(context, slice)
+            else
+              generate_for_app(context)
+            end
+          end
+
+          private
+
+          attr_reader :fs
+
+          attr_reader :inflector
+
+          def generate_for_slice(context, slice)
+            slice_directory = fs.join("slices", slice)
+            raise MissingSliceError.new(slice) unless fs.directory?(slice_directory)
+
+            fs.mkdir(directory = fs.join(slice_directory, "views", "parts", context.namespaces))
+            fs.write(fs.join(directory, "#{context.name}.rb"), t("slice_part.erb", context))
+          end
+
+          def generate_for_app(context)
+            fs.mkdir(directory = fs.join("app", "views", "parts", context.namespaces))
+            fs.write(fs.join(directory, "#{context.name}.rb"), t("app_part.erb", context))
+          end
+
+          def template(path, context)
+            require "erb"
+
+            ERB.new(
+              File.read(__dir__ + "/part/#{path}"),
+              trim_mode: "-"
+            ).result(context.ctx)
+          end
+
+          alias_method :t, :template
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/part.rb
+++ b/lib/hanami/cli/generators/app/part.rb
@@ -8,17 +8,17 @@ module Hanami
   module CLI
     module Generators
       module App
-        # @since 2.0.0
+        # @since 2.1.0
         # @api private
         class Part
-          # @since 2.0.0
+          # @since 2.1.0
           # @api private
           def initialize(fs:, inflector:)
             @fs = fs
             @inflector = inflector
           end
 
-          # @since 2.0.0
+          # @since 2.1.0
           # @api private
           def call(app, key, slice)
             context = PartContext.new(inflector, app, slice, key)
@@ -32,23 +32,56 @@ module Hanami
 
           private
 
+          # @since 2.1.0
+          # @api private
           attr_reader :fs
 
+          # @since 2.1.0
+          # @api private
           attr_reader :inflector
 
+          # @since 2.1.0
+          # @api private
           def generate_for_slice(context, slice)
             slice_directory = fs.join("slices", slice)
             raise MissingSliceError.new(slice) unless fs.directory?(slice_directory)
+
+            generate_base_part_for_app(context)
+            generate_base_part_for_slice(context, slice)
 
             fs.mkdir(directory = fs.join(slice_directory, "views", "parts", *context.underscored_namespace))
             fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("slice_part.erb", context))
           end
 
+          # @since 2.1.0
+          # @api private
           def generate_for_app(context)
+            generate_base_part_for_app(context)
+
             fs.mkdir(directory = fs.join("app", "views", "parts", *context.underscored_namespace))
             fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("app_part.erb", context))
           end
 
+          # @since 2.1.0
+          # @api private
+          def generate_base_part_for_app(context)
+            path = fs.join("app", "views", "part.rb")
+            return if fs.exist?(path)
+
+            fs.write(path, t("app_base_part.erb", context))
+          end
+
+          # @since 2.1.0
+          # @api private
+          def generate_base_part_for_slice(context, slice)
+            path = fs.join("slices", slice, "views", "part.rb")
+            return if fs.exist?(path)
+
+            fs.write(path, t("slice_base_part.erb", context))
+          end
+
+          # @since 2.1.0
+          # @api private
           def template(path, context)
             require "erb"
 
@@ -58,6 +91,8 @@ module Hanami
             ).result(context.ctx)
           end
 
+          # @since 2.1.0
+          # @api private
           alias_method :t, :template
         end
       end

--- a/lib/hanami/cli/generators/app/part.rb
+++ b/lib/hanami/cli/generators/app/part.rb
@@ -40,12 +40,12 @@ module Hanami
             slice_directory = fs.join("slices", slice)
             raise MissingSliceError.new(slice) unless fs.directory?(slice_directory)
 
-            fs.mkdir(directory = fs.join(slice_directory, "views", "parts", context.namespaces))
+            fs.mkdir(directory = fs.join(slice_directory, "views", "parts", *context.namespaces))
             fs.write(fs.join(directory, "#{context.name}.rb"), t("slice_part.erb", context))
           end
 
           def generate_for_app(context)
-            fs.mkdir(directory = fs.join("app", "views", "parts", context.namespaces))
+            fs.mkdir(directory = fs.join("app", "views", "parts", *context.namespaces))
             fs.write(fs.join(directory, "#{context.name}.rb"), t("app_part.erb", context))
           end
 

--- a/lib/hanami/cli/generators/app/part.rb
+++ b/lib/hanami/cli/generators/app/part.rb
@@ -40,13 +40,13 @@ module Hanami
             slice_directory = fs.join("slices", slice)
             raise MissingSliceError.new(slice) unless fs.directory?(slice_directory)
 
-            fs.mkdir(directory = fs.join(slice_directory, "views", "parts", *context.namespaces))
-            fs.write(fs.join(directory, "#{context.name}.rb"), t("slice_part.erb", context))
+            fs.mkdir(directory = fs.join(slice_directory, "views", "parts", *context.underscored_namespace))
+            fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("slice_part.erb", context))
           end
 
           def generate_for_app(context)
-            fs.mkdir(directory = fs.join("app", "views", "parts", *context.namespaces))
-            fs.write(fs.join(directory, "#{context.name}.rb"), t("app_part.erb", context))
+            fs.mkdir(directory = fs.join("app", "views", "parts", *context.underscored_namespace))
+            fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("app_part.erb", context))
           end
 
           def template(path, context)

--- a/lib/hanami/cli/generators/app/part/app_base_part.erb
+++ b/lib/hanami/cli/generators/app/part/app_base_part.erb
@@ -1,0 +1,9 @@
+# auto_register: false
+# frozen_string_literal: true
+
+module <%= camelized_app_name %>
+  module Views
+    class Part < Hanami::View::Part
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/part/app_part.erb
+++ b/lib/hanami/cli/generators/app/part/app_part.erb
@@ -5,7 +5,7 @@ module <%= camelized_app_name %>
   module Views
     module Parts
 <%= module_namespace_declaration -%>
-  <%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_app_name %>::Part
+  <%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_app_name %>::Views::Part
   <%= module_namespace_offset %>end
 <%= module_namespace_end -%>
     end

--- a/lib/hanami/cli/generators/app/part/app_part.erb
+++ b/lib/hanami/cli/generators/app/part/app_part.erb
@@ -1,0 +1,13 @@
+# auto_register: false
+# frozen_string_literal: true
+
+module <%= camelized_app_name %>
+  module Views
+    module Parts
+<%= module_namespace_declaration -%>
+  <%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_app_name %>::Part
+  <%= module_namespace_offset %>end
+<%= module_namespace_end -%>
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/part/slice_base_part.erb
+++ b/lib/hanami/cli/generators/app/part/slice_base_part.erb
@@ -1,0 +1,9 @@
+# auto_register: false
+# frozen_string_literal: true
+
+module <%= camelized_slice_name %>
+  module Views
+    class Part < <%= camelized_app_name %>::Views::Part
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/part/slice_part.erb
+++ b/lib/hanami/cli/generators/app/part/slice_part.erb
@@ -5,7 +5,7 @@ module <%= camelized_slice_name %>
   module Views
     module Parts
 <%= module_namespace_declaration -%>
-  <%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_slice_name %>::Part
+  <%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_slice_name %>::Views::Part
   <%= module_namespace_offset %>end
 <%= module_namespace_end -%>
     end

--- a/lib/hanami/cli/generators/app/part/slice_part.erb
+++ b/lib/hanami/cli/generators/app/part/slice_part.erb
@@ -1,0 +1,13 @@
+# auto_register: false
+# frozen_string_literal: true
+
+module <%= camelized_slice_name %>
+  module Views
+    module Parts
+<%= module_namespace_declaration -%>
+  <%= module_namespace_offset %>class <%= camelized_name %> < <%= camelized_slice_name %>::Part
+  <%= module_namespace_offset %>end
+<%= module_namespace_end -%>
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/part_context.rb
+++ b/lib/hanami/cli/generators/app/part_context.rb
@@ -13,15 +13,19 @@ module Hanami
         # @api private
         class PartContext < SliceContext
           # TODO: move these constants somewhere that will let us reuse them
+
+          # @since 2.1.0
+          # @api private
           KEY_SEPARATOR = "."
           private_constant :KEY_SEPARATOR
 
-          NAMESPACE_SEPARATOR = "::"
-          private_constant :NAMESPACE_SEPARATOR
-
+          # @since 2.1.0
+          # @api private
           INDENTATION = "  "
           private_constant :INDENTATION
 
+          # @since 2.1.0
+          # @api private
           OFFSET = INDENTATION * 2
           private_constant :OFFSET
 
@@ -46,12 +50,6 @@ module Hanami
           # @api private
           def name
             @name ||= key.split(KEY_SEPARATOR)[-1]
-          end
-
-          # @since 2.1.0
-          # @api private
-          def camelized_namespace
-            namespaces.map { inflector.camelize(_1) }.join(NAMESPACE_SEPARATOR)
           end
 
           # @since 2.1.0

--- a/lib/hanami/cli/generators/app/part_context.rb
+++ b/lib/hanami/cli/generators/app/part_context.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative "slice_context"
+require "dry/files/path"
+
+module Hanami
+  module CLI
+    module Generators
+      # @since 2.1.0
+      # @api private
+      module App
+        # @since 2.1.0
+        # @api private
+        class PartContext < SliceContext
+          # TODO: move these constants somewhere that will let us reuse them
+          KEY_SEPARATOR = "."
+          private_constant :KEY_SEPARATOR
+
+          NAMESPACE_SEPARATOR = "::"
+          private_constant :NAMESPACE_SEPARATOR
+
+          INDENTATION = "  "
+          private_constant :INDENTATION
+
+          OFFSET = INDENTATION * 2
+          private_constant :OFFSET
+
+          # @since 2.1.0
+          # @api private
+          attr_reader :key
+
+          # @since 2.1.0
+          # @api private
+          def initialize(inflector, app, slice, key)
+            @key = key
+            super(inflector, app, slice, nil)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def namespaces
+            @namespaces ||= key.split(KEY_SEPARATOR)[..-2]
+          end
+
+          # @since 2.1.0
+          # @api private
+          def name
+            @name ||= key.split(KEY_SEPARATOR)[-1]
+          end
+
+          # @since 2.1.0
+          # @api private
+          def camelized_namespace
+            namespaces.map { inflector.camelize(_1) }.join(NAMESPACE_SEPARATOR)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def camelized_name
+            inflector.camelize(name)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def underscored_namespace
+            namespaces.map { inflector.underscore(_1) }
+          end
+
+          # @since 2.1.0
+          # @api private
+          def underscored_name
+            inflector.underscore(name)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def module_namespace_declaration
+            namespaces.each_with_index.map { |token, i|
+              "#{OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
+            }.join($/)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def module_namespace_end
+            namespaces.each_with_index.map { |_, i|
+              "#{OFFSET}#{INDENTATION * i}end"
+            }.reverse.join($/)
+          end
+
+          # @since 2.1.0
+          # @api private
+          def module_namespace_offset
+            "#{OFFSET}#{INDENTATION * namespaces.count}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
@@ -208,6 +208,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
         end
       end
     end
+
+    context "with missing slice" do
+      it "raises error" do
+        within_application_directory do
+          expect { subject.call(name: "user", slice: "foo") }.to raise_error(Hanami::CLI::MissingSliceError)
+        end
+      end
+    end
   end
 
   private

--- a/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "ostruct"
+
+RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
+  subject { described_class.new(fs: fs, inflector: inflector, generator: generator) }
+
+  let(:out) { StringIO.new }
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+  let(:inflector) { Dry::Inflector.new }
+  let(:generator) { Hanami::CLI::Generators::App::Part.new(fs: fs, inflector: inflector) }
+  let(:app) { Hanami.app.namespace }
+  let(:dir) { inflector.underscore(app) }
+
+  def output
+    out.rewind && out.read.chomp
+  end
+
+  context "generating for app" do
+    it "generates a part in a top-level namespace" do
+      within_application_directory do
+        subject.call(name: "user")
+
+        # part
+        part = <<~EXPECTED
+          # auto_register: false
+          # frozen_string_literal: true
+
+          module Test
+            module Views
+              module Parts
+                class User < Test::Part
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/views/parts/user.rb")).to eq(part)
+        expect(output).to include("Created app/views/parts/user.rb")
+      end
+    end
+  end
+
+  context "generating for a slice" do
+    it "generates a view in a top-level namespace" do
+      within_application_directory do
+        fs.mkdir("slices/main")
+        subject.call(name: "user", slice: "main")
+
+        # view
+        view_file = <<~EXPECTED
+          # auto_register: false
+          # frozen_string_literal: true
+
+          module Main
+            module Views
+              module Parts
+                class User < Main::Part
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("slices/main/views/parts/user.rb")).to eq(view_file)
+        expect(output).to include("Created slices/main/views/parts/user.rb")
+      end
+    end
+  end
+
+  private
+
+  def within_application_directory
+    fs.mkdir(dir)
+    fs.chdir(dir) do
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            root { "Hello from Hanami" }
+          end
+        end
+      CODE
+
+      fs.write("config/routes.rb", routes)
+
+      yield
+    end
+  end
+end


### PR DESCRIPTION
# Feature

Introduce a new CLI command to generate View Parts.
If the base part of the app (or slice) is missing, generate it.

## App

### First generated part

```shell
$ bundle exec hanami generate part author
Created app/views/part.rb
Created app/views/parts/
Created app/views/parts/author.rb
```

`app/views/part.rb`

```ruby
# auto_register: false
# frozen_string_literal: true

module Bookshelf
  module Views
    class Part < Hanami::View::Part
    end
  end
end
```

`app/views/parts/author.rb`

```ruby
# auto_register: false
# frozen_string_literal: true

module Bookshelf
  module Views
    module Parts
      class Author < Bookshelf::Views::Part
      end
    end
  end
end
```

### Second generated part

```shell
$ bundle exec hanami generate part book
Created app/views/parts/book.rb
```

## Slice

### First generated part

```shell
$ bundle exec hanami generate part user --slice=admin
Created app/views/part.rb
Created slices/admin/views/part.rb
Created slices/admin/views/parts/
Created slices/admin/views/parts/user.rb
```

`slices/admin/views/part.rb`

```ruby
# auto_register: false
# frozen_string_literal: true

module Admin
  module Views
    class Part < Bookshelf::Views::Part
    end
  end
end
```

`slices/admin/views/parts/user.rb`

```ruby
# auto_register: false
# frozen_string_literal: true

module Admin
  module Views
    module Parts
      class User < Admin::Views::Part
      end
    end
  end
end
```

### Missing slice

```shell
$ bundle exec hanami generate part user --slice=foo
slice `foo' is missing, please generate with `hanami generate slice foo'
```

## Help

```shell
$ bundle exec hanami generate part --help

Command:
  hanami g part

Usage:
  hanami g part NAME

Arguments:
  NAME                              # REQUIRED Part name

Options:
  --slice=VALUE                     # Slice name
  --help, -h                        # Print this help

Examples:
  hanami g part book               (MyApp::Views::Parts::Book)
  hanami g part book --slice=admin (Admin::Views::Parts::Book)
```

```shell
$ bundle exec hanami generate --help
Commands:
  hanami generate action NAME
  hanami generate part NAME
  hanami generate slice NAME
  hanami generate view NAME
```

---

Ref https://github.com/hanami/cli/issues/113