### PR TITLE
Remove unused assets settings

### DIFF
--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -44,20 +44,6 @@ module Hanami
 
             # @since 2.1.0
             # @api private
-            def entry_points
-              config.entry_points.map do |entry_point|
-                escape(entry_point)
-              end.join(" ")
-            end
-
-            # @since 2.1.0
-            # @api private
-            def destination
-              escape(config.destination)
-            end
-
-            # @since 2.1.0
-            # @api private
             def escape(str)
               Shellwords.shellescape(str)
             end

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -19,7 +19,7 @@ module Hanami
 
               if config.subresource_integrity.any?
                 result << "--"
-                result << "--sri=#{config.subresource_integrity.join(',')}"
+                result << "--sri=#{escape(config.subresource_integrity.join(','))}"
               end
 
               result


### PR DESCRIPTION
We're not using the `entry_points` and `destination` assets settings right now. These are currently hardcoded inside assets-js, so remove these references to avoid any confusion that we may be able to configure these from the outside. See https://github.com/hanami/assets/pull/132, where we're removing those settings directly from the hanami-assets gem.

While we're here, properly shellescape the `sri` argument given to the assets CLI.