### PR TITLE
Fix npm package version formatting

### DIFF
--- a/lib/hanami/cli/generators/version.rb
+++ b/lib/hanami/cli/generators/version.rb
@@ -32,7 +32,7 @@ module Hanami
           if prerelease?
             result = result
               .sub(/\.(alpha|beta|rc)/, '-\1')
-              .sub(/(alpha|beta|rc)(.+)\.(.+)$/, '\1.\2')
+              .sub(/(alpha|beta|rc)(\d+)(\..+)?$/, '\1.\2')
           end
 
           "^#{result}"

--- a/spec/unit/hanami/cli/generators/version_spec.rb
+++ b/spec/unit/hanami/cli/generators/version_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Generators::Version do
+  describe "#npm_package_requirement" do
+    it "returns the npm package version" do
+      allow(Hanami::CLI::Generators::Version).to receive(:version).and_return("2.1.0.rc1")
+
+      expect(subject.npm_package_requirement).to eq("^2.1.0-rc.1")
+
+      allow(Hanami::CLI::Generators::Version).to receive(:version).and_return("2.1.0.rc1.1")
+
+      expect(subject.npm_package_requirement).to eq("^2.1.0-rc.1")
+    end
+  end
+end


### PR DESCRIPTION
The `Hanami::CLI::Generators::Version#npm_package_requirement` currently returns `2.1.0-rc1` instead of the correct `2.1.0-rc.1`.