### PR TITLE
Add --skip-tests flag to generate commands

### DIFF
--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -22,12 +22,25 @@ module Hanami
             DEFAULT_SKIP_VIEW = false
             private_constant :DEFAULT_SKIP_VIEW
 
+            DEFAULT_SKIP_TESTS = false
+            private_constant :DEFAULT_SKIP_TESTS
+
             argument :name, required: true, desc: "Action name"
             option :url, required: false, type: :string, desc: "Action URL"
             option :http, required: false, type: :string, desc: "Action HTTP method"
             # option :format, required: false, type: :string, default: DEFAULT_FORMAT, desc: "Template format"
-            option :skip_view, required: false, type: :boolean, default: DEFAULT_SKIP_VIEW,
-                               desc: "Skip view and template generation"
+            option \
+              :skip_view,
+              required: false,
+              type: :boolean,
+              default: DEFAULT_SKIP_VIEW,
+              desc: "Skip view and template generation"
+            option \
+              :skip_tests,
+              required: false,
+              type: :boolean,
+              default: DEFAULT_SKIP_TESTS,
+              desc: "Skip test generation"
             option :slice, required: false, desc: "Slice name"
 
             # rubocop:disable Layout/LineLength
@@ -60,8 +73,16 @@ module Hanami
 
             # @since 2.0.0
             # @api private
-            def call(name:, url: nil, http: nil, format: DEFAULT_FORMAT, skip_view: DEFAULT_SKIP_VIEW, slice: nil,
-                     context: nil, **)
+            def call(
+              name:,
+              url: nil,
+              http: nil,
+              format: DEFAULT_FORMAT,
+              skip_view: DEFAULT_SKIP_VIEW,
+              skip_tests: DEFAULT_SKIP_TESTS, # rubocop:disable Lint/UnusedMethodArgument
+              slice: nil,
+              context: nil, **
+            )
               slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
               name = naming.action_name(name)
               *controller, action = name.split(ACTION_SEPARATOR)

--- a/lib/hanami/cli/commands/app/generate/part.rb
+++ b/lib/hanami/cli/commands/app/generate/part.rb
@@ -12,8 +12,17 @@ module Hanami
           # @since 2.1.0
           # @api private
           class Part < App::Command
+            DEFAULT_SKIP_TESTS = false
+            private_constant :DEFAULT_SKIP_TESTS
+
             argument :name, required: true, desc: "Part name"
             option :slice, required: false, desc: "Slice name"
+            option \
+              :skip_tests,
+              required: false,
+              type: :boolean,
+              default: DEFAULT_SKIP_TESTS,
+              desc: "Skip test generation"
 
             example [
               %(book               (MyApp::Views::Parts::Book)),
@@ -36,7 +45,7 @@ module Hanami
 
             # @since 2.0.0
             # @api private
-            def call(name:, slice: nil, **)
+            def call(name:, slice: nil, skip_tests: DEFAULT_SKIP_TESTS, **) # rubocop:disable Lint/UnusedMethodArgument
               slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
 
               generator.call(app.namespace, name, slice)


### PR DESCRIPTION
This will allow hanami-rspec to observe this flag and skip its work if true.

This is in service of making sure we don't generate spurious (and failing) tests in our new 2.1 getting started guide for web apps.

(More generally, it would be nice if gems adding hooks around the core CLI commands could register their own options, since that would mean we could limit these changes to the hanami-rspec gem only, but for now, we have to make this change to register the flag here, and then use the flag over there)

