### PR TITLE
Show errors when NPM install fails

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -99,7 +99,12 @@ module Hanami
 
                   unless skip_assets
                     out.puts "Running npm install..."
-                    system_call.call("npm", ["install"])
+                    system_call.call("npm", ["install"]).tap do |result|
+                      unless result.successful?
+                        puts "NPM ERROR:"
+                        puts result.err.lines.map {|line| line.prepend("    ")}
+                      end
+                    end
                   end
 
                   out.puts "Running Hanami install..."


### PR DESCRIPTION
Sample output now:
```sh
% exe/hanami new bookshelf
Created bookshelf/
-> Within bookshelf/
Created .gitignore
Created .env
Created README.md
Created Gemfile
Created Rakefile
Created Procfile.dev
Created config.ru
Created bin/dev
Created config/app.rb
Created config/settings.rb
Created config/routes.rb
Created config/puma.rb
Created lib/tasks/.keep
Created lib/bookshelf/types.rb
Created app/actions/.keep
Created app/action.rb
Created app/view.rb
Created app/views/helpers.rb
Created app/templates/layouts/app.html.erb
Created package.json
Created config/assets.mjs
Created app/assets/js/app.js
Created app/assets/css/app.css
Created app/assets/images/favicon.ico
Created public/404.html
Created public/500.html
Running Bundler install...
Running npm install...
NPM ERROR:
    npm ERR! code ETARGET
    npm ERR! notarget No matching version found for hanami-assets@^2.1.0-rc1.
    npm ERR! notarget In most cases you or one of your dependencies are requesting
    npm ERR! notarget a package version that doesn't exist.

    npm ERR! A complete log of this run can be found in:
    npm ERR!     /Users/sean/.npm/_logs/2023-11-07T01_38_25_312Z-debug-0.log
Running Hanami install...
```

I don't think we should fail when npm fails, but it would be nice to let the user know there was a problem. This could happen if there's some issue with their npm install, or if they don't have it installed at all.

Open to adding more text, or making this smaller (if it's a long error message, the whole thing will show). For example, we could just show the last line `npm ERR!     /Users/sean/.npm/_logs/2023-11-07T01_38_25_312Z-debug-0.log` if we want to.

(The underlying issue here was fixed in #119, but I reintroduced it locally to get the failure)