### PR TITLE
Print result of assets compilation

### DIFF
--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -12,6 +12,24 @@ module Hanami
           class Compile < Assets::Command
             desc "Compile assets for deployments"
 
+            SUCCESSFUL_EXIT_CODE = 0
+
+            # @since 2.1.0
+            # @api private
+            def call(**)
+              result = super
+              if result.exit_code == SUCCESSFUL_EXIT_CODE
+                puts result.out
+
+                if result.err && result.err != ""
+                  puts ""
+                  puts result.err
+                end
+              else
+                raise AssetsCompilationError.new(result.out, result.err)
+              end
+            end
+
             # @since 2.1.0
             # @api private
             def cmd_with_args

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -91,5 +91,13 @@ module Hanami
         super("`#{scheme}' is not a supported db scheme")
       end
     end
+
+    # since 2.1.0
+    # @api public
+    class AssetsCompilationError < Error
+      def initialize(stdout, stderr)
+        super("#{stdout}\n\nErrors on assets compilation:\n\n#{stderr}")
+      end
+    end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -6,9 +6,30 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, :app do
 
   context "#call" do
     it "invokes hanami-assets executable" do
-      expect(system_call).to receive(:call).with("npm run --silent", "assets")
+      expect(system_call).to receive(:call).with("npm run --silent", "assets") { Hanami::CLI::SystemCall::Result.new(exit_code: 0, out: "", err: "") }
 
       subject.call
+    end
+
+    it "writes stdout and stderr to stdout on success" do
+      expect(system_call).to receive(:call).with("npm run --silent", "assets") { Hanami::CLI::SystemCall::Result.new(exit_code: 0, out: "This is out", err: "This is err") }
+      expect($stdout).to receive(:puts).with("This is out")
+      expect($stdout).to receive(:puts).with("")
+      expect($stdout).to receive(:puts).with("This is err")
+
+      subject.call
+    end
+
+    it "writes only stdout when stderr is empty on success" do
+      expect(system_call).to receive(:call).with("npm run --silent", "assets") { Hanami::CLI::SystemCall::Result.new(exit_code: 0, out: "This is out", err: "") }
+      expect($stdout).to receive(:puts).with("This is out")
+
+      subject.call
+    end
+
+    it "raises exception on non-zero exit code" do
+      expect(system_call).to receive(:call).with("npm run --silent", "assets") { Hanami::CLI::SystemCall::Result.new(exit_code: 1, out: "This is out", err: "This is err") }
+      expect { subject.call }.to raise_error(Hanami::CLI::AssetsCompilationError, "This is out\n\nErrors on assets compilation:\n\nThis is err")
     end
   end
 end


### PR DESCRIPTION
This comes as a result of a problems I had with the CI, where it reported missing assets even though I had `hanami assets precompile` step. The reason was quite dumb - I did not run `npm install` first. However, because `hanami assets precompile` swallows the output of an underlying esbuild command, the error was not visible to me.

This swings the pendulum to the opposite direction: it outputs stdout and stderr to the users both on successful compilation and failed one. While the use case for the latter is obvious, the one for the former might not be. But when I enable `info` logging level for my esbuild in the project, I can now see a nice results of what was generated:

```
$ be hanami assets compile
> assets
> node config/assets.mjs

public/assets/app-7PQYDDGS.css       81b 
  public/assets/app-LSLFPUMX.js        53b 
  public/assets/app-7PQYDDGS.css.map  196b 
  public/assets/app-LSLFPUMX.js.map    93b 

⚡ Done in 7ms
```

On error:

```
$ be hanami assets compile
> assets
> node config/assets.mjs

Errors on assets compilation:

node:internal/errors:466
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'hanami-assets' imported from /home/katafrakt/dev/palaver/config/assets.mjs
    at new NodeError (node:internal/errors:377:5)
    at packageResolve (node:internal/modules/esm/resolve:910:9)
    at moduleResolve (node:internal/modules/esm/resolve:959:20)
    at defaultResolve (node:internal/modules/esm/resolve:1174:11)
    at ESMLoader.resolve (node:internal/modules/esm/loader:605:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:318:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:80:40)
    at link (node:internal/modules/esm/module_job:78:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v18.3.0
```