### PR TITLE
Implement generic component generator

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -32,6 +32,7 @@ module Hanami
               prefix.register "action", Generate::Action
               prefix.register "view", Generate::View
               prefix.register "part", Generate::Part
+              prefix.register "component", Generate::Component
             end
           end
         end

--- a/lib/hanami/cli/commands/app/generate/component.rb
+++ b/lib/hanami/cli/commands/app/generate/component.rb
@@ -9,6 +9,7 @@ module Hanami
       module App
         module Generate
           # @api private
+          # @since 2.2.0
           class Component < App::Command
             argument :name, required: true, desc: "Component name"
             option :slice, required: false, desc: "Slice name"
@@ -16,13 +17,14 @@ module Hanami
             example [
               %(operations.create_user               (MyApp::Operations::CreateUser)),
               %(operations.user.create               (MyApp::Operations::Create::User)),
-              %(operations.create_user --slice=admin (Admin::Operations::CreateUser)),
-              %(Operations::CreateUser (MyApp::Operations::CreateUser)),
+              %(operations.create_user               --slice=admin (Admin::Operations::CreateUser)),
+              %(Operations::CreateUser               (MyApp::Operations::CreateUser)),
             ]
             attr_reader :generator
             private :generator
 
             # @api private
+            # @since 2.2.0
             def initialize(
               fs: Hanami::CLI::Files.new,
               inflector: Dry::Inflector.new,
@@ -34,6 +36,7 @@ module Hanami
             end
 
             # @api private
+            # @since 2.2.0
             def call(name:, slice: nil, **)
               slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
 

--- a/lib/hanami/cli/commands/app/generate/component.rb
+++ b/lib/hanami/cli/commands/app/generate/component.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "dry/inflector"
+require "dry/files"
+require "shellwords"
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Generate
+          # @api private
+          class Component < App::Command
+            argument :name, required: true, desc: "Component name"
+            option :slice, required: false, desc: "Slice name"
+
+            example [
+              %(operations.create_user               (MyApp::Operations::CreateUser)),
+              %(operations.user.create               (MyApp::Operations::Create::User)),
+              %(operations.create_user --slice=admin (Admin::Operations::CreateUser)),
+              %(Operations::CreateUser (MyApp::Operations::CreateUser)),
+            ]
+            attr_reader :generator
+            private :generator
+
+            # @api private
+            def initialize(
+              fs: Hanami::CLI::Files.new,
+              inflector: Dry::Inflector.new,
+              generator: Generators::App::Component.new(fs: fs, inflector: inflector),
+              **
+            )
+              @generator = generator
+              super(fs: fs)
+            end
+
+            # @api private
+            def call(name:, slice: nil, **)
+              slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
+
+              generator.call(app.namespace, name, slice)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/component.rb
+++ b/lib/hanami/cli/generators/app/component.rb
@@ -7,14 +7,17 @@ module Hanami
     module Generators
       module App
         # @api private
+        # @since 2.2.0
         class Component
           # @api private
+          # @since 2.2.0
           def initialize(fs:, inflector:)
             @fs = fs
             @inflector = inflector
           end
 
           # @api private
+          # @since 2.2.0
           def call(app, key, slice)
             context = ComponentContext.new(inflector, app, slice, key)
 
@@ -27,13 +30,10 @@ module Hanami
 
           private
 
-          # @api private
           attr_reader :fs
 
-          # @api private
           attr_reader :inflector
 
-          # @api private
           def generate_for_slice(context, slice)
             slice_directory = fs.join("slices", slice)
             raise MissingSliceError.new(slice) unless fs.directory?(slice_directory)
@@ -42,7 +42,6 @@ module Hanami
             fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("slice_component.erb", context))
           end
 
-          # @api private
           def generate_for_app(context)
             fs.mkdir(directory = fs.join("app", context.namespaces))
             fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("component.erb", context))

--- a/lib/hanami/cli/generators/app/component.rb
+++ b/lib/hanami/cli/generators/app/component.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "erb"
+require "dry/files"
+module Hanami
+  module CLI
+    module Generators
+      module App
+        # @api private
+        class Component
+          # @api private
+          def initialize(fs:, inflector:)
+            @fs = fs
+            @inflector = inflector
+          end
+
+          # @api private
+          def call(app, key, slice)
+            context = ComponentContext.new(inflector, app, slice, key)
+
+            if slice
+              generate_for_slice(context, slice)
+            else
+              generate_for_app(context)
+            end
+          end
+
+          private
+
+          # @api private
+          attr_reader :fs
+
+          # @api private
+          attr_reader :inflector
+
+          # @api private
+          def generate_for_slice(context, slice)
+            slice_directory = fs.join("slices", slice)
+            raise MissingSliceError.new(slice) unless fs.directory?(slice_directory)
+
+            fs.mkdir(directory = fs.join(slice_directory, context.namespaces))
+            fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("slice_component.erb", context))
+          end
+
+          # @api private
+          def generate_for_app(context)
+            fs.mkdir(directory = fs.join("app", context.namespaces))
+            fs.write(fs.join(directory, "#{context.underscored_name}.rb"), t("component.erb", context))
+          end
+
+          def template(path, context)
+            ERB.new(
+              File.read(__dir__ + "/component/#{path}")
+            ).result(context.ctx)
+          end
+
+          alias_method :t, :template
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/component/component.erb
+++ b/lib/hanami/cli/generators/app/component/component.erb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module <%= camelized_app_name %>
+<%= module_namespace_declaration %>
+<%= module_namespace_offset %>class <%= camelized_name %>
+<%= module_namespace_offset %>end
+<%= module_namespace_end %>
+end

--- a/lib/hanami/cli/generators/app/component/slice_component.erb
+++ b/lib/hanami/cli/generators/app/component/slice_component.erb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module <%= camelized_slice_name %>
+<%= module_namespace_declaration %>
+<%= module_namespace_offset %>class <%= camelized_name %>
+<%= module_namespace_offset %>end
+<%= module_namespace_end %>
+end

--- a/lib/hanami/cli/generators/app/component_context.rb
+++ b/lib/hanami/cli/generators/app/component_context.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    module Generators
+      module App
+        class ComponentContext < SliceContext
+          # Taken from lib/hanami/cli/generators/app/view_context.rb which mentions they should be moved somewhere. Not sure where yet.
+          MATCHER_PATTERN = /::|\./
+          private_constant :MATCHER_PATTERN
+
+          NAMESPACE_SEPARATOR = "::"
+          private_constant :NAMESPACE_SEPARATOR
+
+          INDENTATION = "  "
+          private_constant :INDENTATION
+
+          OFFSET = 1
+          private_constant :OFFSET
+
+          # @since 2.1.0
+          # @api private
+          attr_reader :key
+
+          # @since 2.1.0
+          # @api private
+          def initialize(inflector, app, slice, key)
+            @key = key
+            super(inflector, app, slice, nil)
+          end
+
+          # @api private
+          def namespaces
+            @namespaces ||= key.split(MATCHER_PATTERN)[..-2].map { inflector.underscore(_1) }
+          end
+
+          # @api private
+          def name
+            @name ||= key.split(MATCHER_PATTERN)[-1]
+          end
+
+          # @api private
+          def camelized_namespace
+            namespaces.map { inflector.camelize(_1) }.join(NAMESPACE_SEPARATOR)
+          end
+
+          # @api private
+          def camelized_name
+            inflector.camelize(name)
+          end
+
+          # @api private
+          def underscored_namespace
+            namespaces.map { inflector.underscore(_1) }
+          end
+
+          # @api private
+          def underscored_name
+            inflector.underscore(name)
+          end
+
+          # @api private
+          def module_namespace_declaration
+            namespaces.each.with_index(OFFSET).map { |token, i|
+              "#{INDENTATION * i}module #{inflector.camelize(token)}"
+            }.join($/)
+          end
+
+          # @api private
+          def module_namespace_end
+            namespaces.each.with_index(OFFSET).map { |_, i|
+              "#{INDENTATION * i}end"
+            }.reverse.join($/)
+          end
+
+          # @api private
+          def module_namespace_offset
+            (INDENTATION * (namespaces.count + OFFSET)).to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/component_context.rb
+++ b/lib/hanami/cli/generators/app/component_context.rb
@@ -18,48 +18,55 @@ module Hanami
           OFFSET = 1
           private_constant :OFFSET
 
-          # @since 2.1.0
           # @api private
+          # @since 2.2.0
           attr_reader :key
 
-          # @since 2.1.0
           # @api private
+          # @since 2.2.0
           def initialize(inflector, app, slice, key)
             @key = key
             super(inflector, app, slice, nil)
           end
 
           # @api private
+          # @since 2.2.0
           def namespaces
             @namespaces ||= key.split(MATCHER_PATTERN)[..-2].map { inflector.underscore(_1) }
           end
 
           # @api private
+          # @since 2.2.0
           def name
             @name ||= key.split(MATCHER_PATTERN)[-1]
           end
 
           # @api private
+          # @since 2.2.0
           def camelized_namespace
             namespaces.map { inflector.camelize(_1) }.join(NAMESPACE_SEPARATOR)
           end
 
           # @api private
+          # @since 2.2.0
           def camelized_name
             inflector.camelize(name)
           end
 
           # @api private
+          # @since 2.2.0
           def underscored_namespace
             namespaces.map { inflector.underscore(_1) }
           end
 
           # @api private
+          # @since 2.2.0
           def underscored_name
             inflector.underscore(name)
           end
 
           # @api private
+          # @since 2.2.0
           def module_namespace_declaration
             namespaces.each.with_index(OFFSET).map { |token, i|
               "#{INDENTATION * i}module #{inflector.camelize(token)}"
@@ -67,6 +74,7 @@ module Hanami
           end
 
           # @api private
+          # @since 2.2.0
           def module_namespace_end
             namespaces.each.with_index(OFFSET).map { |_, i|
               "#{INDENTATION * i}end"
@@ -74,6 +82,7 @@ module Hanami
           end
 
           # @api private
+          # @since 2.2.0
           def module_namespace_offset
             (INDENTATION * (namespaces.count + OFFSET)).to_s
           end

--- a/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "ostruct"
+
+RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
+  subject { described_class.new(fs: fs, inflector: inflector, generator: generator) }
+
+  let(:out) { StringIO.new }
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+  let(:inflector) { Dry::Inflector.new }
+  let(:generator) { Hanami::CLI::Generators::App::Component.new(fs: fs, inflector: inflector) }
+  let(:app) { Hanami.app.namespace }
+  let(:underscored_app) { inflector.underscore(app) }
+  let(:dir) { underscored_app }
+  let(:slice) { "api" }
+
+  def output
+    out.rewind && out.read.chomp
+  end
+
+  context "generating for app" do
+    context "shallowly nested" do
+      it "generates the component" do
+        subject.call(name: "operations.send_welcome_email")
+
+        component = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Operations
+              class SendWelcomeEmail
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/operations/send_welcome_email.rb")).to eq(component)
+        expect(output).to include("Created app/operations/send_welcome_email.rb")
+      end
+    end
+
+    context "deeply nested" do
+      it "generates the component" do
+        subject.call(name: "operations.user.mailing.send_welcome_email")
+
+        component = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Operations
+              module User
+                module Mailing
+                  class SendWelcomeEmail
+                  end
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/operations/user/mailing/send_welcome_email.rb")).to eq(component)
+        expect(output).to include("Created app/operations/user/mailing/send_welcome_email.rb")
+      end
+    end
+  end
+
+  context "generating for a slice" do
+    context "shallowly nested" do
+      it "generates the component" do
+        fs.mkdir("slices/main")
+        subject.call(name: "renderers.welcome_email", slice: "main")
+
+        component = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Main
+            module Renderers
+              class WelcomeEmail
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("slices/main/renderers/welcome_email.rb")).to eq(component)
+        expect(output).to include("Created slices/main/renderers/welcome_email.rb")
+      end
+    end
+
+    context "deeply nested" do
+      it "generates the component" do
+        fs.mkdir("slices/main")
+        subject.call(name: "renderers.user.mailing.welcome_email", slice: "main")
+
+        component = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Main
+            module Renderers
+              module User
+                module Mailing
+                  class WelcomeEmail
+                  end
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("slices/main/renderers/user/mailing/welcome_email.rb")).to eq(component)
+        expect(output).to include("Created slices/main/renderers/user/mailing/welcome_email.rb")
+      end
+    end
+
+    context "with missing slice" do
+      it "raises error" do
+        expect { subject.call(name: "user", slice: "foo") }.to raise_error(Hanami::CLI::MissingSliceError)
+      end
+    end
+  end
+
+  context "with constantized name for component given" do
+    it "generates the component" do
+      subject.call(name: "Operations::SendWelcomeEmail")
+
+      component = <<~EXPECTED
+        # frozen_string_literal: true
+
+        module Test
+          module Operations
+            class SendWelcomeEmail
+            end
+          end
+        end
+      EXPECTED
+
+      expect(fs.read("app/operations/send_welcome_email.rb")).to eq(component)
+      expect(output).to include("Created app/operations/send_welcome_email.rb")
+    end
+  end
+end


### PR DESCRIPTION
### **Context:**
Hi. I noticed this task in Hanami github projects: https://github.com/orgs/hanami/projects/2?pane=issue&itemId=37953496
Thought I give it a go, to get acquainted with dry-rb and hanami source code more, and maybe be useful to maintainers as a side effect. I know the task was marked as "maybe" but I often wrote generators for rails and wanted to see how much different would it be here.

### **Solution:**
The generator is really simple, as components are general objects with no one interface or anything. It is basically a shortcut to creating a file with the right name in the right scope and slice or no slice. That is what I understood that the idea was behind this task.
I also accounted for CLI receiving the name in Pascal Case like `Opeations::CreateUser`. This is a personal preference, since this is how I usually generate new ruby classes through rubymine, but I think it might be a useful option for some. 

### **TBD:**
For my code, the collection of constants with different characters used in `lib/hanami/cli/generators/app/view_context.rb` was also useful. I noticed the TODO that it should be moved. I would like to do thath, but I am unsure what would be the desired location. Something like `lib/hanami/cli/constants.rb` seems like a simple solution? But I was thinking more along the lines of `lib/hanami/cli/formatting` since all those constants are used to format the input or output, however that does not seem 100% right (this naming seems like a stretch, or might be misleading, since it is not functional, it would just be a module with constants or something).

Anyway, eager to see any form of feedback. Would you like the generator to do something more? Any feedback is appreciated since this is my first attempt at hanami source code.

I was also unsure about how to document the code with the version tags, since I started this before 2.1 was released.

Some screenshots of usage of my local gem version:

![cli_component_slice](https://github.com/hanami/cli/assets/25006471/d0fe621f-ce67-4009-8725-4f8171094b07)
![cli_component](https://github.com/hanami/cli/assets/25006471/ee57213d-79da-462b-9fcd-64e215c27d31)
