### PR TITLE
Run multiple assets processes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ Lint/DuplicateBranch:
 Lint/EmptyFile:
   Exclude:
     - 'spec/fixtures/**/*.rb'
+Lint/NonLocalExitFromIterator:
+  Enabled: false
 Naming/HeredocDelimiterNaming:
   Enabled: false
 Naming/MethodParameterName:

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ unless ENV["CI"]
 end
 
 gem "hanami", github: "hanami/hanami", branch: "main"
-gem "hanami-assets", github: "hanami/assets", branch: "change-package-manager-setting"
+gem "hanami-assets", github: "hanami/assets", branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ unless ENV["CI"]
 end
 
 gem "hanami", github: "hanami/hanami", branch: "main"
-gem "hanami-assets", github: "hanami/assets", branch: "main"
+gem "hanami-assets", github: "hanami/assets", branch: "change-package-manager-setting"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "dry-files", github: "dry-rb/dry-files", branch: "main"
 
 gem "rack"
 
+gem "hanami-devtools", github: "hanami/devtools", branch: "main"
+
 group :test do
   gem "pry"
 end

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -12,8 +12,8 @@ module Hanami
           # @since 2.1.0
           # @api private
           class Command < App::Command
-            def initialize(config: app.config.assets, system_call: SystemCall.new, **)
-              super()
+            def initialize(config: app.config.assets, system_call: SystemCall.new, **opts)
+              super(**opts)
               @system_call = system_call
               @config = config
             end
@@ -21,6 +21,13 @@ module Hanami
             # @since 2.1.0
             # @api private
             def call(**)
+              slices = slices_with_assets
+
+              if slices.empty?
+                out.puts "No assets found."
+                return
+              end
+
               pids = slices_with_assets.map { |slice| fork_child(slice) }
 
               Signal.trap("INT") do

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -9,6 +9,21 @@ module Hanami
     module Commands
       module App
         module Assets
+          # Base class for assets commands.
+          #
+          # Finds slices with assets present (anything in an `assets/` dir), then forks a child
+          # process for each slice to run the assets command (`config/assets.js`) for the slice.
+          #
+          # Prefers the slice's own `config/assets.js` if present, otherwise falls back to the
+          # app-level file.
+          #
+          # Passes `--path` and `--dest` arguments to this command to compile assets for the given
+          # slice only and save them into a dedicated directory (`public/assets/` for the app,
+          # `public/[slice_name]/` for slices).
+          #
+          # @see Watch
+          # @see Compile
+          #
           # @since 2.1.0
           # @api private
           class Command < App::Command
@@ -84,6 +99,8 @@ module Hanami
               cmd
             end
 
+            # @since 2.1.0
+            # @api private
             def slices_with_assets
               slices = app.slices.with_nested + [app]
               slices.select { |slice| slice_assets?(slice) }

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -28,6 +28,13 @@ module Hanami
                 return
               end
 
+              slices.each do |slice|
+                unless assets_config(slice)
+                  out.puts "No assets config found for #{slice}. Please create a config/assets.js."
+                  return
+                end
+              end
+
               pids = slices_with_assets.map { |slice| fork_child_assets_command(slice) }
 
               Signal.trap("INT") do
@@ -88,6 +95,11 @@ module Hanami
               slice.root.join("assets").directory?
             end
 
+            # Returns the path to the assets config (`config/assets.js`) for the given slice.
+            #
+            # Prefers a config file local to the slice, otherwise falls back to app-level config.
+            # Returns nil if no config can be found.
+            #
             # @since 2.1.0
             # @api private
             def assets_config(slice)
@@ -95,10 +107,7 @@ module Hanami
               return config if config.exist?
 
               config = slice.app.root.join("config", "assets.js")
-              return config if config.exist?
-
-              # TODO: real error
-              raise "no asset config found"
+              config if config.exist?
             end
 
             # @since 2.1.0

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -21,9 +21,15 @@ module Hanami
             # @since 2.1.0
             # @api private
             def call(**)
-              cmd, *args = cmd_with_args
+              pids = slices_with_assets.map { |slice| fork_child(slice) }
 
-              system_call.call(cmd, *args)
+              Signal.trap("INT") do
+                pids.each do |pid|
+                  Process.kill(sig, pid)
+                end
+              end
+
+              Process.waitall
             end
 
             private
@@ -38,8 +44,54 @@ module Hanami
 
             # @since 2.1.0
             # @api private
-            def cmd_with_args
-              [config.package_manager_run_command, "assets"]
+            def fork_child(slice)
+              Process.fork do
+                cmd, *args = cmd_with_args(slice)
+                system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
+              rescue Interrupt
+                # When this has been interrupted (by the Signal.trap handler in #call), catch the
+                # interrupt and exit cleanly, without showing the default full backtrace.
+              end
+            end
+
+            # @since 2.1.0
+            # @api private
+            def cmd_with_args(slice)
+              cmd = [config.node_command, assets_config(slice).to_s, "--"]
+
+              if slice.eql?(slice.app)
+                cmd << "--path=app"
+                cmd << "--target=public/assets"
+              else
+                cmd << "--path=#{slice.root.relative_path_from(slice.app.root)}"
+                cmd << "--target=public/assets/#{slice.slice_name}"
+              end
+
+              cmd
+            end
+
+            def slices_with_assets
+              slices = app.slices.with_nested + [app]
+              slices.select { |slice| slice_assets?(slice) }
+            end
+
+            # @since 2.1.0
+            # @api private
+            def slice_assets?(slice)
+              slice.root.join("assets").directory?
+            end
+
+            # @since 2.1.0
+            # @api private
+            def assets_config(slice)
+              config = slice.root.join("config", "assets.js")
+              return config if config.exist?
+
+              config = slice.app.root.join("config", "assets.js")
+              return config if config.exist?
+
+              # TODO: real error
+              raise "no asset config found"
             end
 
             # @since 2.1.0

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -28,7 +28,7 @@ module Hanami
                 return
               end
 
-              pids = slices_with_assets.map { |slice| fork_child(slice) }
+              pids = slices_with_assets.map { |slice| fork_child_assets_command(slice) }
 
               Signal.trap("INT") do
                 pids.each do |pid|
@@ -51,9 +51,9 @@ module Hanami
 
             # @since 2.1.0
             # @api private
-            def fork_child(slice)
+            def fork_child_assets_command(slice)
               Process.fork do
-                cmd, *args = cmd_with_args(slice)
+                cmd, *args = assets_command(slice)
                 system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
               rescue Interrupt
                 # When this has been interrupted (by the Signal.trap handler in #call), catch the
@@ -63,7 +63,7 @@ module Hanami
 
             # @since 2.1.0
             # @api private
-            def cmd_with_args(slice)
+            def assets_command(slice)
               cmd = [config.node_command, assets_config(slice).to_s, "--"]
 
               if slice.eql?(slice.app)

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -68,10 +68,10 @@ module Hanami
 
               if slice.eql?(slice.app)
                 cmd << "--path=app"
-                cmd << "--target=public/assets"
+                cmd << "--dest=public/assets"
               else
                 cmd << "--path=#{slice.root.relative_path_from(slice.app.root)}"
-                cmd << "--target=public/assets/#{slice.slice_name}"
+                cmd << "--dest=public/assets/#{slice.slice_name}"
               end
 
               cmd

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -12,8 +12,8 @@ module Hanami
           class Compile < Assets::Command
             desc "Compile assets for deployments"
 
-            def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **)
-              super(config: config, system_call: system_call)
+            def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **opts)
+              super(config: config, system_call: system_call, **opts)
             end
 
             private

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -18,7 +18,7 @@ module Hanami
 
             def call(**)
               slices = app.slices.with_nested + [app]
-              pids = slices.map { |slice| fork_child(slice) }
+              pids = slices.map { |slice| fork_child(slice) if slice_assets?(slice) }
 
               Signal.trap("INT") do
                 pids.each do |pid|
@@ -59,6 +59,10 @@ module Hanami
               end
 
               result
+            end
+
+            def slice_assets?(slice)
+              slice.root.join("assets").directory?
             end
 
             def assets_config(slice)

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -12,17 +12,65 @@ module Hanami
           class Compile < Assets::Command
             desc "Compile assets for deployments"
 
+            def call(**)
+              slices = app.slices.with_nested + [app]
+
+              # capture pids here
+              start_children(slices)
+            end
+
             # @since 2.1.0
             # @api private
-            def cmd_with_args
-              result = super
+            def cmd_with_args(slice)
+              result = super()
+
+              result << "--"
+
+              if slice.eql?(slice.app)
+                result << "--path=app"
+                result << "--target=public/assets"
+              else
+                result << "--path=#{slice.root.relative_path_from(slice.app.root)}"
+                result << "--target=public/assets/#{slice.slice_name}"
+                # TODO: work for nested slices
+              end
 
               if config.subresource_integrity.any?
-                result << "--"
                 result << "--sri=#{escape(config.subresource_integrity.join(','))}"
               end
 
               result
+            end
+
+            private
+
+            def start_children(slices)
+              slices.each do |slice|
+                fork_child(slice)
+              end
+            end
+
+            def fork_child(slice)
+              Process.fork do
+                cmd, *args = cmd_with_args(slice)
+                p cmd_with_args(slice)
+                result = system_call.call(cmd, *args)
+
+                if result.exit_code == 0
+                  puts result.out
+
+                  if result.err && result.err != ""
+                    puts ""
+                    puts result.err
+                  end
+                else
+                  puts "AssetsCompilationError"
+                  puts result.out
+                  puts result.err
+                  raise "AssetsCompilationError"
+                  # raise AssetsCompilationError.new(result.out, result.err)
+                end
+              end
             end
           end
         end

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -14,18 +14,12 @@ module Hanami
 
             def call(**)
               slices = app.slices.with_nested + [app]
+              pids = slices.map { |slice| fork_child(slice) }
 
-              # capture pids here
-              start_children(slices)
-            end
-
-
-
-            private
-
-            def start_children(slices)
-              slices.each do |slice|
-                fork_child(slice)
+              Signal.trap("INT") do
+                pids.each do |pid|
+                  Process.kill(sig, pid)
+                end
               end
 
               Process.waitall

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -7,11 +7,15 @@ module Hanami
     module Commands
       module App
         module Assets
+          # Compiles assets for each slice.
+          #
           # @since 2.1.0
           # @api private
           class Compile < Assets::Command
             desc "Compile assets for deployments"
 
+            # @since 2.1.0
+            # @api private
             def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **opts)
               super(config: config, system_call: system_call, **opts)
             end

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -35,7 +35,7 @@ module Hanami
               Process.fork do
                 cmd, *args = cmd_with_args(slice)
                 system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
-              rescue Interrupt => e
+              rescue Interrupt
                 # When this has been interrupted (by the Signal.trap handler in #call), catch the
                 # interrupt and exit cleanly, without showing the default full backtrace.
               end

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -20,7 +20,7 @@ module Hanami
 
             # @since 2.1.0
             # @api private
-            def cmd_with_args(slice)
+            def assets_command(slice)
               cmd = super
 
               if config.subresource_integrity.any?

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -16,64 +16,18 @@ module Hanami
               super(config: config, system_call: system_call)
             end
 
-            def call(**)
-              slices = app.slices.with_nested + [app]
-              pids = slices.map { |slice| fork_child(slice) if slice_assets?(slice) }
-
-              Signal.trap("INT") do
-                pids.each do |pid|
-                  Process.kill(sig, pid)
-                end
-              end
-
-              Process.waitall
-            end
-
             private
-
-            def fork_child(slice)
-              Process.fork do
-                cmd, *args = cmd_with_args(slice)
-                system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
-              rescue Interrupt
-                # When this has been interrupted (by the Signal.trap handler in #call), catch the
-                # interrupt and exit cleanly, without showing the default full backtrace.
-              end
-            end
 
             # @since 2.1.0
             # @api private
             def cmd_with_args(slice)
-              result = [config.node_command, assets_config(slice).to_s, "--"]
-
-              if slice.eql?(slice.app)
-                result << "--path=app"
-                result << "--target=public/assets"
-              else
-                result << "--path=#{slice.root.relative_path_from(slice.app.root)}"
-                result << "--target=public/assets/#{slice.slice_name}"
-              end
+              cmd = super
 
               if config.subresource_integrity.any?
-                result << "--sri=#{escape(config.subresource_integrity.join(','))}"
+                cmd << "--sri=#{escape(config.subresource_integrity.join(','))}"
               end
 
-              result
-            end
-
-            def slice_assets?(slice)
-              slice.root.join("assets").directory?
-            end
-
-            def assets_config(slice)
-              config = slice.root.join("config", "assets.js")
-              return config if config.exist?
-
-              config = slice.app.root.join("config", "assets.js")
-              return config if config.exist?
-
-              # TODO: real error
-              raise "no asset config found"
+              cmd
             end
           end
         end

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -48,6 +48,8 @@ module Hanami
               slices.each do |slice|
                 fork_child(slice)
               end
+
+              Process.waitall
             end
 
             def fork_child(slice)
@@ -56,7 +58,7 @@ module Hanami
                 p cmd_with_args(slice)
                 result = system_call.call(cmd, *args)
 
-                if result.exit_code == 0
+                if result.exit_code == 0 # rubocop:disable Style/NumericPredicate TODO disable this entirely
                   puts result.out
 
                   if result.err && result.err != ""

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -13,8 +13,8 @@ module Hanami
           class Watch < Assets::Command
             desc "Start assets watch mode"
 
-            def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **)
-              super(config: config, system_call: system_call)
+            def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **opts)
+              super(config: config, system_call: system_call, **opts)
             end
 
             private

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -70,11 +70,7 @@ module Hanami
             # @since 2.1.0
             # @api private
             def cmd_with_args(slice)
-              result = super()
-
-              result << "--"
-
-              result << "--watch"
+              result = [config.node_command, assets_config(slice).to_s, "--", "--watch"]
 
               if slice.eql?(slice.app)
                 result << "--path=app"
@@ -85,6 +81,17 @@ module Hanami
               end
 
               result
+            end
+
+            def assets_config(slice)
+              config = slice.root.join("config", "assets.js")
+              return config if config.exist?
+
+              config = slice.app.root.join("config", "assets.js")
+              return config if config.exist?
+
+              # TODO: real error
+              raise "no asset config found"
             end
           end
         end

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -82,7 +82,6 @@ module Hanami
               else
                 result << "--path=#{slice.root.relative_path_from(slice.app.root)}"
                 result << "--target=public/assets/#{slice.slice_name}"
-                # TODO: work for nested slices
               end
 
               result

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -8,11 +8,15 @@ module Hanami
     module Commands
       module App
         module Assets
+          # Watches for asset changes within each slice.
+          #
           # @since 2.1.0
           # @api private
           class Watch < Assets::Command
             desc "Start assets watch mode"
 
+            # @since 2.1.0
+            # @api private
             def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **opts)
               super(config: config, system_call: system_call, **opts)
             end

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -19,17 +19,11 @@ module Hanami
 
             def call(**)
               slices = app.slices.with_nested + [app]
-
-              # capture pids here
               pids = start_children(slices)
-
 
               %w[INT USR1 TERM].each do |sig|
                 Signal.trap(sig) do
                   pids.each do |pid|
-                    puts "killing..."
-                    p sig
-                    p pid
                     Process.kill(sig, pid)
                   end
                 end
@@ -70,7 +64,6 @@ module Hanami
             def fork_child(slice)
               Process.fork do
                 cmd, *args = cmd_with_args(slice)
-                p cmd_with_args(slice)
                 result = system_call.call(cmd, *args)
 
                 if result.exit_code == 0
@@ -81,11 +74,7 @@ module Hanami
                     puts result.err
                   end
                 else
-                  puts "AssetsCompilationError"
-                  puts result.out
-                  puts result.err
-                  raise "AssetsCompilationError"
-                  # raise AssetsCompilationError.new(result.out, result.err)
+                  raise AssetsCompilationError.new(result.out, result.err)
                 end
               end
             end

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -78,6 +78,9 @@ module Hanami
                 else
                   raise AssetsCompilationError.new(result.out, result.err)
                 end
+              rescue Interrupt => e
+                # When this has been interrupted (by the Signal.trap handler in #call), catch the
+                # interrupt and exit cleanly, without showing the default full backtrace.
               end
             end
 

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -19,13 +19,11 @@ module Hanami
 
             def call(**)
               slices = app.slices.with_nested + [app]
-              pids = start_children(slices)
+              pids = slices.map { |slice| fork_child(slice) }
 
-              %w[INT USR1 TERM].each do |sig|
-                Signal.trap(sig) do
-                  pids.each do |pid|
-                    Process.kill(sig, pid)
-                  end
+              Signal.trap("INT") do
+                pids.each do |pid|
+                  Process.kill(sig, pid)
                 end
               end
 
@@ -33,14 +31,6 @@ module Hanami
             end
 
             private
-
-            # @since 2.1.0
-            # @api private
-            def start_children(slices)
-              slices.map do |slice|
-                fork_child(slice)
-              end
-            end
 
             # @since 2.1.0
             # @api private

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -21,7 +21,7 @@ module Hanami
 
             # @since 2.1.0
             # @api private
-            def cmd_with_args(slice)
+            def assets_command(slice)
               super + ["--watch"]
             end
           end

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -66,6 +66,8 @@ module Hanami
                 cmd, *args = cmd_with_args(slice)
                 result = system_call.call(cmd, *args)
 
+                # In ordinary usage, watch mode runs until it is interrupted by the user. We should
+                # only get here if the watch command fails for some reason.
                 if result.exit_code == 0
                   puts result.out
 

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -17,62 +17,12 @@ module Hanami
               super(config: config, system_call: system_call)
             end
 
-            def call(**)
-              slices = app.slices.with_nested + [app]
-              pids = slices.map { |slice| fork_child(slice) if slice_assets?(slice) }
-
-              Signal.trap("INT") do
-                pids.each do |pid|
-                  Process.kill(sig, pid)
-                end
-              end
-
-              Process.waitall
-            end
-
             private
 
             # @since 2.1.0
             # @api private
-            def fork_child(slice)
-              Process.fork do
-                cmd, *args = cmd_with_args(slice)
-                system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
-              rescue Interrupt
-                # When this has been interrupted (by the Signal.trap handler in #call), catch the
-                # interrupt and exit cleanly, without showing the default full backtrace.
-              end
-            end
-
-            # @since 2.1.0
-            # @api private
             def cmd_with_args(slice)
-              result = [config.node_command, assets_config(slice).to_s, "--", "--watch"]
-
-              if slice.eql?(slice.app)
-                result << "--path=app"
-                result << "--target=public/assets"
-              else
-                result << "--path=#{slice.root.relative_path_from(slice.app.root)}"
-                result << "--target=public/assets/#{slice.slice_name}"
-              end
-
-              result
-            end
-
-            def slice_assets?(slice)
-              slice.root.join("assets").directory?
-            end
-
-            def assets_config(slice)
-              config = slice.root.join("config", "assets.js")
-              return config if config.exist?
-
-              config = slice.app.root.join("config", "assets.js")
-              return config if config.exist?
-
-              # TODO: real error
-              raise "no asset config found"
+              super + ["--watch"]
             end
           end
         end

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -32,35 +32,18 @@ module Hanami
               Process.waitall
             end
 
-            # @since 2.1.0
-            # @api private
-            def cmd_with_args(slice)
-              result = super()
-
-              result << "--"
-
-              result << "--watch"
-
-              if slice.eql?(slice.app)
-                result << "--path=app"
-                result << "--target=public/assets"
-              else
-                result << "--path=#{slice.root.relative_path_from(slice.app.root)}"
-                result << "--target=public/assets/#{slice.slice_name}"
-                # TODO: work for nested slices
-              end
-
-              result
-            end
-
             private
 
+            # @since 2.1.0
+            # @api private
             def start_children(slices)
               slices.map do |slice|
                 fork_child(slice)
               end
             end
 
+            # @since 2.1.0
+            # @api private
             def fork_child(slice)
               Process.fork do
                 cmd, *args = cmd_with_args(slice)
@@ -84,14 +67,26 @@ module Hanami
               end
             end
 
+            # @since 2.1.0
+            # @api private
+            def cmd_with_args(slice)
+              result = super()
 
-            # private
+              result << "--"
 
-            # # @since 2.1.0
-            # # @api private
-            # def cmd_with_args
-            #   super + ["--", "--watch"]
-            # end
+              result << "--watch"
+
+              if slice.eql?(slice.app)
+                result << "--path=app"
+                result << "--target=public/assets"
+              else
+                result << "--path=#{slice.root.relative_path_from(slice.app.root)}"
+                result << "--target=public/assets/#{slice.slice_name}"
+                # TODO: work for nested slices
+              end
+
+              result
+            end
           end
         end
       end

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -38,7 +38,7 @@ module Hanami
               Process.fork do
                 cmd, *args = cmd_with_args(slice)
                 system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
-              rescue Interrupt => e
+              rescue Interrupt
                 # When this has been interrupted (by the Signal.trap handler in #call), catch the
                 # interrupt and exit cleanly, without showing the default full backtrace.
               end

--- a/spec/integration/run_spec.rb
+++ b/spec/integration/run_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bin/hanami", :app do
       let(:args) { %w[unknown command] }
 
       it "prints help and exits with error code" do
-        expect(exit_code).to be(1)
+        expect(exit_code).to eq 1
         expect(stderr).to include("Commands:")
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe "bin/hanami", :app do
       let(:args) { %w[generate action home.index --slice=foo] }
 
       it "prints error message and exits with error code" do
-        expect(exit_code).to be(1)
+        expect(exit_code).to eq 1
         expect(stderr).to include("slice `foo' is missing")
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "hanami/cli"
+require "pathname"
+
+SPEC_ROOT = Pathname(File.expand_path(__dir__)).freeze
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -61,6 +64,7 @@ RSpec.configure do |config|
   config.around(app: true) do |example|
     require_relative "fixtures/test/config/app" unless defined?(Test::App)
     example.run
+    $LOADED_FEATURES.delete(SPEC_ROOT.join("fixtures/test/config/app.rb").to_s)
   end
 end
 

--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "hanami/devtools/integration/files"
+require "hanami/devtools/integration/with_tmp_directory"
+require "json"
+require "tmpdir"
+require "zeitwerk"
+
+module RSpec
+  module Support
+    module WithTmpDirectory
+      private
+
+      def make_tmp_directory
+        Pathname(Dir.mktmpdir).tap do |dir|
+          (@made_tmp_dirs ||= []) << dir
+        end
+      end
+    end
+
+    module App
+    end
+  end
+end
+
+RSpec.shared_context "App integration" do
+  let(:app_modules) { %i[Test TestApp Admin Main] }
+end
+
+def autoloaders_teardown!
+  ObjectSpace.each_object(Zeitwerk::Loader) do |loader|
+    loader.unregister if loader.dirs.any? { |dir|
+      dir.include?("/spec/") || dir.include?(Dir.tmpdir) ||
+      dir.include?("/slices/") || dir.include?("/app")
+    }
+  end
+end
+
+RSpec.configure do |config|
+  config.include RSpec::Support::Files, :app_integration
+  config.include RSpec::Support::WithTmpDirectory, :app_integration
+  config.include RSpec::Support::App, :app_integration
+  config.include_context "App integration", :app, :app_integration
+
+  prepare_example = proc do
+    # Conditionally assign in case these have been assigned earlier for specific example groups
+    @load_paths ||= $LOAD_PATH.dup
+    @loaded_features ||= $LOADED_FEATURES.dup
+  end
+
+  tidy_example = proc do
+    autoloaders_teardown!
+
+    Hanami.instance_variable_set(:@_bundled, {})
+    Hanami.remove_instance_variable(:@_app) if Hanami.instance_variable_defined?(:@_app)
+
+    $LOAD_PATH.replace(@load_paths)
+
+    # Remove example-specific LOADED_FEATURES added when running each example
+    new_features_to_keep = ($LOADED_FEATURES - @loaded_features).tap { |feats|
+      feats.delete_if do |path|
+        path =~ %r{hanami/(setup|prepare|boot|application/container/providers)} ||
+          path.include?(SPEC_ROOT.to_s) ||
+          path.include?(Dir.tmpdir)
+      end
+    }
+    $LOADED_FEATURES.replace(@loaded_features + new_features_to_keep)
+
+    app_modules.each do |app_module_name|
+      next unless Object.const_defined?(app_module_name)
+
+      Object.const_get(app_module_name).tap do |mod|
+        mod.constants.each do |name|
+          mod.send(:remove_const, name)
+        end
+      end
+
+      Object.send(:remove_const, app_module_name)
+    end
+  end
+
+  config.before(:each, :app) { instance_eval(&prepare_example) }
+  config.before(:each, :app_integration) { instance_eval(&prepare_example) }
+  config.after(:each, :app) { instance_eval(&tidy_example) }
+  config.after(:each, :app_integration) { instance_eval(&tidy_example) }
+
+  config.after :all do
+    if instance_variable_defined?(:@made_tmp_dirs)
+      Array(@made_tmp_dirs).each do |dir|
+        FileUtils.remove_entry dir
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -1,14 +1,141 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, :app do
-  subject { described_class.new(system_call: system_call) }
-  let(:system_call) { proc { |**| } }
+RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integration do
+  subject(:compile_command) { described_class.new(system_call: interactive_system_call) }
+  let(:interactive_system_call) { instance_double(Hanami::CLI::InteractiveSystemCall) }
 
-  context "#call" do
-    it "invokes hanami-assets executable" do
-      expect(system_call).to receive(:call).with("npm run --silent", "assets")
+  before do
+    with_directory(make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
 
-      subject.call
+      write "config/assets.js", ""
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  before do
+    # Instead of forking a process per slice, run that code directly. This is is necessary becuase
+    # RSpec method expectations won't work on objects in a forked process.
+    allow(Process).to receive(:fork).and_wrap_original do |_original_method, &block|
+      block.call
+    end
+  end
+
+  describe "assets in app" do
+    describe "assets dir present" do
+      def before_prepare
+        write "assets/.keep", ""
+      end
+
+      it "compiles the app assets" do
+        expect(interactive_system_call).to receive(:call).with(
+          "node",
+          Hanami.app.root.join("config", "assets.js").to_s,
+          "--",
+          "--path=app",
+          "--target=public/assets",
+          {out_prefix: "[test_app] "}
+        )
+
+        compile_command.call
+      end
+    end
+
+    describe "assets dir absent" do
+      it "does not watch app assets" do
+        expect(interactive_system_call).not_to receive(:call)
+
+        compile_command.call
+      end
+    end
+  end
+
+  describe "assets in slice" do
+    describe "assets dir present" do
+      def before_prepare
+        write "slices/admin/assets/.keep", ""
+      end
+
+      it "compiles the slice assets" do
+        expect(interactive_system_call).to receive(:call).with(
+          "node",
+          Hanami.app.root.join("config", "assets.js").to_s,
+          "--",
+          "--path=slices/admin",
+          "--target=public/assets/admin",
+          {out_prefix: "[admin] "}
+        )
+
+        compile_command.call
+      end
+    end
+
+    describe "slice assets config file" do
+      def before_prepare
+        write "slices/admin/config/assets.js", ""
+        write "slices/admin/assets/.keep", ""
+      end
+
+      it "compiles the slice assets using the slice's assets config" do
+        expect(interactive_system_call).to receive(:call).with(
+          "node",
+          Hanami.app.root.join("slices", "admin", "config", "assets.js").to_s,
+          "--",
+          "--path=slices/admin",
+          "--target=public/assets/admin",
+          {out_prefix: "[admin] "}
+        )
+
+        compile_command.call
+      end
+    end
+
+    describe "assets dir absent" do
+      def before_prepare
+        write "slices/admin/.keep", ""
+      end
+
+      it "does not watch app assets" do
+        expect(interactive_system_call).not_to receive(:call)
+
+        compile_command.call
+      end
+    end
+  end
+
+  describe "assets present in multiple slices" do
+    def before_prepare
+      write "slices/admin/assets/.keep", ""
+      write "slices/main/assets/.keep", ""
+    end
+
+    it "compiles the assets for each slice" do
+      expect(interactive_system_call).to receive(:call).with(
+        "node",
+        Hanami.app.root.join("config", "assets.js").to_s,
+        "--",
+        "--path=slices/admin",
+        "--target=public/assets/admin",
+        {out_prefix: "[admin] "}
+      )
+
+      expect(interactive_system_call).to receive(:call).with(
+        "node",
+        Hanami.app.root.join("config", "assets.js").to_s,
+        "--",
+        "--path=slices/main",
+        "--target=public/assets/main",
+        {out_prefix: "[main] "}
+      )
+
+      compile_command.call
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
           "--path=app",
-          "--target=public/assets",
+          "--dest=public/assets",
           {out_prefix: "[test_app] "}
         )
 
@@ -84,7 +84,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--target=public/assets/admin",
+          "--dest=public/assets/admin",
           {out_prefix: "[admin] "}
         )
 
@@ -104,7 +104,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           Hanami.app.root.join("slices", "admin", "config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--target=public/assets/admin",
+          "--dest=public/assets/admin",
           {out_prefix: "[admin] "}
         )
 
@@ -137,7 +137,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/admin",
-        "--target=public/assets/admin",
+        "--dest=public/assets/admin",
         {out_prefix: "[admin] "}
       )
 
@@ -146,7 +146,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/main",
-        "--target=public/assets/main",
+        "--dest=public/assets/main",
         {out_prefix: "[main] "}
       )
 
@@ -166,7 +166,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=app",
-        "--target=public/assets",
+        "--dest=public/assets",
         "--sri=sha256,sha512",
         {out_prefix: "[test_app] "}
       )

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -174,4 +174,19 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
       compile_command.call
     end
   end
+
+  describe "missing config/asset.js" do
+    def before_prepare
+      write "assets/.keep", ""
+      FileUtils.rm_f "config/assets.js"
+    end
+
+    it "prints an error message" do
+      expect(interactive_system_call).not_to receive(:call)
+
+      compile_command.call
+
+      expect(output).to eq "No assets config found for TestApp::App. Please create a config/assets.js.\n"
+    end
+  end
 end

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integration do
-  subject(:compile_command) { described_class.new(system_call: interactive_system_call) }
+  subject(:compile_command) {
+    described_class.new(
+      system_call: interactive_system_call,
+      out: out
+    )
+  }
+
   let(:interactive_system_call) { instance_double(Hanami::CLI::InteractiveSystemCall) }
+
+  let(:out) { StringIO.new }
+  let(:output) {
+    out.rewind
+    out.read
+  }
 
   before do
     with_directory(make_tmp_directory) do
@@ -54,6 +66,8 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         expect(interactive_system_call).not_to receive(:call)
 
         compile_command.call
+
+        expect(output).to eq "No assets found.\n"
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
 
       write "config/assets.js", ""
 
+      require "hanami/setup"
       before_prepare if respond_to?(:before_prepare)
       require "hanami/prepare"
     end
@@ -133,6 +134,27 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         "--path=slices/main",
         "--target=public/assets/main",
         {out_prefix: "[main] "}
+      )
+
+      compile_command.call
+    end
+  end
+
+  describe "subresource integrity configured" do
+    def before_prepare
+      Hanami.app.config.assets.subresource_integrity = [:sha256, :sha512]
+      write "assets/.keep", ""
+    end
+
+    it "passes the setting via the --sri flag" do
+      expect(interactive_system_call).to receive(:call).with(
+        "node",
+        Hanami.app.root.join("config", "assets.js").to_s,
+        "--",
+        "--path=app",
+        "--target=public/assets",
+        "--sri=sha256,sha512",
+        {out_prefix: "[test_app] "}
       )
 
       compile_command.call

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integration do
-  subject(:watch_command) { described_class.new(system_call: interactive_system_call) }
+  subject(:watch_command) {
+    described_class.new(
+      system_call: interactive_system_call,
+      out: out
+    )
+  }
+
   let(:interactive_system_call) { instance_double(Hanami::CLI::InteractiveSystemCall) }
+
+  let(:out) { StringIO.new }
+  let(:output) {
+    out.rewind
+    out.read
+  }
 
   before do
     with_directory(make_tmp_directory) do
@@ -54,6 +66,8 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         expect(interactive_system_call).not_to receive(:call)
 
         watch_command.call
+
+        expect(output).to eq "No assets found.\n"
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
           "--path=app",
-          "--target=public/assets",
+          "--dest=public/assets",
           "--watch",
           {out_prefix: "[test_app] "}
         )
@@ -84,7 +84,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--target=public/assets/admin",
+          "--dest=public/assets/admin",
           "--watch",
           {out_prefix: "[admin] "}
         )
@@ -105,7 +105,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           Hanami.app.root.join("slices", "admin", "config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--target=public/assets/admin",
+          "--dest=public/assets/admin",
           "--watch",
           {out_prefix: "[admin] "}
         )
@@ -139,7 +139,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/admin",
-        "--target=public/assets/admin",
+        "--dest=public/assets/admin",
         "--watch",
         {out_prefix: "[admin] "}
       )
@@ -149,7 +149,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/main",
-        "--target=public/assets/main",
+        "--dest=public/assets/main",
         "--watch",
         {out_prefix: "[main] "}
       )

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -1,14 +1,146 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, :app do
-  subject { described_class.new(system_call: interactive_system_call) }
-  let(:interactive_system_call) { proc { |**| } }
+RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integration do
+  subject(:watch_command) { described_class.new(system_call: interactive_system_call) }
+  let(:interactive_system_call) { instance_double(Hanami::CLI::InteractiveSystemCall) }
 
-  context "#call" do
-    it "invokes hanami-assets executable" do
-      expect(interactive_system_call).to receive(:call).with("npm run --silent", "assets", "--", "--watch")
+  before do
+    with_directory(make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
 
-      subject.call
+      write "config/assets.js", ""
+
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  before do
+    # Instead of forking a process per slice, run that code directly. This is is necessary becuase
+    # RSpec method expectations won't work on objects in a forked process.
+    allow(Process).to receive(:fork).and_wrap_original do |_original_method, &block|
+      block.call
+    end
+  end
+
+  describe "assets in app" do
+    describe "assets dir present" do
+      def before_prepare
+        write "assets/.keep", ""
+      end
+
+      it "watches the app assets" do
+        expect(interactive_system_call).to receive(:call).with(
+          "node",
+          Hanami.app.root.join("config", "assets.js").to_s,
+          "--",
+          "--watch",
+          "--path=app",
+          "--target=public/assets",
+          {out_prefix: "[test_app] "}
+        )
+
+        watch_command.call
+      end
+    end
+
+    describe "assets dir absent" do
+      it "does not watch app assets" do
+        expect(interactive_system_call).not_to receive(:call)
+
+        watch_command.call
+      end
+    end
+  end
+
+  describe "assets in slice" do
+    describe "assets dir present" do
+      def before_prepare
+        write "slices/admin/assets/.keep", ""
+      end
+
+      it "watches the slice assets" do
+        expect(interactive_system_call).to receive(:call).with(
+          "node",
+          Hanami.app.root.join("config", "assets.js").to_s,
+          "--",
+          "--watch",
+          "--path=slices/admin",
+          "--target=public/assets/admin",
+          {out_prefix: "[admin] "}
+        )
+
+        watch_command.call
+      end
+    end
+
+    describe "slice assets config file" do
+      def before_prepare
+        write "slices/admin/config/assets.js", ""
+        write "slices/admin/assets/.keep", ""
+      end
+
+      it "watches the slice assets using the slice's assets config" do
+        expect(interactive_system_call).to receive(:call).with(
+          "node",
+          Hanami.app.root.join("slices", "admin", "config", "assets.js").to_s,
+          "--",
+          "--watch",
+          "--path=slices/admin",
+          "--target=public/assets/admin",
+          {out_prefix: "[admin] "}
+        )
+
+        watch_command.call
+      end
+    end
+
+    describe "assets dir absent" do
+      def before_prepare
+        write "slices/admin/.keep", ""
+      end
+
+      it "does not watch app assets" do
+        expect(interactive_system_call).not_to receive(:call)
+
+        watch_command.call
+      end
+    end
+  end
+
+  describe "assets present in multiple slices" do
+    def before_prepare
+      write "slices/admin/assets/.keep", ""
+      write "slices/main/assets/.keep", ""
+    end
+
+    it "watches the assets for each slice" do
+      expect(interactive_system_call).to receive(:call).with(
+        "node",
+        Hanami.app.root.join("config", "assets.js").to_s,
+        "--",
+        "--watch",
+        "--path=slices/admin",
+        "--target=public/assets/admin",
+        {out_prefix: "[admin] "}
+      )
+
+      expect(interactive_system_call).to receive(:call).with(
+        "node",
+        Hanami.app.root.join("config", "assets.js").to_s,
+        "--",
+        "--watch",
+        "--path=slices/main",
+        "--target=public/assets/main",
+        {out_prefix: "[main] "}
+      )
+
+      watch_command.call
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           "node",
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
-          "--watch",
           "--path=app",
           "--target=public/assets",
+          "--watch",
           {out_prefix: "[test_app] "}
         )
 
@@ -69,9 +69,9 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           "node",
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
-          "--watch",
           "--path=slices/admin",
           "--target=public/assets/admin",
+          "--watch",
           {out_prefix: "[admin] "}
         )
 
@@ -90,9 +90,9 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           "node",
           Hanami.app.root.join("slices", "admin", "config", "assets.js").to_s,
           "--",
-          "--watch",
           "--path=slices/admin",
           "--target=public/assets/admin",
+          "--watch",
           {out_prefix: "[admin] "}
         )
 
@@ -124,9 +124,9 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         "node",
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
-        "--watch",
         "--path=slices/admin",
         "--target=public/assets/admin",
+        "--watch",
         {out_prefix: "[admin] "}
       )
 
@@ -134,9 +134,9 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         "node",
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
-        "--watch",
         "--path=slices/main",
         "--target=public/assets/main",
+        "--watch",
         {out_prefix: "[main] "}
       )
 

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -3,7 +3,7 @@
 require "hanami"
 require "securerandom"
 
-RSpec.describe Hanami::CLI::Commands::App::Generate::Slice do
+RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
   subject { described_class.new(fs: fs, inflector: inflector, generator: generator) }
 
   before do


### PR DESCRIPTION
Build upon https://github.com/hanami/assets-js/pull/20 and update the `assets compile` and `assets watch` commands to fork a child process per slice and run a separate assets command per each.

Provide appropriate `--path` and `--dest` flags for each of these commands, allowing each slice's assets to be compiled separately and generated into distinct directories (`public/assets/` for the app, and `public/assets/[slice_name]/` for slices).

Supports per-slice assets config, by running a slice's own `config/assets.js`, if present, otherwise falling back to the app's `config/assets.js`.

Finally, incorporates hanami/assets#138, using the new `node_command` setting to invoke node when running the `config/assets.js` command.