### PR TITLE
Properly detect assets inside app/assets/

### DIFF
--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -109,7 +109,14 @@ module Hanami
             # @since 2.1.0
             # @api private
             def slice_assets?(slice)
-              slice.root.join("assets").directory?
+              assets_path =
+                if slice.app.eql?(slice)
+                  slice.root.join("app", "assets")
+                else
+                  slice.root.join("assets")
+                end
+
+              assets_path.directory?
             end
 
             # Returns the path to the assets config (`config/assets.js`) for the given slice.

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integration do
-  subject(:compile_command) {
+  subject(:command) {
     described_class.new(
       system_call: interactive_system_call,
       out: out
@@ -57,7 +57,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           {out_prefix: "[test_app] "}
         )
 
-        compile_command.call
+        command.call
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
       it "does not watch app assets" do
         expect(interactive_system_call).not_to receive(:call)
 
-        compile_command.call
+        command.call
 
         expect(output).to eq "No assets found.\n"
       end
@@ -88,7 +88,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           {out_prefix: "[admin] "}
         )
 
-        compile_command.call
+        command.call
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           {out_prefix: "[admin] "}
         )
 
-        compile_command.call
+        command.call
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
       it "does not watch app assets" do
         expect(interactive_system_call).not_to receive(:call)
 
-        compile_command.call
+        command.call
       end
     end
   end
@@ -150,7 +150,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         {out_prefix: "[main] "}
       )
 
-      compile_command.call
+      command.call
     end
   end
 
@@ -171,7 +171,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         {out_prefix: "[test_app] "}
       )
 
-      compile_command.call
+      command.call
     end
   end
 
@@ -184,7 +184,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
     it "prints an error message" do
       expect(interactive_system_call).not_to receive(:call)
 
-      compile_command.call
+      command.call
 
       expect(output).to eq "No assets config found for TestApp::App. Please create a config/assets.js.\n"
     end

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
   describe "assets in app" do
     describe "assets dir present" do
       def before_prepare
-        write "assets/.keep", ""
+        write "app/assets/.keep", ""
       end
 
       it "compiles the app assets" do
@@ -157,7 +157,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
   describe "subresource integrity configured" do
     def before_prepare
       Hanami.app.config.assets.subresource_integrity = [:sha256, :sha512]
-      write "assets/.keep", ""
+      write "app/assets/.keep", ""
     end
 
     it "passes the setting via the --sri flag" do
@@ -177,7 +177,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
 
   describe "missing config/asset.js" do
     def before_prepare
-      write "assets/.keep", ""
+      write "app/assets/.keep", ""
       FileUtils.rm_f "config/assets.js"
     end
 

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integration do
-  subject(:watch_command) {
+  subject(:command) {
     described_class.new(
       system_call: interactive_system_call,
       out: out
@@ -57,7 +57,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           {out_prefix: "[test_app] "}
         )
 
-        watch_command.call
+        command.call
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
       it "does not watch app assets" do
         expect(interactive_system_call).not_to receive(:call)
 
-        watch_command.call
+        command.call
 
         expect(output).to eq "No assets found.\n"
       end
@@ -89,7 +89,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           {out_prefix: "[admin] "}
         )
 
-        watch_command.call
+        command.call
       end
     end
 
@@ -110,7 +110,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           {out_prefix: "[admin] "}
         )
 
-        watch_command.call
+        command.call
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
       it "does not watch app assets" do
         expect(interactive_system_call).not_to receive(:call)
 
-        watch_command.call
+        command.call
       end
     end
   end
@@ -154,7 +154,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         {out_prefix: "[main] "}
       )
 
-      watch_command.call
+      command.call
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
   describe "assets in app" do
     describe "assets dir present" do
       def before_prepare
-        write "assets/.keep", ""
+        write "app/assets/.keep", ""
       end
 
       it "watches the app assets" do


### PR DESCRIPTION
For the app, assets live inside /app/assets, instead of just /assets.