### PR TITLE
Provide command default args via `.new` instead of `#initialize`

### DIFF
--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -13,18 +13,40 @@ module Hanami
     class Command < Dry::CLI::Command
       # Returns a new command.
       #
-      # This method does not need to be called directly when creating comments for the CLI. Commands
+      # Provides default values so they can be available to any subclasses defining their own
+      # {#initialize} methods.
+      #
+      # @see #initialize
+      #
+      # @since 2.1.0
+      # @api public
+      def self.new(
+        out: $stdout,
+        err: $stderr,
+        fs: Hanami::CLI::Files.new,
+        inflector: Dry::Inflector.new,
+        **opts
+      )
+        super(out: out, err: err, fs: fs, inflector: inflector, **opts)
+      end
+
+      # Returns a new command.
+      #
+      # This method does not need to be called directly when creating commands for the CLI. Commands
       # are registered as classes, and the CLI framework will initialize the command when needed.
-      # This means that all parameters for `#initialize` should also be given default arguments.
+      # This means that all parameters for `#initialize` should also be given default arguments. See
+      # {.new} for the standard default arguments for all commands.
       #
       # @param out [IO] I/O stream for standard command output
       # @param err [IO] I/O stream for comment errror output
       # @param fs [Hanami::CLI::Files] object for managing file system interactions
       # @param inflector [Dry::Inflector] inflector for any command-level inflections
       #
+      # @see .new
+      #
       # @since 2.0.0
       # @api public
-      def initialize(out: $stdout, err: $stderr, fs: Hanami::CLI::Files.new, inflector: Dry::Inflector.new)
+      def initialize(out:, err:, fs:, inflector:)
         super()
         @out = out
         @err = err

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -2,7 +2,7 @@
 
 require "shellwords"
 require_relative "../command"
-require_relative "../../../system_call"
+require_relative "../../../interactive_system_call"
 
 module Hanami
   module CLI
@@ -27,10 +27,18 @@ module Hanami
           # @since 2.1.0
           # @api private
           class Command < App::Command
-            def initialize(config: app.config.assets, system_call: SystemCall.new, **opts)
-              super(**opts)
-              @system_call = system_call
+            # @since 2.1.0
+            # @api private
+            def initialize(
+              out:, err:,
+              config: app.config.assets,
+              system_call: InteractiveSystemCall.new(out: out, err: err, exit_after: false),
+              **opts
+            )
+              super(out: out, err: err, **opts)
+
               @config = config
+              @system_call = system_call
             end
 
             # @since 2.1.0

--- a/lib/hanami/cli/commands/app/assets/compile.rb
+++ b/lib/hanami/cli/commands/app/assets/compile.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "command"
-require_relative "../../../interactive_system_call"
 
 module Hanami
   module CLI
@@ -14,12 +13,6 @@ module Hanami
           # @api private
           class Compile < Assets::Command
             desc "Compile assets for deployments"
-
-            # @since 2.1.0
-            # @api private
-            def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **opts)
-              super(config: config, system_call: system_call, **opts)
-            end
 
             private
 

--- a/lib/hanami/cli/commands/app/assets/watch.rb
+++ b/lib/hanami/cli/commands/app/assets/watch.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "command"
-require_relative "../../../interactive_system_call"
 
 module Hanami
   module CLI
@@ -14,12 +13,6 @@ module Hanami
           # @api private
           class Watch < Assets::Command
             desc "Start assets watch mode"
-
-            # @since 2.1.0
-            # @api private
-            def initialize(config: app.config.assets, system_call: InteractiveSystemCall.new(exit_after: false), **opts)
-              super(config: config, system_call: system_call, **opts)
-            end
 
             private
 

--- a/lib/hanami/cli/commands/app/dev.rb
+++ b/lib/hanami/cli/commands/app/dev.rb
@@ -15,23 +15,28 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          def initialize(interactive_system_call: InteractiveSystemCall.new, **)
-            @interactive_system_call = interactive_system_call
-            super()
+          def initialize(
+            out:, err:,
+            system_call: InteractiveSystemCall.new(out: out, err: err),
+            **opts
+          )
+            super(out: out, err: err, **opts)
+
+            @system_call = system_call
           end
 
           # @since 2.1.0
           # @api private
           def call(**)
             bin, args = executable
-            interactive_system_call.call(bin, *args)
+            system_call.call(bin, *args)
           end
 
           private
 
           # @since 2.1.0
           # @api private
-          attr_reader :interactive_system_call
+          attr_reader :system_call
 
           # @since 2.1.0
           # @api private

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -61,12 +61,16 @@ module Hanami
 
             # @since 2.0.0
             # @api private
-            def initialize(fs: Hanami::CLI::Files.new, inflector: Dry::Inflector.new,
-                           naming: Naming.new(inflector: inflector),
-                           generator: Generators::App::Action.new(fs: fs, inflector: inflector), **)
+            def initialize(
+              fs:, inflector:,
+              naming: Naming.new(inflector: inflector),
+              generator: Generators::App::Action.new(fs: fs, inflector: inflector),
+              **opts
+            )
+              super(fs: fs, inflector: inflector, **opts)
+
               @naming = naming
               @generator = generator
-              super(fs: fs)
             end
 
             # rubocop:disable Metrics/ParameterLists

--- a/lib/hanami/cli/commands/app/generate/part.rb
+++ b/lib/hanami/cli/commands/app/generate/part.rb
@@ -34,13 +34,12 @@ module Hanami
             # @since 2.0.0
             # @api private
             def initialize(
-              fs: Hanami::CLI::Files.new,
-              inflector: Dry::Inflector.new,
+              fs:, inflector:,
               generator: Generators::App::Part.new(fs: fs, inflector: inflector),
-              **
+              **opts
             )
+              super(fs: fs, inflector: inflector, **opts)
               @generator = generator
-              super(fs: fs)
             end
 
             # @since 2.0.0

--- a/lib/hanami/cli/commands/app/generate/slice.rb
+++ b/lib/hanami/cli/commands/app/generate/slice.rb
@@ -23,10 +23,13 @@ module Hanami
 
             # @since 2.0.0
             # @api private
-            def initialize(fs: Hanami::CLI::Files.new, inflector: Dry::Inflector.new,
-                           generator: Generators::App::Slice.new(fs: fs, inflector: inflector), **)
+            def initialize(
+              fs:, inflector:,
+              generator: Generators::App::Slice.new(fs: fs, inflector: inflector),
+              **opts
+            )
+              super(fs: fs, inflector: inflector, **opts)
               @generator = generator
-              super(fs: fs)
             end
 
             # @since 2.0.0

--- a/lib/hanami/cli/commands/app/generate/view.rb
+++ b/lib/hanami/cli/commands/app/generate/view.rb
@@ -33,13 +33,12 @@ module Hanami
             # @since 2.0.0
             # @api private
             def initialize(
-              fs: Hanami::CLI::Files.new,
-              inflector: Dry::Inflector.new,
+              fs:, inflector:,
               generator: Generators::App::View.new(fs: fs, inflector: inflector),
-              **
+              **opts
             )
+              super(fs: fs, inflector: inflector, **opts)
               @generator = generator
-              super(fs: fs)
             end
 
             # @since 2.0.0

--- a/lib/hanami/cli/commands/app/server.rb
+++ b/lib/hanami/cli/commands/app/server.rb
@@ -46,8 +46,8 @@ module Hanami
 
           # @since 2.0.0
           # @api private
-          def initialize(server: Hanami::CLI::Server.new)
-            super()
+          def initialize(server: Hanami::CLI::Server.new, **opts)
+            super(**opts)
             @server = server
           end
 

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -63,17 +63,16 @@ module Hanami
           # @since 2.0.0
           # @api private
           def initialize(
-            fs: Hanami::CLI::Files.new,
-            inflector: Dry::Inflector.new,
+            fs:, inflector:,
             bundler: CLI::Bundler.new(fs: fs),
             generator: Generators::Gem::App.new(fs: fs, inflector: inflector),
             system_call: SystemCall.new,
-            **other
+            **opts
           )
+            super(fs: fs, inflector: inflector, **opts)
             @bundler = bundler
             @generator = generator
             @system_call = system_call
-            super(fs: fs, inflector: inflector, **other)
           end
 
           # rubocop:enable Metrics/ParameterLists

--- a/spec/unit/hanami/cli/commands/app/dev_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/dev_spec.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Dev do
-  subject { described_class.new(interactive_system_call: interactive_system_call) }
-  let(:interactive_system_call) { proc { |**| } }
-  let(:bin) { "bin/dev" }
+  subject { described_class.new(system_call: system_call) }
+  let(:system_call) { instance_double(Hanami::CLI::InteractiveSystemCall) }
 
   context "#call" do
     it "invokes external command to start Procfile based session" do
-      expect(interactive_system_call).to receive(:call).with(bin)
+      expect(system_call).to receive(:call).with "bin/dev"
 
       subject.call
     end


### PR DESCRIPTION
This allows these default args to be already provided by the time any subclass `#initialize`  is called, which means they can be accessed inside that method (or even inside its other default args) without the same defaults having to be re-provided.

For example, a subclass that needs `out:` and `err:` can now do this:

```ruby
def initialize(out:, err:, inflector:, another: AnotherClass.new(out:, err:, inflector:), **opts)
  super(out:, err:, inflector:, **opts)
  @another = another
end
```

Where previously, redefining the default args was necessary:

```ruby
def initialize(out: $stdout, err:, $stderr, inflector: Dry::Inflector.new, another: AnotherClass.new(out:, err:, inflector:), **opts)
  super(out:, err:, inflector:, **opts)
  @another = another
end
```

This arrangement required unnecessary repetition of the default values, and would have made it impractical (or even a source of unexpected behaviour) for hanami-cli to change those default values in the future, as their previous incarnations may have been repeated across command subclasses.