### PR TITLE
Remove "assets" from package.json "scripts" section

### DIFF
--- a/lib/hanami/cli/generators/gem/app/package.json.erb
+++ b/lib/hanami/cli/generators/gem/app/package.json.erb
@@ -2,9 +2,6 @@
   "name": "<%= underscored_app_name %>",
   "private": true,
   "type": "module",
-  "scripts": {
-    "assets": "node config/assets.js"
-  },
   "dependencies": {
     <%= hanami_assets_npm_package %>
   }

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -143,9 +143,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           "name": "#{app}",
           "private": true,
           "type": "module",
-          "scripts": {
-            "assets": "node config/assets.js"
-          },
           "dependencies": {
             "hanami-assets": "#{hanami_npm_version}"
           }


### PR DESCRIPTION
We no longer need this. Instead, our assets CLI commands are detecting the `config/assets.js` file and calling it directly.

Fixes #133.