### PR TITLE
Don’t namespace asset tags for slice layouts

### DIFF
--- a/lib/hanami/cli/generators/app/slice_context.rb
+++ b/lib/hanami/cli/generators/app/slice_context.rb
@@ -38,13 +38,13 @@ module Hanami
           # @since 2.1.0
           # @api private
           def stylesheet_erb_tag
-            %(<%= stylesheet_tag "#{slice}/app" %>)
+            %(<%= stylesheet_tag "app" %>)
           end
 
           # @since 2.1.0
           # @api private
           def javascript_erb_tag
-            %(<%= javascript_tag "#{slice}/app" %>)
+            %(<%= javascript_tag "app" %>)
           end
 
           private

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -116,11 +116,11 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>#{inflector.humanize(app)} - #{inflector.humanize(slice)}</title>
             <%= favicon_tag %>
-            <%= stylesheet_tag "#{slice}/app" %>
+            <%= stylesheet_tag "app" %>
           </head>
           <body>
             <%= yield %>
-            <%= javascript_tag "#{slice}/app" %>
+            <%= javascript_tag "app" %>
           </body>
         </html>
       ERB


### PR DESCRIPTION
This is no longer necessary with the independent assets per slice.