### PR TITLE
Underscore slice names in public asset dirs

### DIFF
--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -101,7 +101,7 @@ module Hanami
                 cmd << "--dest=public/assets"
               else
                 cmd << "--path=#{slice.root.relative_path_from(slice.app.root)}"
-                cmd << "--dest=public/assets/#{slice.slice_name}"
+                cmd << "--dest=public/assets/#{Hanami::Assets.public_assets_dir(slice)}"
               end
 
               cmd

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--dest=public/assets/admin",
+          "--dest=public/assets/_admin",
           {out_prefix: "[admin] "}
         )
 
@@ -104,7 +104,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
           Hanami.app.root.join("slices", "admin", "config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--dest=public/assets/admin",
+          "--dest=public/assets/_admin",
           {out_prefix: "[admin] "}
         )
 
@@ -137,7 +137,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/admin",
-        "--dest=public/assets/admin",
+        "--dest=public/assets/_admin",
         {out_prefix: "[admin] "}
       )
 
@@ -146,7 +146,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/main",
-        "--dest=public/assets/main",
+        "--dest=public/assets/_main",
         {out_prefix: "[main] "}
       )
 

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           Hanami.app.root.join("config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--dest=public/assets/admin",
+          "--dest=public/assets/_admin",
           "--watch",
           {out_prefix: "[admin] "}
         )
@@ -105,7 +105,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
           Hanami.app.root.join("slices", "admin", "config", "assets.js").to_s,
           "--",
           "--path=slices/admin",
-          "--dest=public/assets/admin",
+          "--dest=public/assets/_admin",
           "--watch",
           {out_prefix: "[admin] "}
         )
@@ -139,7 +139,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/admin",
-        "--dest=public/assets/admin",
+        "--dest=public/assets/_admin",
         "--watch",
         {out_prefix: "[admin] "}
       )
@@ -149,7 +149,7 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
         Hanami.app.root.join("config", "assets.js").to_s,
         "--",
         "--path=slices/main",
-        "--dest=public/assets/main",
+        "--dest=public/assets/_main",
         "--watch",
         {out_prefix: "[main] "}
       )


### PR DESCRIPTION
This will avoid naming collisions with ordinary user-controlled files or directories.

Uses the new `Hanami::Assets.public_assets_dir` method introduced in https://github.com/hanami/assets/pull/140.