### PR TITLE
Use stringified signal when Ctrl+C received by assets command

### DIFF
--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -62,7 +62,7 @@ module Hanami
 
               Signal.trap("INT") do
                 pids.each do |pid|
-                  Process.kill(sig, pid)
+                  Process.kill("INT", pid)
                 end
               end
 


### PR DESCRIPTION
When I use `hanami assets watch` and then close it with Ctrl+C, I see:

```
hanami assets watch
[blog] [watch] build finished, watching for changes...
^C/Users/ryan.bigg/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/hanami-cli-2.1.0/lib/hanami/cli/commands/app/assets/command.rb:65:in `block (2 levels) in call': undefined local variable or method `sig' for #<Hanami::CLI::Commands::App::Assets::Watch:0x00000001103fdc00 @app=Blog::App, @out=#<IO:<STDOUT>>, @err=#<IO:<STDERR>>, @fs=#<Hanami::CLI::Files:0x00000001104fc340 @adapter=#<Dry::Files::FileSystem:0x00000001104fc1d8 @file=File, @file_utils=FileUtils>, @out=#<IO:<STDOUT>>>, @inflector=#<Dry::Inflector>, @config=#<Hanami::Config::Assets:0x0000000107cf10e0 @__config__=#<Dry::Configurable::Config values={:serve=>true}>, @base_config=#<Hanami::Assets::Config:0x0000000104e16ce8 @__config__=#<Dry::Configurable::Config values={:node_command=>"node", :path_prefix=>"/assets", :subresource_integrity=>[], :base_url=>#<Hanami::Assets::BaseUrl:0x000000011089f8f8 @url="">}>>>, @system_call=#<Hanami::CLI::InteractiveSystemCall:0x00000001108bb3c8 @out=#<IO:<STDOUT>>, @err=#<IO:<STDERR>>, @exit_after=false>> (NameError)

                  Process.kill(sig, pid)
```

I am not sure what `sig` was supposed to be here... perhaps `"INT"`?