### PR TITLE
Clarify `dev` vs `server` in command descriptions

### DIFF
--- a/lib/hanami/cli/commands/app/dev.rb
+++ b/lib/hanami/cli/commands/app/dev.rb
@@ -11,7 +11,7 @@ module Hanami
         class Dev < App::Command
           # @since 2.1.0
           # @api private
-          desc "Start the application in development mode"
+          desc "Start all servers in Procfile.dev, for development"
 
           # @since 2.1.0
           # @api private

--- a/lib/hanami/cli/commands/app/server.rb
+++ b/lib/hanami/cli/commands/app/server.rb
@@ -34,7 +34,7 @@ module Hanami
           DEFAULT_CONFIG_PATH = "config.ru"
           private_constant :DEFAULT_CONFIG_PATH
 
-          desc "Start Hanami app server"
+          desc "Start Hanami server (Ruby only), for development"
 
           option :host, default: nil, required: false,
                         desc: "The host address to bind to (falls back to the rack handler)"


### PR DESCRIPTION
It's hard to condense the distinction down to just a handful of words, so feel free to tweak.

I also wonder if we should combine the commands somehow, since the distinction here between `dev` and `server` isn't intuitive, though I understand how they came to be, of course.

Maybe just `hanami dev` does the following:
* Does `Procfile.dev` exist?
  * Yes
    * Does it only have this in it: `web: bundle exec hanami server`?
      * Yes: Start Rack::Server
      * No: Run foreman
  * No: Start Rack::Server

And then add a flag like `hanami dev --ruby` to just start Rack::Server if that's needed