### PR TITLE
Update `db migrate` for new db layer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,12 +12,16 @@ end
 gem "hanami", github: "hanami/hanami", branch: "main"
 gem "hanami-assets", github: "hanami/assets", branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
+gem "hanami-db", github: "hanami/db", branch: "main"
 gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 
 gem "dry-files", github: "dry-rb/dry-files", branch: "main"
+gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 
 gem "rack"
+
+gem "sqlite3"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -27,6 +27,12 @@ module Hanami
               end
             end
 
+            if Hanami.bundled?("hanami-db")
+              reigster "db" do |db|
+                db.register "migrate", DB::Migrate
+              end
+            end
+
             register "generate", aliases: ["g"] do |prefix|
               prefix.register "slice", Generate::Slice
               prefix.register "action", Generate::Action

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -78,6 +78,7 @@ module Hanami
               elsif slices.length < 1
                 out.puts <<~STR
                   WARNING: Database #{database.name} has no config/db/ directory.
+
                 STR
               end
             end

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "hanami/env"
+require "shellwords"
 require_relative "utils/database"
-require_relative "../../../files"
 
 module Hanami
   module CLI
@@ -15,13 +14,57 @@ module Hanami
           # @since 2.2.0
           # @api private
           class Command < App::Command
-            attr_reader :database
+            option :app, required: false, type: :boolean, default: false, desc: "Use app database"
+            option :slice, required: false, desc: "Use database for slice"
 
-            def initialize(**)
-              super
+            private
 
-              # TODO: make plural (for slices)
-              @database = Utils::Database[app]
+            def databases(app: false, slice: nil)
+              if app
+                [database_for_app]
+              elsif slice
+                [database_for_slice(slice)]
+              else
+                all_databases
+              end
+            end
+
+            def database_for_app
+              Utils::Database[app]
+            end
+
+            def database_for_slice(slice)
+              slice = inflector.underscore(Shellwords.shellescape(slice)).to_sym
+
+              Utils::Database[app.slices[slice]]
+            end
+
+            def all_databases
+              slices = app.slices.with_nested << app
+
+              slices_by_database_url = slices.each_with_object({}) { |slice, hsh|
+                next unless slice.container.providers.find_and_load_provider(:db)
+
+                slice.prepare :db
+                database_url = slice["db.gateway"].connection.uri
+
+                hsh[database_url] ||= [] << slice
+              }
+
+              canonical_db_slices = slices_by_database_url.each_with_object([]) { |(url, slices), arr|
+                # TODO: refactor into separate method
+                slices_with_config = slices.select { _1.root.join("config", "db").directory? }
+
+                if slices_with_config.length > 1
+                  # TODO warning
+                elsif slices_with_config.length < 1
+                  # TODO warning
+                end
+
+                arr << slices.first
+              }
+
+              canonical_db_slices.map { Utils::Database[_1] }
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "hanami/env"
+require_relative "utils/database"
+require_relative "../../../files"
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module DB
+          # Base class for `hanami` CLI commands intended to be executed within an existing Hanami
+          # app.
+          #
+          # @since 2.2.0
+          # @api private
+          class Command < App::Command
+            attr_reader :database
+
+            def initialize(**)
+              super
+
+              # TODO: make plural (for slices)
+              @database = Utils::Database[app]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -9,30 +9,23 @@ module Hanami
       module App
         module DB
           # @api private
-          class Migrate < App::Command
+          class Migrate < DB::Command
             desc "Migrates database"
 
             option :target, desc: "Target migration number", aliases: ["-t"]
 
-            # @api private
             def call(target: nil, **)
-              return true if Dir[File.join(app.root, "db/migrate/*.rb")].empty?
+              # FIXME update this to work with new paths (plus app vs slice)
 
               measure "database #{database.name} migrated" do
                 if target
-                  run_migrations(target: Integer(target))
+                  database.run_migrations(target: Integer(target))
                 else
-                  run_migrations
+                  database.run_migrations
                 end
 
                 true
               end
-            end
-
-            private
-
-            def run_migrations(**options)
-              database.run_migrations(**options)
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -14,8 +14,16 @@ module Hanami
 
             option :target, desc: "Target migration number", aliases: ["-t"]
 
-            def call(target: nil, **)
-              # FIXME update this to work with new paths (plus app vs slice)
+            def call(target: nil, app: false, slice: nil, **)
+              databases(app: app, slice: slice).each do |database|
+                migrate_database(database, target: target)
+              end
+            end
+
+            private
+
+            def migrate_database(database, target:)
+              return true unless migrations?(database)
 
               measure "database #{database.name} migrated" do
                 if target
@@ -26,6 +34,10 @@ module Hanami
 
                 true
               end
+            end
+
+            def migrations?(database)
+              database.migrations_path.directory? && database.sequel_migrator.files.any?
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -97,12 +97,6 @@ module Hanami
                 end
               end
 
-              def applied_migrations
-                sequel_migrator.applied_migrations
-              end
-
-              private
-
               def migrator
                 @migrator ||= begin
                   require "rom/sql"
@@ -120,6 +114,10 @@ module Hanami
                     Sequel::TimestampMigrator.new(migrator.connection, migrations_path, {})
                   end
                 end
+              end
+
+              def applied_migrations
+                sequel_migrator.applied_migrations
               end
 
               def migrations_path

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -54,8 +54,7 @@ module Hanami
               end
 
               def name
-                # FIXME: replace with something better
-                database_url
+                database_uri.path
               end
 
               def database_url

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -53,7 +53,7 @@ module Hanami
 
               # @api private
               def dump_file
-                "#{root_path}/db/structure.sql"
+                slice.root.join("config/db/structure.sql")
               end
             end
           end

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -10,29 +10,38 @@ module Hanami
           module Utils
             # @api private
             class Sqlite < Database
-              # @api private
+              def name
+                @name ||= begin
+                  db_path = Pathname(database_uri.path).realpath
+                  app_path = slice.app.root.realpath
+
+                  if db_path.to_s.start_with?("#{app_path.to_s}#{File::SEPARATOR}")
+                    db_path.relative_path_from(app_path).to_s
+                  else
+                    db_path.to_s
+                  end
+                end
+              end
+
               def create_command
-                rom_config
                 true
               end
 
-              # @api private
               def drop_command
                 file_path.unlink
                 true
               end
 
-              # @api private
               def dump_command
                 raise Hanami::CLI::NotImplementedError
               end
 
-              # @api private
               def load_command
                 raise Hanami::CLI::NotImplementedError
               end
 
-              # @api private
+              private
+
               def file_path
                 @file_path ||= Pathname(slice.root.join(config.uri.path)).realpath
               end

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -34,7 +34,7 @@ module Hanami
 
               # @api private
               def file_path
-                @file_path ||= Pathname("#{root_path}#{config.uri.path}").realpath
+                @file_path ||= Pathname(slice.root.join(config.uri.path)).realpath
               end
             end
           end

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -37,7 +37,134 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
   end
 
-  context "db in app" do
+  context "single db in app" do
+    def before_prepare
+      write "config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "config/db/migrate/20240602211330_add_body_to_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            alter_table :posts do
+              add_column :body, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "sqlite::memory"
+    end
+
+    it "runs the migrations" do
+      command.call
+
+      expect(output).to match /database.+migrated/
+
+      expect(Hanami.app["relations.posts"].to_a).to eq []
+    end
+
+    it "runs migrations to a specific target" do
+      command.call # to add_body_to_posts
+      expect(output).to match /database.+migrated/
+
+      column_names = Hanami.app["db.gateway"].connection
+        .execute("PRAGMA table_info(posts)").to_a
+        .map { _1[1] }
+      expect(column_names).to eq %w[id title body]
+
+      command.call(target: "20240602201330") # back to create_posts
+      expect(output).to match /database.+migrated/
+
+      column_names = Hanami.app["db.gateway"].connection
+        .execute("PRAGMA table_info(posts)").to_a
+        .map { _1[1] }
+      expect(column_names).to eq %w[id title] # no more body
+
+      expect(Hanami.app["relations.posts"].to_a).to eq []
+    end
+  end
+
+  context "single db with no migration files" do
+    def before_prepare
+      write "app/relations/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "sqlite::memory"
+    end
+
+    it "does nothing" do
+      command.call
+      expect(output).to be_empty
+    end
+  end
+
+  context "single db in slice" do
+    def before_prepare
+      write "slices/admin/config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/relations/posts.rb", <<~RUBY
+        module Admin
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "sqlite::memory"
+    end
+
+    it "runs the migrations" do
+      command.call
+
+      expect(output).to match /database.+migrated/
+
+      expect(Admin::Slice["relations.posts"].to_a).to eq []
+    end
+
+    it "runs the migrations when the slice is specified" do
+      command.call(slice: "admin")
+
+      expect(output).to match /database.+migrated/
+
+      expect(Admin::Slice["relations.posts"].to_a).to eq []
+    end
+  end
+
+  context "dbs across app and slice" do
     def before_prepare
       write "config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
         ROM::SQL.migration do
@@ -59,49 +186,133 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
           end
         end
       RUBY
+
+      write "slices/main/config/db/migrate/20240602201330_create_users.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :comments do
+              primary_key :id
+              column :body, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/relations/comments.rb", <<~RUBY
+        module Main
+          module Relations
+            class Comments < Hanami::DB::Relation
+              schema :comments, infer: true
+            end
+          end
+        end
+      RUBY
     end
 
     before do
-      ENV["DATABASE_URL"] = "sqlite::memory"
-      # ENV["DATABASE_URL"] = "sqlite://#{File.join(@dir, "test.db")}"
+      ENV["DATABASE_URL"] = "sqlite://#{File.join(@dir, "app.db")}"
+      ENV["MAIN__DATABASE_URL"] = "sqlite://#{File.join(@dir, "main.db")}"
     end
 
-    it "runs the migrations" do
+    it "runs the migrations for all databases" do
       command.call
 
-      expect(output).to match /database.+migrated/
+      expect(output).to include "app.db migrated"
+      expect(output).to include "main.db migrated"
 
       expect(Hanami.app["relations.posts"].to_a).to eq []
+      expect(Main::Slice["relations.comments"].to_a).to eq []
+    end
+
+    it "runs the migration for the app" do
+      command.call(app: true)
+
+      expect(output).to include "app.db migrated"
+      expect(output).not_to include "main.db migrated"
+
+      expect(Hanami.app["relations.posts"].to_a).to eq []
+      expect { Main::Slice["relations.comments"].to_a }.to raise_error Sequel::Error
+    end
+
+    it "runs the migration for a given slice" do
+      command.call(slice: "main")
+
+      expect(output).to include "main.db migrated"
+      expect(output).not_to include "app.db migrated"
+
+      expect(Main::Slice["relations.comments"].to_a).to eq []
+      expect { Hanami.app["relations.posts"].to_a }.to raise_error Sequel::Error
+    end
+  end
+
+  context "multiple dbs across multiple slices" do
+    def before_prepare
+      write "slices/admin/config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/relations/posts.rb", <<~RUBY
+        module Admin
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/config/db/migrate/20240602201330_create_users.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :comments do
+              primary_key :id
+              column :body, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/relations/comments.rb", <<~RUBY
+        module Main
+          module Relations
+            class Comments < Hanami::DB::Relation
+              schema :comments, infer: true
+            end
+          end
+        end
+      RUBY
+    end
+
+    before do
+      ENV["ADMIN__DATABASE_URL"] = "sqlite://#{File.join(@dir, "admin.db")}"
+      ENV["MAIN__DATABASE_URL"] = "sqlite://#{File.join(@dir, "main.db")}"
+    end
+
+    it "runs the migrations for all databases" do
+      command.call
+
+      expect(output).to include "admin.db migrated"
+      expect(output).to include "main.db migrated"
+
+      expect(Admin::Slice["relations.posts"].to_a).to eq []
+      expect(Main::Slice["relations.comments"].to_a).to eq []
+    end
+
+    it "runs the migration for a given slice" do
+      command.call(slice: "admin")
+
+      expect(output).to include "admin.db migrated"
+      expect(output).not_to include "main.db migrated"
+
+      expect(Admin::Slice["relations.posts"].to_a).to eq []
+      expect { Main::Slice["relations.comments"].to_a }.to raise_error Sequel::Error
     end
   end
 end
-
-# RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app, :command, :db do
-#   it "runs migrations" do
-#     expect(database).to receive(:run_migrations)
-
-#     command.call
-
-#     expect(output).to include("database test migrated")
-#   end
-
-#   it "runs migrations against a specific target" do
-#     if RUBY_VERSION > "3.2"
-#       expect(database).to receive(:run_migrations).with({target: 312})
-#     else
-#       expect(database).to receive(:run_migrations).with(target: 312)
-#     end
-
-#     command.call(target: "312")
-
-#     expect(output).to include("database test migrated")
-#   end
-
-#   it "doesn't do anything with no migration files" do
-#     pending "need a way to easily set up a test app with no migrations"
-
-#     command.call
-
-#     expect(output).to include("no migrations files found")
-#   end
-# end

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -1,31 +1,107 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app, :command, :db do
-  it "runs migrations" do
-    expect(database).to receive(:run_migrations)
+RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
+  subject(:command) {
+    described_class.new(
+      out: out
+    )
+  }
 
-    command.call
+  let(:out) { StringIO.new }
+  let(:output) {
+    out.rewind
+    out.read
+  }
 
-    expect(output).to include("database test migrated")
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
   end
 
-  it "runs migrations against a specific target" do
-    if RUBY_VERSION > "3.2"
-      expect(database).to receive(:run_migrations).with({target: 312})
-    else
-      expect(database).to receive(:run_migrations).with(target: 312)
+  after do
+    ENV.replace(@env)
+  end
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      require "hanami/setup"
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  context "db in app" do
+    def before_prepare
+      write "config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "app/relations/posts.rb", <<~RUBY
+        module TestApp
+          module Relations
+            class Posts < Hanami::DB::Relation
+              schema :posts, infer: true
+            end
+          end
+        end
+      RUBY
     end
 
-    command.call(target: "312")
+    before do
+      ENV["DATABASE_URL"] = "sqlite::memory"
+      # ENV["DATABASE_URL"] = "sqlite://#{File.join(@dir, "test.db")}"
+    end
 
-    expect(output).to include("database test migrated")
-  end
+    it "runs the migrations" do
+      command.call
 
-  it "doesn't do anything with no migration files" do
-    pending "need a way to easily set up a test app with no migrations"
+      expect(output).to match /database.+migrated/
 
-    command.call
-
-    expect(output).to include("no migrations files found")
+      expect(Hanami.app["relations.posts"].to_a).to eq []
+    end
   end
 end
+
+# RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app, :command, :db do
+#   it "runs migrations" do
+#     expect(database).to receive(:run_migrations)
+
+#     command.call
+
+#     expect(output).to include("database test migrated")
+#   end
+
+#   it "runs migrations against a specific target" do
+#     if RUBY_VERSION > "3.2"
+#       expect(database).to receive(:run_migrations).with({target: 312})
+#     else
+#       expect(database).to receive(:run_migrations).with(target: 312)
+#     end
+
+#     command.call(target: "312")
+
+#     expect(output).to include("database test migrated")
+#   end
+
+#   it "doesn't do anything with no migration files" do
+#     pending "need a way to easily set up a test app with no migrations"
+
+#     command.call
+
+#     expect(output).to include("no migrations files found")
+#   end
+# end


### PR DESCRIPTION
Update `db migrate` to work for multiple databases configured across the app and its slices.

To find databases to operate on, it:

1. Looks for all slices (app included) with a `:db` provider present, and groups these by their database URLs
2. For each database URL, finds the slice that has a `config/db/` directory - this is considered the "canonical" slice for the database. 
3. Migrates the database for each such slice.
    - If >1 slices have a config/db/, it prints a warning, and choose to operate on the first slice only.

The command also supports the following arguments:

- `--app` to operate on the app's db only
- `--slice=slice_name` to operate on a specific slice's database (in this case, we operate directly on that slice, and don't take the steps noted above to try and find the canonical slice for the database; we trust that the user has provided the right slice via this argument)

Resolves #151