### PR TITLE
Update `db version` for new db layer

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -30,6 +30,7 @@ module Hanami
             if Hanami.bundled?("hanami-db")
               reigster "db" do |db|
                 db.register "migrate", DB::Migrate
+                db.register "version", DB::Version
               end
             end
 

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -40,7 +40,7 @@ module Hanami
             end
 
             def all_databases
-              slices = app.slices.with_nested << app
+              slices = [app] + app.slices.with_nested
 
               slices_by_database_url = slices.each_with_object({}) { |slice, hsh|
                 next unless slice.container.providers.find_and_load_provider(:db)

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -34,7 +34,7 @@ module Hanami
             end
 
             def migrations?(database)
-              database.migrations_path.directory? && database.sequel_migrator.files.any?
+              database.migrations_dir? && database.sequel_migrator.files.any?
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../app/command"
-require_relative "structure/dump"
-
 module Hanami
   module CLI
     module Commands

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -122,6 +122,10 @@ module Hanami
               def migrations_path
                 slice.root.join(MIGRATIONS_DIR)
               end
+
+              def migrations_dir?
+                migrations_path.directory?
+              end
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/version.rb
+++ b/lib/hanami/cli/commands/app/db/version.rb
@@ -12,7 +12,6 @@ module Hanami
             # @api private
             def call(app: false, slice: nil, **)
               databases(app: app, slice: slice).each do |database|
-                p database
                 migration = database.applied_migrations.last
                 version = migration ? File.basename(migration, ".*") : "not available"
 

--- a/lib/hanami/cli/commands/app/db/version.rb
+++ b/lib/hanami/cli/commands/app/db/version.rb
@@ -12,6 +12,11 @@ module Hanami
             # @api private
             def call(app: false, slice: nil, **)
               databases(app: app, slice: slice).each do |database|
+                unless database.migrations_dir?
+                  out.puts "=> Cannot find version for slice #{database.slice.slice_name.to_s.inspect}: missing config/db/migrate/ dir"
+                  return
+                end
+
                 migration = database.applied_migrations.last
                 version = migration ? File.basename(migration, ".*") : "not available"
 

--- a/lib/hanami/cli/commands/app/db/version.rb
+++ b/lib/hanami/cli/commands/app/db/version.rb
@@ -1,24 +1,23 @@
 # frozen_string_literal: true
 
-require_relative "../../app/command"
-
 module Hanami
   module CLI
     module Commands
       module App
         module DB
           # @api private
-          class Version < App::Command
+          class Version < DB::Command
             desc "Print schema version"
 
-            option :target, desc: "Target migration number", aliases: ["-t"]
-
             # @api private
-            def call(target: nil, **) # rubocop:disable Lint/UnusedMethodArgument
-              migration = database.applied_migrations.last
-              version = migration ? File.basename(migration, ".*") : "not available"
+            def call(app: false, slice: nil, **)
+              databases(app: app, slice: slice).each do |database|
+                p database
+                migration = database.applied_migrations.last
+                version = migration ? File.basename(migration, ".*") : "not available"
 
-              out.puts "=> current schema version is #{version}"
+                out.puts "=> #{database.name} current schema version is #{version}"
+              end
             end
           end
         end

--- a/spec/unit/hanami/cli/commands/app/db/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/version_spec.rb
@@ -1,19 +1,96 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app, :command, :db do
-  it "outputs schema version" do
-    expect(database).to receive(:applied_migrations).and_return(["312_create_users"])
+RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
+  subject(:command) {
+    described_class.new(
+      out: out
+    )
+  }
 
-    command.call
+  let(:out) { StringIO.new }
+  let(:output) {
+    out.rewind
+    out.read
+  }
 
-    expect(output).to include("current schema version is 312")
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
   end
 
-  it "outputs not available when there's no info in the migrations table" do
-    expect(database).to receive(:applied_migrations).and_return([])
-
-    command.call
-
-    expect(output).to include("current schema version is not available")
+  after do
+    ENV.replace(@env)
   end
+
+  def migrate
+    command.run_command(Hanami::CLI::Commands::App::DB::Migrate)
+    out.truncate(0)
+  end
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      require "hanami/setup"
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  context "db in app" do
+    def before_prepare
+      write "config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "config/db/migrate/20240602211330_add_body_to_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            alter_table :posts do
+              add_column :body, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "app/relations/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "sqlite://#{File.join(@dir, "app.db")}"
+
+    end
+
+    it "outputs the version" do
+      migrate
+
+      command.call
+
+      expect(output).to include "app.db current schema version is 20240602211330_add_body_to_posts"
+    end
+  end
+
+  context "multiple dbs" do
+    # WIP
+  end
+
+  # it "outputs not available when there's no info in the migrations table" do
+  #   expect(database).to receive(:applied_migrations).and_return([])
+
+  #   command.call
+
+  #   expect(output).to include("current schema version is not available")
+  # end
 end

--- a/spec/unit/hanami/cli/commands/app/db/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/version_spec.rb
@@ -22,11 +22,6 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
     ENV.replace(@env)
   end
 
-  def migrate
-    command.run_command(Hanami::CLI::Commands::App::DB::Migrate)
-    out.truncate(0)
-  end
-
   before do
     with_directory(@dir = make_tmp_directory) do
       write "config/app.rb", <<~RUBY
@@ -40,6 +35,11 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
       before_prepare if respond_to?(:before_prepare)
       require "hanami/prepare"
     end
+  end
+
+  def migrate
+    command.run_command(Hanami::CLI::Commands::App::DB::Migrate)
+    out.truncate(0)
   end
 
   context "db in app" do
@@ -70,10 +70,9 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
 
     before do
       ENV["DATABASE_URL"] = "sqlite://#{File.join(@dir, "app.db")}"
-
     end
 
-    it "outputs the version" do
+    it "prints the version" do
       migrate
 
       command.call
@@ -83,14 +82,84 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
   end
 
   context "multiple dbs" do
-    # WIP
+    def before_prepare
+      write "config/db/migrate/20240602191330_create_categories.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :categories do
+              primary_key :id
+              column :name, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "app/relations/.keep", ""
+
+      write "slices/admin/config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :posts do
+              primary_key :id
+              column :title, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "slices/admin/relations/.keep", ""
+
+      write "slices/main/config/db/migrate/20240602211330_create_comments.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :comments do
+              primary_key :id
+              column :body, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      write "slices/main/relations/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "sqlite://#{File.join(@dir, "app.db")}"
+      ENV["ADMIN__DATABASE_URL"] = "sqlite://#{File.join(@dir, "admin.db")}"
+      ENV["MAIN__DATABASE_URL"] = "sqlite://#{File.join(@dir, "main.db")}"
+    end
+
+    it "prints the versions for all databases" do
+      migrate
+
+      command.call
+
+      expect(output).to include "app.db current schema version is 20240602191330_create_categories"
+      expect(output).to include "admin.db current schema version is 20240602201330_create_posts"
+      expect(output).to include "main.db current schema version is 20240602211330_create_comments"
+
+      # Ordering of lines
+      expect(output).to match /app.db.+admin.db.+main.db/m
+    end
+
+    it "prints the version of the app db only when given --app" do
+      migrate
+
+      command.call(app: true)
+
+      expect(output).to include "app.db current schema version is 20240602191330_create_categories"
+      expect(output).not_to include "admin.db"
+      expect(output).not_to include "main.db"
+    end
+
+    it "prints the version of a slice when given --slice" do
+      migrate
+
+      command.call(slice: "admin")
+
+      expect(output).to include "admin.db current schema version is 20240602201330_create_posts"
+      expect(output).not_to include "app.db"
+      expect(output).not_to include "main.db"
+    end
   end
-
-  # it "outputs not available when there's no info in the migrations table" do
-  #   expect(database).to receive(:applied_migrations).and_return([])
-
-  #   command.call
-
-  #   expect(output).to include("current schema version is not available")
-  # end
 end


### PR DESCRIPTION
Update `db version` to work for multiple databases configured across the app and its slices.

To find databases to operate on, it uses the same approach devised in #160:

1. Looks for all slices (app included) with a `:db` provider present, and groups these by their database URLs
2. For each database URL, finds the slice that has a `config/db/` directory - this is considered the "canonical" slice for the database. 

The command also supports the following arguments:

- `--app` to use the app's db only
- `--slice=slice_name` to use the db for a specific slice (in this case, we operate directly on that slice, and don't take the steps noted above to try and find the canonical slice for the database; we trust that the user has provided the right slice via this argument)

Resolves #156