### PR TITLE
Adapt component generator to new command defaults

### DIFF
--- a/lib/hanami/cli/commands/app/generate/component.rb
+++ b/lib/hanami/cli/commands/app/generate/component.rb
@@ -26,13 +26,12 @@ module Hanami
             # @api private
             # @since 2.2.0
             def initialize(
-              fs: Hanami::CLI::Files.new,
-              inflector: Dry::Inflector.new,
+              fs:, inflector:,
               generator: Generators::App::Component.new(fs: fs, inflector: inflector),
-              **
+              **opts
             )
               @generator = generator
-              super(fs: fs)
+              super(fs: fs, inflector: inflector, **opts)
             end
 
             # @api private


### PR DESCRIPTION
This adapts to https://github.com/hanami/cli/pull/137/files which was created after I created https://github.com/hanami/cli/pull/130 but merged before it. My branch wasn't rebased before merge and since it was new files, there was no conflict. 

This change simply adapts to what the parent object does now withi default initialize params.