### PR TITLE
Enable `db structure dump` for new db layer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 
 gem "rack"
 
-gem "pg"
 gem "sqlite3"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 
 gem "rack"
 
+gem "pg"
 gem "sqlite3"
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -30,6 +30,7 @@ module Hanami
             if Hanami.bundled?("hanami-db")
               register "db" do |db|
                 db.register "migrate", DB::Migrate
+                db.register "structure dump", DB::Structure::Dump
                 db.register "version", DB::Version
               end
             end

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -17,6 +17,17 @@ module Hanami
             option :app, required: false, type: :boolean, default: false, desc: "Use app database"
             option :slice, required: false, desc: "Use database for slice"
 
+            attr_reader :system_call
+
+            def initialize(
+              out:, err:,
+              system_call: SystemCall.new,
+              **opts
+            )
+              super(out: out, err: err, **opts)
+              @system_call = system_call
+            end
+
             private
 
             def databases(app: false, slice: nil)
@@ -30,24 +41,23 @@ module Hanami
             end
 
             def database_for_app
-              Utils::Database[app]
+              build_database(app)
             end
 
             def database_for_slice(slice)
               slice = inflector.underscore(Shellwords.shellescape(slice)).to_sym
 
-              Utils::Database[app.slices[slice]]
+              build_database(app.slices[slice])
             end
 
             def all_databases
               slices = [app] + app.slices.with_nested
 
               slices_by_database_url = slices.each_with_object({}) { |slice, hsh|
-                next unless slice.container.providers[:db]
+                provider = slice.container.providers[:db]
+                next unless provider
 
-                slice.prepare :db
-                database_url = slice["db.gateway"].connection.uri
-
+                database_url = provider.source.send(:database_url)
                 hsh[database_url] ||= []
                 hsh[database_url] << slice
               }
@@ -55,7 +65,7 @@ module Hanami
               databases = slices_by_database_url.each_with_object([]) { |(url, slices), arr|
                 slices_with_config = slices.select { _1.root.join("config", "db").directory? }
 
-                database = Utils::Database[slices_with_config.first || slices.first]
+                database = build_database(slices_with_config.first || slices.first)
 
                 warn_on_misconfigured_database database, slices_with_config
 
@@ -63,6 +73,10 @@ module Hanami
               }
 
               databases
+            end
+
+            def build_database(slice)
+              Utils::Database[slice, system_call: system_call]
             end
 
             def warn_on_misconfigured_database(database, slices)

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -57,7 +57,7 @@ module Hanami
                 provider = slice.container.providers[:db]
                 next unless provider
 
-                database_url = provider.source.send(:database_url)
+                database_url = provider.source.database_url
                 hsh[database_url] ||= []
                 hsh[database_url] << slice
               }

--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../app/command"
-
 module Hanami
   module CLI
     module Commands
@@ -10,13 +8,15 @@ module Hanami
           # @api private
           module Structure
             # @api private
-            class Dump < App::Command
-              desc "Dumps database structure to db/structure.sql file"
+            class Dump < DB::Command
+              desc "Dumps database structure to config/db/structure.sql file"
 
               # @api private
-              def call(*)
-                measure("#{database.name} structure dumped to db/structure.sql") do
-                  database.dump_command
+              def call(app: false, slice: nil, **)
+                databases(app: app, slice: slice).each do |database|
+                  measure("#{database.name} structure dumped to config/db/structure.sql") do
+                    database.dump_command
+                  end
                 end
               end
             end

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -100,6 +100,8 @@ module Hanami
 
               def migrator
                 @migrator ||= begin
+                  slice.prepare :db
+
                   require "rom/sql"
                   ROM::SQL::Migration::Migrator.new(connection, path: migrations_path)
                 end
@@ -107,6 +109,8 @@ module Hanami
 
               def sequel_migrator
                 @sequel_migrator ||= begin
+                  slice.prepare :db
+
                   require "sequel"
                   Sequel.extension :migration
 

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -40,7 +40,7 @@ module Hanami
                 provider = slice.container.providers[:db]
                 raise "this is not a db slice" unless provider
 
-                database_scheme = provider.source.send(:database_url).then { URI(_1).scheme }
+                database_scheme = provider.source.database_url.then { URI(_1).scheme }
                 database_class = DATABASE_CLASS_RESOLVER[database_scheme].call
                 database_class.new(slice: slice, system_call: system_call)
               end
@@ -60,7 +60,7 @@ module Hanami
               end
 
               def database_url
-                slice.container.providers[:db].source.send(:database_url)
+                slice.container.providers[:db].source.database_url
               end
 
               def database_uri

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -28,7 +28,10 @@ module Hanami
 
               # @api private
               def dump_command
-                system(cli_env_vars, "pg_dump --schema-only --no-owner #{escaped_name} > #{dump_file}")
+                system_call.call(
+                  "pg_dump --schema-only --no-owner #{escaped_name} > #{dump_file}",
+                  env: cli_env_vars
+                )
               end
 
               # @api private
@@ -44,10 +47,10 @@ module Hanami
               # @api private
               def cli_env_vars
                 @cli_env_vars ||= {}.tap do |vars|
-                  vars["PGHOST"] = config.host.to_s
-                  vars["PGPORT"] = config.port.to_s if config.port
-                  vars["PGUSER"] = config.user.to_s if config.user
-                  vars["PGPASSWORD"] = config.pass.to_s if config.pass
+                  vars["PGHOST"] = database_uri.hostname.to_s
+                  vars["PGPORT"] = database_uri.port.to_s if database_uri.port
+                  vars["PGUSER"] = database_uri.user.to_s if database_uri.user
+                  vars["PGPASSWORD"] = database_uri.password.to_s if database_uri.password
                 end
               end
 

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -12,7 +12,7 @@ module Hanami
             class Sqlite < Database
               def name
                 @name ||= begin
-                  db_path = Pathname(database_uri.path).realpath
+                  db_path = Pathname(database_uri.path).expand_path
                   app_path = slice.app.root.realpath
 
                   if db_path.to_s.start_with?("#{app_path.to_s}#{File::SEPARATOR}")

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration do
+  subject(:command) {
+    described_class.new(
+      system_call: system_call,
+      out: out
+    )
+  }
+
+  let(:system_call) { instance_spy(Hanami::CLI::SystemCall) }
+
+  let(:out) { StringIO.new }
+  let(:output) {
+    out.rewind
+    out.read
+  }
+
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      require "hanami/setup"
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  context "postgres" do
+    context "single db in app" do
+      def before_prepare
+        write "config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
+          ROM::SQL.migration do
+            change do
+              create_table :posts do
+                primary_key :id
+                column :title, :text, null: false
+              end
+            end
+          end
+        RUBY
+
+        write "app/relations/.keep", ""
+      end
+
+      before do
+        ENV["DATABASE_URL"] = "postgres://localhost:5432/bookshelf_development"
+      end
+
+      it "works?" do
+        command.call
+
+        expect(system_call).to have_received(:call)
+          .with(
+            "pg_dump --schema-only --no-owner bookshelf_development > #{@dir.realpath.join("config", "db", "structure.sql")}",
+            env: {
+              "PGHOST" => "localhost",
+              "PGPORT" => "5432"
+            }
+          )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Enable the `db structure dump` command for our new database layer, and add tests covering its use with Postgres. Support for other database types will follow later (see #157, #158).

As part of this change, make `Hanami::Providers::DB#database_url` public API, and access it through `slice.container.providers[:db].source.database_url` (with `Dry::System::Provider#source` soon to be tagged as public API too).

This ensures that the canonical databases across an app can be identified via their database URL strings alone, without having to establish a full connection to the database. This means all the `db` CLI commands (not just `structure dump`) can operate more efficiently. It also makes them easier to test inside the repo, since we can avoid providing the live database servers for them to connect to.

Resolves #154.