### PR TITLE
Load providers via `#[]`

### DIFF
--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -43,7 +43,7 @@ module Hanami
               slices = [app] + app.slices.with_nested
 
               slices_by_database_url = slices.each_with_object({}) { |slice, hsh|
-                next unless slice.container.providers.find_and_load_provider(:db)
+                next unless slice.container.providers[:db]
 
                 slice.prepare :db
                 database_url = slice["db.gateway"].connection.uri

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -36,7 +36,7 @@ module Hanami
               ).freeze
 
               def self.[](slice)
-                unless slice.container.providers.find_and_load_provider(:db)
+                unless slice.container.providers[:db]
                   raise "this is not a db slice"
                 end
 


### PR DESCRIPTION
Now that dry-system is updated to find and load providers when accessing them via `#[]` (see https://github.com/dry-rb/dry-system/pull/273), we can use this shorter, nicer method.