### PR TITLE
Add `db structure load` for new db layer

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -31,6 +31,7 @@ module Hanami
               register "db" do |db|
                 db.register "migrate", DB::Migrate
                 db.register "structure dump", DB::Structure::Dump
+                db.register "structure load", DB::Structure::Load
                 db.register "version", DB::Version
               end
             end

--- a/lib/hanami/cli/commands/app/db/structure/load.rb
+++ b/lib/hanami/cli/commands/app/db/structure/load.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module DB
+          # @api private
+          module Structure
+            # @api private
+            class Load < DB::Command
+              desc "Loads database from config/db/structure.sql file"
+
+              # @api private
+              def call(app: false, slice: nil, **)
+                databases(app: app, slice: slice).each do |database|
+                  measure("#{database.name} structure loaded from config/db/structure.sql") do
+                    database.load_command
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/commands/app/db/structure/load.rb
+++ b/lib/hanami/cli/commands/app/db/structure/load.rb
@@ -14,7 +14,10 @@ module Hanami
               # @api private
               def call(app: false, slice: nil, **)
                 databases(app: app, slice: slice).each do |database|
-                  measure("#{database.name} structure loaded from config/db/structure.sql") do
+                  slice_root = database.slice.root.relative_path_from(database.slice.app.root)
+                  structure_path = slice_root.join("config", "db", "structure.sql")
+
+                  measure("#{database.name} structure loaded from #{structure_path}") do
                     database.load_command
                   end
                 end

--- a/lib/hanami/cli/commands/app/db/structure/load.rb
+++ b/lib/hanami/cli/commands/app/db/structure/load.rb
@@ -18,7 +18,12 @@ module Hanami
                   structure_path = slice_root.join("config", "db", "structure.sql")
 
                   measure("#{database.name} structure loaded from #{structure_path}") do
-                    database.load_command
+                    database.exec_load_command.tap do |result|
+                      unless result.successful?
+                        out.puts result.err
+                        break false
+                      end
+                    end
                   end
                 end
               end

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -87,7 +87,7 @@ module Hanami
                 raise Hanami::CLI::NotImplementedError
               end
 
-              def load_command
+              def exec_load_command
                 raise Hanami::CLI::NotImplementedError
               end
 

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -21,7 +21,7 @@ module Hanami
               end
 
               # @api private
-              def load_command
+              def exec_load_command
                 raise Hanami::CLI::NotImplementedError
               end
             end

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -35,7 +35,7 @@ module Hanami
               end
 
               # @api private
-              def load_command
+              def exec_load_command
                 system_call.call(
                   "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output #{File::NULL} --file #{structure_file} #{escaped_name}",
                   env: cli_env_vars

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -29,14 +29,17 @@ module Hanami
               # @api private
               def dump_command
                 system_call.call(
-                  "pg_dump --schema-only --no-owner #{escaped_name} > #{dump_file}",
+                  "pg_dump --schema-only --no-owner #{escaped_name} > #{structure_file}",
                   env: cli_env_vars
                 )
               end
 
               # @api private
               def load_command
-                raise "Not Implemented Yet"
+                system_call.call(
+                  "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output #{File::NULL} --file #{structure_file} #{escaped_name}",
+                  env: cli_env_vars
+                )
               end
 
               # @api private
@@ -55,7 +58,7 @@ module Hanami
               end
 
               # @api private
-              def dump_file
+              def structure_file
                 slice.root.join("config/db/structure.sql")
               end
             end

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -36,7 +36,7 @@ module Hanami
                 raise Hanami::CLI::NotImplementedError
               end
 
-              def load_command
+              def exec_load_command
                 raise Hanami::CLI::NotImplementedError
               end
 

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -42,17 +42,6 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
   context "single db in app" do
     def before_prepare
-      write "config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
-        ROM::SQL.migration do
-          change do
-            create_table :posts do
-              primary_key :id
-              column :title, :text, null: false
-            end
-          end
-        end
-      RUBY
-
       write "app/relations/.keep", ""
     end
 

--- a/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
     )
   }
 
-  let(:system_call) { instance_spy(Hanami::CLI::SystemCall) }
+  let(:system_call) {
+    instance_spy(
+      Hanami::CLI::SystemCall,
+      call: Hanami::CLI::SystemCall::Result.new(exit_code: 0, out: "", err: "")
+    )
+  }
 
   let(:out) { StringIO.new }
   let(:output) {
@@ -148,6 +153,32 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
         )
 
       expect(output).to include "bookshelf_admin_development structure loaded from slices/admin/config/db/structure.sql"
+    end
+  end
+
+  context "load command fails" do
+    def before_prepare
+      write "config/db/.keep", ""
+      write "app/relations/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "postgres://localhost:5432/bookshelf_development"
+    end
+
+    before do
+      allow(system_call).to receive(:call).and_return Hanami::CLI::SystemCall::Result.new(
+        exit_code: 2,
+        out: "",
+        err: "some-psql-error"
+      )
+    end
+
+    it "prints the error" do
+      command.call
+
+      expect(output).to include "some-psql-error"
+      expect(output).to include %(!!! => "bookshelf_development structure loaded from config/db/structure.sql" FAILED)
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
             "PGPORT" => "5432"
           }
         )
+
+      expect(output).to include "bookshelf_development structure loaded from config/db/structure.sql"
     end
   end
 
@@ -108,6 +110,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
           }
         )
         .once
+
+      expect(output).to include "bookshelf_development structure loaded from config/db/structure.sql"
+      expect(output).to include "bookshelf_admin_development structure loaded from slices/admin/config/db/structure.sql"
+      expect(output).to include "bookshelf_main_development structure loaded from slices/main/config/db/structure.sql"
     end
 
     it "dumps the structure for the app db when given --app" do
@@ -123,6 +129,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
             "PGPORT" => "5432"
           }
         )
+
+      expect(output).to include "bookshelf_development structure loaded from config/db/structure.sql"
     end
 
     it "dumps the structure for a slice db when given --slice" do
@@ -138,6 +146,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration
             "PGPORT" => "5432"
           }
         )
+
+      expect(output).to include "bookshelf_admin_development structure loaded from slices/admin/config/db/structure.sql"
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/load_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Load, :app_integration do
+  subject(:command) {
+    described_class.new(
+      system_call: system_call,
+      out: out
+    )
+  }
+
+  let(:system_call) { instance_spy(Hanami::CLI::SystemCall) }
+
+  let(:out) { StringIO.new }
+  let(:output) {
+    out.rewind
+    out.read
+  }
+
+  before do
+    @env = ENV.to_h
+    allow(Hanami::Env).to receive(:loaded?).and_return(false)
+  end
+
+  after do
+    ENV.replace(@env)
+  end
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      require "hanami/setup"
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+  end
+
+  context "single db in app" do
+    def before_prepare
+      write "app/relations/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "postgres://localhost:5432/bookshelf_development"
+    end
+
+    it "dumps the structure for the app db" do
+      command.call
+
+      expect(system_call).to have_received(:call)
+        .with(
+          "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output /dev/null --file #{@dir.realpath.join("config", "db", "structure.sql")} bookshelf_development",
+          env: {
+            "PGHOST" => "localhost",
+            "PGPORT" => "5432"
+          }
+        )
+    end
+  end
+
+  context "multiple dbs across app and slices" do
+    def before_prepare
+      write "app/relations/.keep", ""
+      write "slices/admin/relations/.keep", ""
+      write "slices/main/relations/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "postgres://localhost:5432/bookshelf_development"
+      ENV["ADMIN__DATABASE_URL"] = "postgres://localhost:5432/bookshelf_admin_development"
+      ENV["MAIN__DATABASE_URL"] = "postgres://anotherhost:2345/bookshelf_main_development"
+    end
+
+    it "dumps the structure for each db" do
+      command.call
+
+      expect(system_call).to have_received(:call)
+        .with(
+          "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output /dev/null --file #{@dir.realpath.join("config", "db", "structure.sql")} bookshelf_development",
+          env: {
+            "PGHOST" => "localhost",
+            "PGPORT" => "5432"
+          }
+        )
+        .once
+
+      expect(system_call).to have_received(:call)
+        .with(
+          "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output /dev/null --file #{@dir.realpath.join("slices", "admin", "config", "db", "structure.sql")} bookshelf_admin_development",
+          env: {
+            "PGHOST" => "localhost",
+            "PGPORT" => "5432"
+          }
+        )
+        .once
+
+      expect(system_call).to have_received(:call)
+        .with(
+          "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output /dev/null --file #{@dir.realpath.join("slices", "main", "config", "db", "structure.sql")} bookshelf_main_development",
+          env: {
+            "PGHOST" => "anotherhost",
+            "PGPORT" => "2345"
+          }
+        )
+        .once
+    end
+
+    it "dumps the structure for the app db when given --app" do
+      command.call(app: true)
+
+      expect(system_call).to have_received(:call).exactly(1).time
+
+      expect(system_call).to have_received(:call)
+        .with(
+          "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output /dev/null --file #{@dir.realpath.join("config", "db", "structure.sql")} bookshelf_development",
+          env: {
+            "PGHOST" => "localhost",
+            "PGPORT" => "5432"
+          }
+        )
+    end
+
+    it "dumps the structure for a slice db when given --slice" do
+      command.call(slice: "admin")
+
+      expect(system_call).to have_received(:call).exactly(1).time
+
+      expect(system_call).to have_received(:call)
+        .with(
+          "psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output /dev/null --file #{@dir.realpath.join("slices", "admin", "config", "db", "structure.sql")} bookshelf_admin_development",
+          env: {
+            "PGHOST" => "localhost",
+            "PGPORT" => "5432"
+          }
+        )
+    end
+  end
+end


### PR DESCRIPTION
Add a `db structure load` command for our new database layer, and add tests covering its use with Postgres. Support for other database types will follow later (see #157, #158).

This includes better handling of errors compared to its counterpart `db structure dump` command. I'll return to improve that command in the next PR.

Resolves #155.