### PR TITLE
Improve `db structure dump` output and error handling

### DIFF
--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -14,7 +14,10 @@ module Hanami
               # @api private
               def call(app: false, slice: nil, **)
                 databases(app: app, slice: slice).each do |database|
-                  measure("#{database.name} structure dumped to config/db/structure.sql") do
+                  slice_root = database.slice.root.relative_path_from(database.slice.app.root)
+                  structure_path = slice_root.join("config", "db", "structure.sql")
+
+                  measure("#{database.name} structure dumped to #{structure_path}") do
                     database.dump_command
                   end
                 end

--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -18,7 +18,12 @@ module Hanami
                   structure_path = slice_root.join("config", "db", "structure.sql")
 
                   measure("#{database.name} structure dumped to #{structure_path}") do
-                    database.exec_dump_command
+                    database.exec_dump_command.tap do |result|
+                      unless result.successful?
+                        out.puts result.err
+                        break false
+                      end
+                    end
                   end
                 end
               end

--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -18,7 +18,7 @@ module Hanami
                   structure_path = slice_root.join("config", "db", "structure.sql")
 
                   measure("#{database.name} structure dumped to #{structure_path}") do
-                    database.dump_command
+                    database.exec_dump_command
                   end
                 end
               end

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -83,7 +83,7 @@ module Hanami
                 raise Hanami::CLI::NotImplementedError
               end
 
-              def dump_command
+              def exec_dump_command
                 raise Hanami::CLI::NotImplementedError
               end
 

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -16,7 +16,7 @@ module Hanami
               end
 
               # @api private
-              def dump_command
+              def exec_dump_command
                 raise Hanami::CLI::NotImplementedError
               end
 

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -29,7 +29,7 @@ module Hanami
               # @api private
               def dump_command
                 system_call.call(
-                  "pg_dump --schema-only --no-owner #{escaped_name} > #{structure_file}",
+                  "pg_dump --schema-only --no-privileges --no-owner --file #{structure_file} #{escaped_name}",
                   env: cli_env_vars
                 )
               end

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -27,7 +27,7 @@ module Hanami
               end
 
               # @api private
-              def dump_command
+              def exec_dump_command
                 system_call.call(
                   "pg_dump --schema-only --no-privileges --no-owner --file #{structure_file} #{escaped_name}",
                   env: cli_env_vars

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -32,7 +32,7 @@ module Hanami
                 true
               end
 
-              def dump_command
+              def exec_dump_command
                 raise Hanami::CLI::NotImplementedError
               end
 

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
       expect(system_call).to have_received(:call)
         .with(
-          "pg_dump --schema-only --no-owner bookshelf_development > #{@dir.realpath.join("config", "db", "structure.sql")}",
+          "pg_dump --schema-only --no-privileges --no-owner --file #{@dir.realpath.join("config", "db", "structure.sql")} bookshelf_development",
           env: {
             "PGHOST" => "localhost",
             "PGPORT" => "5432"
@@ -81,7 +81,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
       expect(system_call).to have_received(:call)
         .with(
-          "pg_dump --schema-only --no-owner bookshelf_development > #{@dir.realpath.join("config", "db", "structure.sql")}",
+          "pg_dump --schema-only --no-privileges --no-owner --file #{@dir.realpath.join("config", "db", "structure.sql")} bookshelf_development",
           env: {
             "PGHOST" => "localhost",
             "PGPORT" => "5432"
@@ -91,7 +91,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
       expect(system_call).to have_received(:call)
         .with(
-          "pg_dump --schema-only --no-owner bookshelf_admin_development > #{@dir.realpath.join("slices", "admin", "config", "db", "structure.sql")}",
+          "pg_dump --schema-only --no-privileges --no-owner --file #{@dir.realpath.join("slices", "admin", "config", "db", "structure.sql")} bookshelf_admin_development",
           env: {
             "PGHOST" => "localhost",
             "PGPORT" => "5432"
@@ -101,7 +101,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
       expect(system_call).to have_received(:call)
         .with(
-          "pg_dump --schema-only --no-owner bookshelf_main_development > #{@dir.realpath.join("slices", "main", "config", "db", "structure.sql")}",
+          "pg_dump --schema-only --no-privileges --no-owner --file #{@dir.realpath.join("slices", "main", "config", "db", "structure.sql")} bookshelf_main_development",
           env: {
             "PGHOST" => "anotherhost",
             "PGPORT" => "2345"
@@ -117,7 +117,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
       expect(system_call).to have_received(:call)
         .with(
-          "pg_dump --schema-only --no-owner bookshelf_development > #{@dir.realpath.join("config", "db", "structure.sql")}",
+          "pg_dump --schema-only --no-privileges --no-owner --file #{@dir.realpath.join("config", "db", "structure.sql")} bookshelf_development",
           env: {
             "PGHOST" => "localhost",
             "PGPORT" => "5432"
@@ -132,7 +132,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
       expect(system_call).to have_received(:call)
         .with(
-          "pg_dump --schema-only --no-owner bookshelf_admin_development > #{@dir.realpath.join("slices", "admin", "config", "db", "structure.sql")}",
+          "pg_dump --schema-only --no-privileges --no-owner --file #{@dir.realpath.join("slices", "admin", "config", "db", "structure.sql")} bookshelf_admin_development",
           env: {
             "PGHOST" => "localhost",
             "PGPORT" => "5432"

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
 
   context "single db in app" do
     def before_prepare
+      write "config/db/.keep", ""
       write "app/relations/.keep", ""
     end
 
@@ -60,13 +61,18 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
             "PGPORT" => "5432"
           }
         )
+
+      expect(output).to include "bookshelf_development structure dumped to config/db/structure.sql"
     end
   end
 
   context "multiple dbs across app and slices" do
     def before_prepare
+      write "config/db/.keep", ""
       write "app/relations/.keep", ""
+      write "slices/admin/config/db/.keep", ""
       write "slices/admin/relations/.keep", ""
+      write "slices/main/config/db/.keep", ""
       write "slices/main/relations/.keep", ""
     end
 
@@ -108,6 +114,10 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
           }
         )
         .once
+
+      expect(output).to include "bookshelf_development structure dumped to config/db/structure.sql"
+      expect(output).to include "bookshelf_admin_development structure dumped to slices/admin/config/db/structure.sql"
+      expect(output).to include "bookshelf_main_development structure dumped to slices/main/config/db/structure.sql"
     end
 
     it "dumps the structure for the app db when given --app" do
@@ -123,6 +133,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
             "PGPORT" => "5432"
           }
         )
+
+      expect(output).to include "bookshelf_development structure dumped to config/db/structure.sql"
     end
 
     it "dumps the structure for a slice db when given --slice" do
@@ -138,6 +150,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
             "PGPORT" => "5432"
           }
         )
+
+      expect(output).to include "bookshelf_admin_development structure dumped to slices/admin/config/db/structure.sql"
     end
   end
 end


### PR DESCRIPTION
Show structure file paths relative from the app root. Show the error output from the `pg_dump` command if it fails.