### PR TITLE
Generate db files during hanami new

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -84,14 +84,12 @@ module Hanami
 
           # rubocop:disable Layout/LineLength
           example [
-            "bookshelf                     # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
-            "bookshelf --head              # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
-            "bookshelf --skip-install      # Generate a new Hanami app, but it skips Hanami installation",
-            "bookshelf --skip-assets       # Generate a new Hanami app without assets",
-            "bookshelf --skip-db           # Generate a new Hanami app without database layer",
-            "bookshelf --database=sqlite   # Generate a new Hanami app with a SQLite database (default)",
-            "bookshelf --database=postgres # Generate a new Hanami app with a Postgres database",
-            "bookshelf --database=mysql    # Generate a new Hanami app with a MySQL database"
+            "bookshelf                                    # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
+            "bookshelf --head                             # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
+            "bookshelf --skip-install                     # Generate a new Hanami app, but it skips Hanami installation",
+            "bookshelf --skip-assets                      # Generate a new Hanami app without assets library",
+            "bookshelf --skip-db                          # Generate a new Hanami app without database library",
+            "bookshelf --database={sqlite|postgres|mysql} # Generate a new Hanami app with a specified database (default: sqlite)",
           ]
           # rubocop:enable Layout/LineLength
 

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -122,13 +122,16 @@ module Hanami
             skip_install: SKIP_INSTALL_DEFAULT,
             skip_assets: SKIP_ASSETS_DEFAULT,
             skip_db: SKIP_DB_DEFAULT,
-            database: DATABASE_SQLITE,
+            database: nil,
             **
           )
             app = inflector.underscore(app)
 
             raise PathAlreadyExistsError.new(app) if fs.exist?(app)
-            raise DatabaseNotSupportedError.new(database, SUPPORTED_DATABASES) unless SUPPORTED_DATABASES.include?(database)
+            raise DatabaseNotSupportedError.new(database, SUPPORTED_DATABASES) if database && !SUPPORTED_DATABASES.include?(database)
+            raise ConflictingOptionsError.new("--skip-db", "--database") if skip_db && database
+
+            database ||= DATABASE_SQLITE
 
             fs.mkdir(app)
             fs.chdir(app) do

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -165,7 +165,7 @@ module Hanami
               end
             end
           end
-          # rubocop:enable Metrics/PerceivedComplexity
+          # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
           private
 

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -122,8 +122,7 @@ module Hanami
             skip_install: SKIP_INSTALL_DEFAULT,
             skip_assets: SKIP_ASSETS_DEFAULT,
             skip_db: SKIP_DB_DEFAULT,
-            database: nil,
-            **
+            database: nil
           )
             # rubocop:enable Metrics/ParameterLists
             app = inflector.underscore(app)
@@ -141,8 +140,7 @@ module Hanami
                 head: head,
                 skip_assets: skip_assets,
                 skip_db: skip_db,
-                database: normalized_database,
-                **
+                database: normalized_database
               )
               generator.call(app, context: context) do
                 if skip_install

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -84,12 +84,14 @@ module Hanami
 
           # rubocop:disable Layout/LineLength
           example [
-            "bookshelf                   # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
-            "bookshelf --head            # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
-            "bookshelf --skip-install    # Generate a new Hanami app, but it skips Hanami installation",
-            "bookshelf --skip-assets     # Generate a new Hanami app without assets",
-            "bookshelf --skip-db         # Generate a new Hanami app without database layer",
-            "bookshelf --database=sqlite # Generate a new Hanami app with a SQLite database (default)"
+            "bookshelf                     # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
+            "bookshelf --head              # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
+            "bookshelf --skip-install      # Generate a new Hanami app, but it skips Hanami installation",
+            "bookshelf --skip-assets       # Generate a new Hanami app without assets",
+            "bookshelf --skip-db           # Generate a new Hanami app without database layer",
+            "bookshelf --database=sqlite   # Generate a new Hanami app with a SQLite database (default)",
+            "bookshelf --database=postgres # Generate a new Hanami app with a Postgres database",
+            "bookshelf --database=mysql    # Generate a new Hanami app with a MySQL database"
           ]
           # rubocop:enable Layout/LineLength
 
@@ -110,9 +112,7 @@ module Hanami
             @system_call = system_call
           end
 
-          # rubocop:enable Metrics/ParameterLists
-
-          # rubocop:disable Metrics/AbcSize
+          # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
 
           # @since 2.0.0
           # @api private
@@ -125,6 +125,7 @@ module Hanami
             database: nil,
             **
           )
+            # rubocop:enable Metrics/ParameterLists
             app = inflector.underscore(app)
 
             raise PathAlreadyExistsError.new(app) if fs.exist?(app)
@@ -166,7 +167,7 @@ module Hanami
               end
             end
           end
-          # rubocop:enable Metrics/AbcSize
+          # rubocop:enable Metrics/PerceivedComplexity
 
           private
 
@@ -176,11 +177,11 @@ module Hanami
 
           def normalize_database(database)
             case database
-            when *[nil, "sqlite", "sqlite3"]
+            when nil, "sqlite", "sqlite3"
               DATABASE_SQLITE
-            when *["mysql", "mysql2"]
+            when "mysql", "mysql2"
               DATABASE_MYSQL
-            when *["postgres", "postgresql", "pg"]
+            when "postgres", "postgresql", "pg"
               DATABASE_POSTGRES
             else
               raise DatabaseNotSupportedError.new(database, SUPPORTED_DATABASES)

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -25,6 +25,11 @@ module Hanami
           SKIP_ASSETS_DEFAULT = false
           private_constant :SKIP_ASSETS_DEFAULT
 
+          # @since x.x.x
+          # @api private
+          SKIP_DB_DEFAULT = false
+          private_constant :SKIP_DB_DEFAULT
+
           desc "Generate a new Hanami app"
 
           # @since 2.0.0
@@ -49,12 +54,19 @@ module Hanami
                                default: SKIP_ASSETS_DEFAULT,
                                desc: "Skip assets"
 
+          # @since x.x.x
+          # @api private
+          option :skip_db, type: :boolean, required: false,
+                           default: SKIP_DB_DEFAULT,
+                           desc: "Skip database layer"
+
           # rubocop:disable Layout/LineLength
           example [
             "bookshelf                # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
             "bookshelf --head         # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
             "bookshelf --skip-install # Generate a new Hanami app, but it skips Hanami installation",
-            "bookshelf --skip-assets  # Generate a new Hanami app without assets"
+            "bookshelf --skip-assets  # Generate a new Hanami app without assets",
+            "bookshelf --skip-db      # Generate a new Hanami app without database layer"
           ]
           # rubocop:enable Layout/LineLength
 
@@ -81,14 +93,14 @@ module Hanami
 
           # @since 2.0.0
           # @api private
-          def call(app:, head: HEAD_DEFAULT, skip_install: SKIP_INSTALL_DEFAULT, skip_assets: SKIP_ASSETS_DEFAULT, **)
+          def call(app:, head: HEAD_DEFAULT, skip_install: SKIP_INSTALL_DEFAULT, skip_assets: SKIP_ASSETS_DEFAULT, skip_db: SKIP_DB_DEFAULT, **)
             app = inflector.underscore(app)
 
             raise PathAlreadyExistsError.new(app) if fs.exist?(app)
 
             fs.mkdir(app)
             fs.chdir(app) do
-              context = Generators::Context.new(inflector, app, head: head, skip_assets: skip_assets)
+              context = Generators::Context.new(inflector, app, head: head, skip_assets: skip_assets, skip_db: skip_db, **)
               generator.call(app, context: context) do
                 if skip_install
                   out.puts "Skipping installation, please enter `#{app}' directory and run `bundle exec hanami install'"

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -40,7 +40,11 @@ module Hanami
 
           # @since x.x.x
           # @api private
-          SUPPORTED_DATABASES = [DATABASE_SQLITE, DATABASE_POSTGRES]
+          DATABASE_MYSQL = "mysql"
+
+          # @since x.x.x
+          # @api private
+          SUPPORTED_DATABASES = [DATABASE_SQLITE, DATABASE_POSTGRES, DATABASE_MYSQL].freeze
 
           desc "Generate a new Hanami app"
 

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -25,24 +25,24 @@ module Hanami
           SKIP_ASSETS_DEFAULT = false
           private_constant :SKIP_ASSETS_DEFAULT
 
-          # @since x.x.x
+          # @since 2.2.0
           # @api private
           SKIP_DB_DEFAULT = false
           private_constant :SKIP_DB_DEFAULT
 
-          # @since x.x.x
+          # @since 2.2.0
           # @api private
           DATABASE_SQLITE = "sqlite"
 
-          # @since x.x.x
+          # @since 2.2.0
           # @api private
           DATABASE_POSTGRES = "postgres"
 
-          # @since x.x.x
+          # @since 2.2.0
           # @api private
           DATABASE_MYSQL = "mysql"
 
-          # @since x.x.x
+          # @since 2.2.0
           # @api private
           SUPPORTED_DATABASES = [DATABASE_SQLITE, DATABASE_POSTGRES, DATABASE_MYSQL].freeze
 
@@ -70,13 +70,13 @@ module Hanami
                                default: SKIP_ASSETS_DEFAULT,
                                desc: "Skip assets"
 
-          # @since x.x.x
+          # @since 2.2.0
           # @api private
           option :skip_db, type: :boolean, required: false,
                            default: SKIP_DB_DEFAULT,
                            desc: "Skip database layer"
 
-          # @since x.x.x
+          # @since 2.2.0
           # @api private
           option :database, type: :string, required: false,
                             default: DATABASE_SQLITE,

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -68,13 +68,13 @@ module Hanami
           # @api private
           option :skip_assets, type: :boolean, required: false,
                                default: SKIP_ASSETS_DEFAULT,
-                               desc: "Skip assets"
+                               desc: "Skip including hanami-assets"
 
           # @since 2.2.0
           # @api private
           option :skip_db, type: :boolean, required: false,
                            default: SKIP_DB_DEFAULT,
-                           desc: "Skip database layer"
+                           desc: "Skip including hanami-db"
 
           # @since 2.2.0
           # @api private
@@ -87,8 +87,8 @@ module Hanami
             "bookshelf                                    # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
             "bookshelf --head                             # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
             "bookshelf --skip-install                     # Generate a new Hanami app, but it skips Hanami installation",
-            "bookshelf --skip-assets                      # Generate a new Hanami app without assets library",
-            "bookshelf --skip-db                          # Generate a new Hanami app without database library",
+            "bookshelf --skip-assets                      # Generate a new Hanami app without hanmai-assets",
+            "bookshelf --skip-db                          # Generate a new Hanami app without hanami-db",
             "bookshelf --database={sqlite|postgres|mysql} # Generate a new Hanami app with a specified database (default: sqlite)",
           ]
           # rubocop:enable Layout/LineLength

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -92,9 +92,19 @@ module Hanami
       end
     end
 
+    # @since x.x.x
+    # @api public
     class DatabaseNotSupportedError < Error
       def initialize(invalid_database, supported_databases)
         super("`#{invalid_database}' is not a supported database. Supported databases are: #{supported_databases.join(', ')}")
+      end
+    end
+
+    # @since x.x.x
+    # @api public
+    class ConflictingOptionsError < Error
+      def initialize(option1, option2)
+        super("`#{option1}' and `#{option2}' cannot be used together")
       end
     end
   end

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -91,5 +91,11 @@ module Hanami
         super("`#{scheme}' is not a supported db scheme")
       end
     end
+
+    class DatabaseNotSupportedError < Error
+      def initialize(invalid_database, supported_databases)
+        super("`#{invalid_database}' is not a supported database. Supported databases are: #{supported_databases.join(', ')}")
+      end
+    end
   end
 end

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -92,7 +92,7 @@ module Hanami
       end
     end
 
-    # @since x.x.x
+    # @since 2.2.0
     # @api public
     class DatabaseNotSupportedError < Error
       def initialize(invalid_database, supported_databases)
@@ -100,7 +100,7 @@ module Hanami
       end
     end
 
-    # @since x.x.x
+    # @since 2.2.0
     # @api public
     class ConflictingOptionsError < Error
       def initialize(option1, option2)

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -86,6 +86,18 @@ module Hanami
           !options.fetch(:skip_db, false)
         end
 
+        # @since x.x.x
+        # @api private
+        def generate_sqlite?
+          database_option == Commands::Gem::New::DATABASE_SQLITE
+        end
+
+        # @since x.x.x
+        # @api private
+        def generate_postgres?
+          database_option == Commands::Gem::New::DATABASE_POSTGRES
+        end
+
         # @since 2.1.0
         # @api private
         def bundled_views?
@@ -107,6 +119,10 @@ module Hanami
         end
 
         private
+
+        def database_option
+          options.fetch(:database, Commands::Gem::New::DATABASE_SQLITE)
+        end
 
         # @since 2.0.0
         # @api private

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -80,6 +80,12 @@ module Hanami
           !options.fetch(:skip_assets, false)
         end
 
+        # @since x.x.x
+        # @api private
+        def generate_db?
+          !options.fetch(:skip_db, false)
+        end
+
         # @since 2.1.0
         # @api private
         def bundled_views?

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -104,6 +104,20 @@ module Hanami
           database_option == Commands::Gem::New::DATABASE_MYSQL
         end
 
+        # @since 2.2.0
+        # @api private
+        def database_url
+          if generate_sqlite?
+            "sqlite://db/#{app}.sqlite"
+          elsif generate_postgres?
+            "postgres://localhost/#{app}"
+          elsif generate_mysql?
+            "mysql://localhost/#{app}"
+          else
+            raise "Unknown database option: #{database_option}"
+          end
+        end
+
         # @since 2.1.0
         # @api private
         def bundled_views?

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -98,6 +98,12 @@ module Hanami
           database_option == Commands::Gem::New::DATABASE_POSTGRES
         end
 
+        # @since x.x.x
+        # @api private
+        def generate_mysql?
+          database_option == Commands::Gem::New::DATABASE_MYSQL
+        end
+
         # @since 2.1.0
         # @api private
         def bundled_views?

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -80,25 +80,25 @@ module Hanami
           !options.fetch(:skip_assets, false)
         end
 
-        # @since x.x.x
+        # @since 2.2.0
         # @api private
         def generate_db?
           !options.fetch(:skip_db, false)
         end
 
-        # @since x.x.x
+        # @since 2.2.0
         # @api private
         def generate_sqlite?
           database_option == Commands::Gem::New::DATABASE_SQLITE
         end
 
-        # @since x.x.x
+        # @since 2.2.0
         # @api private
         def generate_postgres?
           database_option == Commands::Gem::New::DATABASE_POSTGRES
         end
 
-        # @since x.x.x
+        # @since 2.2.0
         # @api private
         def generate_mysql?
           database_option == Commands::Gem::New::DATABASE_MYSQL

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -70,6 +70,7 @@ module Hanami
 
             if context.generate_db?
               fs.write("app/repo.rb", t("repo.erb", context))
+              fs.write("app/db/relation.rb", t("relation.erb", context))
             end
 
             fs.write("public/404.html", file("404.html"))

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -74,6 +74,7 @@ module Hanami
               fs.write("app/db/struct.rb", t("struct.erb", context))
               fs.touch("app/structs/.keep")
               fs.touch("app/repos/.keep")
+              fs.touch("config/db/migrate/.keep")
             end
 
             fs.write("public/404.html", file("404.html"))

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -71,6 +71,7 @@ module Hanami
             if context.generate_db?
               fs.write("app/repo.rb", t("repo.erb", context))
               fs.write("app/db/relation.rb", t("relation.erb", context))
+              fs.write("app/db/struct.rb", t("struct.erb", context))
             end
 
             fs.write("public/404.html", file("404.html"))

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -68,6 +68,10 @@ module Hanami
               fs.write("app/assets/images/favicon.ico", file("favicon.ico"))
             end
 
+            if context.generate_db?
+              fs.write("app/repo.rb", t("repo.erb", context))
+            end
+
             fs.write("public/404.html", file("404.html"))
             fs.write("public/500.html", file("500.html"))
           end

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -72,6 +72,8 @@ module Hanami
               fs.write("app/repo.rb", t("repo.erb", context))
               fs.write("app/db/relation.rb", t("relation.erb", context))
               fs.write("app/db/struct.rb", t("struct.erb", context))
+              fs.touch("app/structs/.keep")
+              fs.touch("app/repos/.keep")
             end
 
             fs.write("public/404.html", file("404.html"))

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -69,7 +69,7 @@ module Hanami
             end
 
             if context.generate_db?
-              fs.write("app/repo.rb", t("repo.erb", context))
+              fs.write("app/db/repo.rb", t("repo.erb", context))
               fs.write("app/db/relation.rb", t("relation.erb", context))
               fs.write("app/db/struct.rb", t("struct.erb", context))
               fs.touch("app/structs/.keep")

--- a/lib/hanami/cli/generators/gem/app/env.erb
+++ b/lib/hanami/cli/generators/gem/app/env.erb
@@ -1,0 +1,3 @@
+<%- if generate_db? -%>
+DATABASE_URL=<%= database_url %>
+<%- end -%>

--- a/lib/hanami/cli/generators/gem/app/env.erb
+++ b/lib/hanami/cli/generators/gem/app/env.erb
@@ -1,3 +1,4 @@
+# This is checked into source control, so put sensitive values into `.env.local`
 <%- if generate_db? -%>
 DATABASE_URL=<%= database_url %>
 <%- end -%>

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -21,6 +21,8 @@ gem "rake"
 gem "sqlite3"
 <%- elsif generate_postgres? -%>
 gem "pg"
+<%- elsif generate_mysql? -%>
+gem "mysql2"
 <%- end -%>
 
 group :development do

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -7,6 +7,9 @@ source "https://rubygems.org"
 <%= hanami_gem("assets") %>
 <%- end -%>
 <%= hanami_gem("controller") %>
+<%- if generate_db? -%>
+<%= hanami_gem("db") %>
+<%- end -%>
 <%= hanami_gem("router") %>
 <%= hanami_gem("validations") %>
 <%= hanami_gem("view") %>

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -17,6 +17,11 @@ source "https://rubygems.org"
 gem "dry-types", "~> 1.0", ">= 1.6.1"
 gem "puma"
 gem "rake"
+<%- if generate_sqlite? -%>
+gem "sqlite3"
+<%- elsif generate_postgres? -%>
+gem "pg"
+<%- end -%>
 
 group :development do
   <%= hanami_gem("webconsole") %>

--- a/lib/hanami/cli/generators/gem/app/gitignore.erb
+++ b/lib/hanami/cli/generators/gem/app/gitignore.erb
@@ -1,4 +1,4 @@
-.env
+.env*.local
 log/*
 <%- if generate_assets? -%>
 public/

--- a/lib/hanami/cli/generators/gem/app/operation.erb
+++ b/lib/hanami/cli/generators/gem/app/operation.erb
@@ -5,5 +5,9 @@ require "dry/operation"
 
 module <%= camelized_app_name %>
   class Operation < Dry::Operation
+    <%- if generate_db? -%>
+    # Provide `transaction do ... end` method for database transactions
+    include Dry::Operation::Extensions::ROM
+    <%- end -%>
   end
 end

--- a/lib/hanami/cli/generators/gem/app/relation.erb
+++ b/lib/hanami/cli/generators/gem/app/relation.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "hanami/db/relation"
+
+module <%= camelized_app_name %>
+  module DB
+    class Relation < Hanami::DB::Relation
+    end
+  end
+end

--- a/lib/hanami/cli/generators/gem/app/repo.erb
+++ b/lib/hanami/cli/generators/gem/app/repo.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "hanami/db/repo"
+
+module <%= camelized_app_name %>
+  # FIXME: Change to Hanami::Repo once that exists
+  class Repo < Hanami::DB::Repo
+    include Deps[container: "db.rom"]
+  end
+end

--- a/lib/hanami/cli/generators/gem/app/repo.erb
+++ b/lib/hanami/cli/generators/gem/app/repo.erb
@@ -4,6 +4,5 @@ require "hanami/db/repo"
 
 module <%= camelized_app_name %>
   class Repo < Hanami::DB::Repo
-    include Deps[container: "db.rom"]
   end
 end

--- a/lib/hanami/cli/generators/gem/app/repo.erb
+++ b/lib/hanami/cli/generators/gem/app/repo.erb
@@ -3,7 +3,6 @@
 require "hanami/db/repo"
 
 module <%= camelized_app_name %>
-  # FIXME: Change to Hanami::Repo once that exists
   class Repo < Hanami::DB::Repo
     include Deps[container: "db.rom"]
   end

--- a/lib/hanami/cli/generators/gem/app/repo.erb
+++ b/lib/hanami/cli/generators/gem/app/repo.erb
@@ -3,6 +3,8 @@
 require "hanami/db/repo"
 
 module <%= camelized_app_name %>
-  class Repo < Hanami::DB::Repo
+  module DB
+    class Repo < Hanami::DB::Repo
+    end
   end
 end

--- a/lib/hanami/cli/generators/gem/app/struct.erb
+++ b/lib/hanami/cli/generators/gem/app/struct.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "hanami/db/struct"
+
+module <%= camelized_app_name %>
+  module DB
+    class Struct < Hanami::DB::Struct
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -410,6 +410,22 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.read("app/action.rb")).to eq(action)
         expect(output).to include("Created app/action.rb")
 
+        # app/repo.rb
+        repo = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/db/repo"
+
+          module #{inflector.camelize(app)}
+            # FIXME: Change to Hanami::Repo once that exists
+            class Repo < Hanami::DB::Repo
+              include Deps[container: "db.rom"]
+            end
+          end
+        EXPECTED
+        expect(fs.read("app/repo.rb")).to eq(repo)
+        expect(output).to include("Created app/repo.rb")
+
         # app/view.rb
         view = <<~RUBY
           # auto_register: false

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     fs.chdir(app) do
       # .gitignore
       gitignore = <<~EXPECTED
-        .env
+        .env*.local
         log/*
         public/
         node_modules/
@@ -555,7 +555,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       fs.chdir(app) do
         # .gitignore
         gitignore = <<~EXPECTED
-          .env
+          .env*.local
           log/*
           public/
           node_modules/

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   let(:inflector) { Dry::Inflector.new }
   let(:system_call) { instance_double(Hanami::CLI::SystemCall, call: successful_system_call_result) }
   let(:app) { "bookshelf" }
-  let(:kwargs) { {head: hanami_head, skip_assets: skip_assets} }
+  let(:kwargs) { {head: hanami_head, skip_db: skip_db, skip_assets: skip_assets} }
 
   let(:hanami_head) { false }
   let(:skip_assets) { false }
+  let(:skip_db) { false }
 
   let(:output) { out.rewind && out.read.chomp }
 
@@ -64,381 +65,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
     expect(fs.directory?(app)).to be(true)
     expect(fs.read("#{app}/config/app.rb")).to include("module #{module_name}")
-  end
-
-  it "generates an app" do
-    expect(bundler).to receive(:install!)
-      .and_return(true)
-
-    expect(bundler).to receive(:exec)
-      .with("hanami install")
-      .and_return(successful_system_call_result)
-
-    expect(bundler).to receive(:exec)
-      .with("check")
-      .at_least(1)
-      .and_return(successful_system_call_result)
-
-    expect(system_call).to receive(:call).with("npm", ["install"])
-
-    subject.call(app: app, **kwargs)
-
-    expect(fs.directory?(app)).to be(true)
-    expect(output).to include("Created #{app}/")
-    expect(output).to include("-> Within #{app}/")
-    expect(output).to include("Running Bundler install...")
-    expect(output).to include("Running Hanami install...")
-
-    fs.chdir(app) do
-      # .gitignore
-      gitignore = <<~EXPECTED
-        .env
-        log/*
-        public/
-        node_modules/
-      EXPECTED
-      expect(fs.read(".gitignore")).to eq(gitignore)
-      expect(output).to include("Created .gitignore")
-
-      # .env
-      env = <<~EXPECTED
-      EXPECTED
-      expect(fs.read(".env")).to eq(env)
-      expect(output).to include("Created .env")
-
-      # README.md
-      readme = <<~EXPECTED
-        # #{inflector.camelize(app)}
-      EXPECTED
-      expect(fs.read("README.md")).to eq(readme)
-      expect(output).to include("Created README.md")
-
-      # Gemfile
-      hanami_version = Hanami::CLI::Generators::Version.gem_requirement
-      gemfile = <<~EXPECTED
-        # frozen_string_literal: true
-
-        source "https://rubygems.org"
-
-        gem "hanami", "#{hanami_version}"
-        gem "hanami-assets", "#{hanami_version}"
-        gem "hanami-controller", "#{hanami_version}"
-        gem "hanami-router", "#{hanami_version}"
-        gem "hanami-validations", "#{hanami_version}"
-        gem "hanami-view", "#{hanami_version}"
-
-        gem "dry-types", "~> 1.0", ">= 1.6.1"
-        gem "puma"
-        gem "rake"
-
-        group :development do
-          gem "hanami-webconsole", "#{hanami_version}"
-        end
-
-        group :development, :test do
-          gem "dotenv"
-        end
-
-        group :cli, :development do
-          gem "hanami-reloader", "#{hanami_version}"
-        end
-
-        group :cli, :development, :test do
-          gem "hanami-rspec", "#{hanami_version}"
-        end
-      EXPECTED
-      expect(fs.read("Gemfile")).to eq(gemfile)
-      expect(output).to include("Created Gemfile")
-
-      # package.json
-      hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
-      package_json = <<~EXPECTED
-        {
-          "name": "#{app}",
-          "private": true,
-          "type": "module",
-          "dependencies": {
-            "hanami-assets": "#{hanami_npm_version}"
-          }
-        }
-      EXPECTED
-      expect(fs.read("package.json")).to eq(package_json)
-      expect(output).to include("Created package.json")
-
-      # Procfile.dev
-      procfile = <<~EXPECTED
-        web: bundle exec hanami server
-        assets: bundle exec hanami assets watch
-      EXPECTED
-      expect(fs.read("Procfile.dev")).to eq(procfile)
-      expect(output).to include("Created Procfile.dev")
-
-      # Rakefile
-      rakefile = <<~EXPECTED
-        # frozen_string_literal: true
-
-        require "hanami/rake_tasks"
-      EXPECTED
-      expect(fs.read("Rakefile")).to eq(rakefile)
-      expect(output).to include("Created Rakefile")
-
-      # config.ru
-      config_ru = <<~EXPECTED
-        # frozen_string_literal: true
-
-        require "hanami/boot"
-
-        run Hanami.app
-      EXPECTED
-      expect(fs.read("config.ru")).to eq(config_ru)
-      expect(output).to include("Created config.ru")
-
-      # bin/dev
-      bin_dev = <<~EXPECTED
-        #!/usr/bin/env sh
-
-        if ! gem list foreman -i --silent; then
-          echo "Installing foreman..."
-          gem install foreman
-        fi
-
-        exec foreman start -f Procfile.dev "$@"
-      EXPECTED
-      expect(fs.read("bin/dev")).to eq(bin_dev)
-      expect(fs.executable?("bin/dev")).to be(true)
-      expect(output).to include("Created bin/dev")
-
-      # config/app.rb
-      hanami_app = <<~EXPECTED
-        # frozen_string_literal: true
-
-        require "hanami"
-
-        module Bookshelf
-          class App < Hanami::App
-          end
-        end
-      EXPECTED
-      expect(fs.read("config/app.rb")).to eq(hanami_app)
-      expect(output).to include("Created config/app.rb")
-
-      # config/assets.js
-      assets = <<~EXPECTED
-        import * as assets from "hanami-assets";
-
-        await assets.run();
-
-        // To provide additional esbuild (https://esbuild.github.io) options, use the following:
-        //
-        // Read more at: https://guides.hanamirb.org/assets/customization/
-        //
-        // await assets.run({
-        //   esbuildOptionsFn: (args, esbuildOptions) => {
-        //     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
-        //     // compile vs watch.
-        //
-        //     return esbuildOptions;
-        //   }
-        // });
-      EXPECTED
-      expect(fs.read("config/assets.js")).to eq(assets)
-      expect(output).to include("Created config/assets.js")
-
-      # config/settings.rb
-      settings = <<~EXPECTED
-        # frozen_string_literal: true
-
-        module Bookshelf
-          class Settings < Hanami::Settings
-            # Define your app settings here, for example:
-            #
-            # setting :my_flag, default: false, constructor: Types::Params::Bool
-          end
-        end
-      EXPECTED
-      expect(fs.read("config/settings.rb")).to eq(settings)
-      expect(output).to include("Created config/settings.rb")
-
-      # config/routes.rb
-      routes = <<~EXPECTED
-        # frozen_string_literal: true
-
-        module Bookshelf
-          class Routes < Hanami::Routes
-            # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
-          end
-        end
-      EXPECTED
-      expect(fs.read("config/routes.rb")).to eq(routes)
-      expect(output).to include("Created config/routes.rb")
-
-      # config/puma.rb
-      puma = <<~EXPECTED
-        # frozen_string_literal: true
-
-        #
-        # Environment and port
-        #
-        port ENV.fetch("HANAMI_PORT", 2300)
-        environment ENV.fetch("HANAMI_ENV", "development")
-
-        #
-        # Threads within each Puma/Ruby process (aka worker)
-        #
-
-        # Configure the minimum and maximum number of threads to use to answer requests.
-        max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
-        min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
-
-        threads min_threads_count, max_threads_count
-
-        #
-        # Workers (aka Puma/Ruby processes)
-        #
-
-        puma_concurrency = Integer(ENV.fetch("HANAMI_WEB_CONCURRENCY", 0))
-        puma_cluster_mode = puma_concurrency > 1
-
-        # How many worker (Puma/Ruby) processes to run.
-        # Typically this is set to the number of available cores.
-        workers puma_concurrency
-
-        #
-        # Cluster mode (aka multiple workers)
-        #
-
-        if puma_cluster_mode
-          # Preload the application before starting the workers. Only in cluster mode.
-          preload_app!
-
-          # Code to run immediately before master process forks workers (once on boot).
-          #
-          # These hooks can block if necessary to wait for background operations unknown
-          # to puma to finish before the process terminates. This can be used to close
-          # any connections to remote servers (database, redis, …) that were opened when
-          # preloading the code.
-          before_fork do
-            Hanami.shutdown
-          end
-        end
-      EXPECTED
-      expect(fs.read("config/puma.rb")).to eq(puma)
-      expect(output).to include("Created config/puma.rb")
-
-      # lib/tasks/.keep
-      tasks_keep = <<~EXPECTED
-      EXPECTED
-      expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
-      expect(output).to include("Created lib/tasks/.keep")
-
-      # app/action.rb
-      action = <<~EXPECTED
-        # auto_register: false
-        # frozen_string_literal: true
-
-        require "hanami/action"
-
-        module #{inflector.camelize(app)}
-          class Action < Hanami::Action
-          end
-        end
-      EXPECTED
-      expect(fs.read("app/action.rb")).to eq(action)
-      expect(output).to include("Created app/action.rb")
-
-      # app/view.rb
-      view = <<~RUBY
-        # auto_register: false
-        # frozen_string_literal: true
-
-        require "hanami/view"
-
-        module #{inflector.camelize(app)}
-          class View < Hanami::View
-          end
-        end
-      RUBY
-      expect(fs.read("app/view.rb")).to eq(view)
-      expect(output).to include("Created app/view.rb")
-
-      # app/views/helpers.rb
-      helpers = <<~RUBY
-        # auto_register: false
-        # frozen_string_literal: true
-
-        module #{inflector.camelize(app)}
-          module Views
-            module Helpers
-              # Add your view helpers here
-            end
-          end
-        end
-      RUBY
-      expect(fs.read("app/views/helpers.rb")).to eq(helpers)
-      expect(output).to include("Created app/views/helpers.rb")
-
-      # app/templates/layouts/app.html.erb
-      layout = <<~ERB
-        <!DOCTYPE html>
-        <html lang="en">
-          <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>#{inflector.humanize(app)}</title>
-            <%= favicon_tag %>
-            <%= stylesheet_tag "app" %>
-          </head>
-          <body>
-            <%= yield %>
-            <%= javascript_tag "app" %>
-          </body>
-        </html>
-      ERB
-      expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
-      expect(output).to include("Created app/templates/layouts/app.html.erb")
-
-      # app/assets/js/app.js
-      app_js = <<~EXPECTED
-        import "../css/app.css";
-      EXPECTED
-      expect(fs.read("app/assets/js/app.js")).to eq(app_js)
-      expect(output).to include("Created app/assets/js/app.js")
-
-      # app/assets/css/app.css
-      app_css = <<~EXPECTED
-        body {
-          background-color: #fff;
-          color: #000;
-          font-family: sans-serif;
-        }
-      EXPECTED
-      expect(fs.read("app/assets/css/app.css")).to eq(app_css)
-      expect(output).to include("Created app/assets/css/app.css")
-
-      # app/assets/images/favicon.ico
-      expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
-
-      # lib/bookshelf/types.rb
-      types = <<~EXPECTED
-        # frozen_string_literal: true
-
-        require "dry/types"
-
-        module #{inflector.camelize(app)}
-          Types = Dry.Types
-
-          module Types
-            # Define your custom types here
-          end
-        end
-      EXPECTED
-      expect(fs.read("lib/#{app}/types.rb")).to eq(types)
-      expect(output).to include("Created lib/bookshelf/types.rb")
-
-      # public/ error pages
-      expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
-      expect(fs.read("public/500.html")).to include %(<title>We’re sorry, but something went wrong (500)</title>)
-    end
   end
 
   context "with head" do
@@ -497,6 +123,385 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("Gemfile")).to eq(gemfile)
         expect(output).to include("Created Gemfile")
+      end
+    end
+  end
+
+  context "without hanami-db" do
+    let(:skip_db) { true }
+
+    it "generates an app" do
+      expect(bundler).to receive(:install!)
+        .and_return(true)
+
+      expect(bundler).to receive(:exec)
+        .with("hanami install")
+        .and_return(successful_system_call_result)
+
+      expect(bundler).to receive(:exec)
+        .with("check")
+        .at_least(1)
+        .and_return(successful_system_call_result)
+
+      expect(system_call).to receive(:call).with("npm", ["install"])
+
+      subject.call(app: app, **kwargs)
+
+      expect(fs.directory?(app)).to be(true)
+      expect(output).to include("Created #{app}/")
+      expect(output).to include("-> Within #{app}/")
+      expect(output).to include("Running Bundler install...")
+      expect(output).to include("Running Hanami install...")
+
+      fs.chdir(app) do
+        # .gitignore
+        gitignore = <<~EXPECTED
+          .env
+          log/*
+          public/
+          node_modules/
+        EXPECTED
+        expect(fs.read(".gitignore")).to eq(gitignore)
+        expect(output).to include("Created .gitignore")
+
+        # .env
+        env = <<~EXPECTED
+        EXPECTED
+        expect(fs.read(".env")).to eq(env)
+        expect(output).to include("Created .env")
+
+        # README.md
+        readme = <<~EXPECTED
+          # #{inflector.camelize(app)}
+        EXPECTED
+        expect(fs.read("README.md")).to eq(readme)
+        expect(output).to include("Created README.md")
+
+        # Gemfile
+        hanami_version = Hanami::CLI::Generators::Version.gem_requirement
+        gemfile = <<~EXPECTED
+          # frozen_string_literal: true
+
+          source "https://rubygems.org"
+
+          gem "hanami", "#{hanami_version}"
+          gem "hanami-assets", "#{hanami_version}"
+          gem "hanami-controller", "#{hanami_version}"
+          gem "hanami-router", "#{hanami_version}"
+          gem "hanami-validations", "#{hanami_version}"
+          gem "hanami-view", "#{hanami_version}"
+
+          gem "dry-types", "~> 1.0", ">= 1.6.1"
+          gem "puma"
+          gem "rake"
+
+          group :development do
+            gem "hanami-webconsole", "#{hanami_version}"
+          end
+
+          group :development, :test do
+            gem "dotenv"
+          end
+
+          group :cli, :development do
+            gem "hanami-reloader", "#{hanami_version}"
+          end
+
+          group :cli, :development, :test do
+            gem "hanami-rspec", "#{hanami_version}"
+          end
+        EXPECTED
+        expect(fs.read("Gemfile")).to eq(gemfile)
+        expect(output).to include("Created Gemfile")
+
+        # package.json
+        hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
+        package_json = <<~EXPECTED
+          {
+            "name": "#{app}",
+            "private": true,
+            "type": "module",
+            "dependencies": {
+              "hanami-assets": "#{hanami_npm_version}"
+            }
+          }
+        EXPECTED
+        expect(fs.read("package.json")).to eq(package_json)
+        expect(output).to include("Created package.json")
+
+        # Procfile.dev
+        procfile = <<~EXPECTED
+          web: bundle exec hanami server
+          assets: bundle exec hanami assets watch
+        EXPECTED
+        expect(fs.read("Procfile.dev")).to eq(procfile)
+        expect(output).to include("Created Procfile.dev")
+
+        # Rakefile
+        rakefile = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/rake_tasks"
+        EXPECTED
+        expect(fs.read("Rakefile")).to eq(rakefile)
+        expect(output).to include("Created Rakefile")
+
+        # config.ru
+        config_ru = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/boot"
+
+          run Hanami.app
+        EXPECTED
+        expect(fs.read("config.ru")).to eq(config_ru)
+        expect(output).to include("Created config.ru")
+
+        # bin/dev
+        bin_dev = <<~EXPECTED
+          #!/usr/bin/env sh
+
+          if ! gem list foreman -i --silent; then
+            echo "Installing foreman..."
+            gem install foreman
+          fi
+
+          exec foreman start -f Procfile.dev "$@"
+        EXPECTED
+        expect(fs.read("bin/dev")).to eq(bin_dev)
+        expect(fs.executable?("bin/dev")).to be(true)
+        expect(output).to include("Created bin/dev")
+
+        # config/app.rb
+        hanami_app = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami"
+
+          module Bookshelf
+            class App < Hanami::App
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/app.rb")).to eq(hanami_app)
+        expect(output).to include("Created config/app.rb")
+
+        # config/assets.js
+        assets = <<~EXPECTED
+          import * as assets from "hanami-assets";
+
+          await assets.run();
+
+          // To provide additional esbuild (https://esbuild.github.io) options, use the following:
+          //
+          // Read more at: https://guides.hanamirb.org/assets/customization/
+          //
+          // await assets.run({
+          //   esbuildOptionsFn: (args, esbuildOptions) => {
+          //     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
+          //     // compile vs watch.
+          //
+          //     return esbuildOptions;
+          //   }
+          // });
+        EXPECTED
+        expect(fs.read("config/assets.js")).to eq(assets)
+        expect(output).to include("Created config/assets.js")
+
+        # config/settings.rb
+        settings = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Bookshelf
+            class Settings < Hanami::Settings
+              # Define your app settings here, for example:
+              #
+              # setting :my_flag, default: false, constructor: Types::Params::Bool
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/settings.rb")).to eq(settings)
+        expect(output).to include("Created config/settings.rb")
+
+        # config/routes.rb
+        routes = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Bookshelf
+            class Routes < Hanami::Routes
+              # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/routes.rb")).to eq(routes)
+        expect(output).to include("Created config/routes.rb")
+
+        # config/puma.rb
+        puma = <<~EXPECTED
+          # frozen_string_literal: true
+
+          #
+          # Environment and port
+          #
+          port ENV.fetch("HANAMI_PORT", 2300)
+          environment ENV.fetch("HANAMI_ENV", "development")
+
+          #
+          # Threads within each Puma/Ruby process (aka worker)
+          #
+
+          # Configure the minimum and maximum number of threads to use to answer requests.
+          max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
+          min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
+
+          threads min_threads_count, max_threads_count
+
+          #
+          # Workers (aka Puma/Ruby processes)
+          #
+
+          puma_concurrency = Integer(ENV.fetch("HANAMI_WEB_CONCURRENCY", 0))
+          puma_cluster_mode = puma_concurrency > 1
+
+          # How many worker (Puma/Ruby) processes to run.
+          # Typically this is set to the number of available cores.
+          workers puma_concurrency
+
+          #
+          # Cluster mode (aka multiple workers)
+          #
+
+          if puma_cluster_mode
+            # Preload the application before starting the workers. Only in cluster mode.
+            preload_app!
+
+            # Code to run immediately before master process forks workers (once on boot).
+            #
+            # These hooks can block if necessary to wait for background operations unknown
+            # to puma to finish before the process terminates. This can be used to close
+            # any connections to remote servers (database, redis, …) that were opened when
+            # preloading the code.
+            before_fork do
+              Hanami.shutdown
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/puma.rb")).to eq(puma)
+        expect(output).to include("Created config/puma.rb")
+
+        # lib/tasks/.keep
+        tasks_keep = <<~EXPECTED
+        EXPECTED
+        expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
+        expect(output).to include("Created lib/tasks/.keep")
+
+        # app/action.rb
+        action = <<~EXPECTED
+          # auto_register: false
+          # frozen_string_literal: true
+
+          require "hanami/action"
+
+          module #{inflector.camelize(app)}
+            class Action < Hanami::Action
+            end
+          end
+        EXPECTED
+        expect(fs.read("app/action.rb")).to eq(action)
+        expect(output).to include("Created app/action.rb")
+
+        # app/view.rb
+        view = <<~RUBY
+          # auto_register: false
+          # frozen_string_literal: true
+
+          require "hanami/view"
+
+          module #{inflector.camelize(app)}
+            class View < Hanami::View
+            end
+          end
+        RUBY
+        expect(fs.read("app/view.rb")).to eq(view)
+        expect(output).to include("Created app/view.rb")
+
+        # app/views/helpers.rb
+        helpers = <<~RUBY
+          # auto_register: false
+          # frozen_string_literal: true
+
+          module #{inflector.camelize(app)}
+            module Views
+              module Helpers
+                # Add your view helpers here
+              end
+            end
+          end
+        RUBY
+        expect(fs.read("app/views/helpers.rb")).to eq(helpers)
+        expect(output).to include("Created app/views/helpers.rb")
+
+        # app/templates/layouts/app.html.erb
+        layout = <<~ERB
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>#{inflector.humanize(app)}</title>
+              <%= favicon_tag %>
+              <%= stylesheet_tag "app" %>
+            </head>
+            <body>
+              <%= yield %>
+              <%= javascript_tag "app" %>
+            </body>
+          </html>
+        ERB
+        expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
+        expect(output).to include("Created app/templates/layouts/app.html.erb")
+
+        # app/assets/js/app.js
+        app_js = <<~EXPECTED
+          import "../css/app.css";
+        EXPECTED
+        expect(fs.read("app/assets/js/app.js")).to eq(app_js)
+        expect(output).to include("Created app/assets/js/app.js")
+
+        # app/assets/css/app.css
+        app_css = <<~EXPECTED
+          body {
+            background-color: #fff;
+            color: #000;
+            font-family: sans-serif;
+          }
+        EXPECTED
+        expect(fs.read("app/assets/css/app.css")).to eq(app_css)
+        expect(output).to include("Created app/assets/css/app.css")
+
+        # app/assets/images/favicon.ico
+        expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
+
+        # lib/bookshelf/types.rb
+        types = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "dry/types"
+
+          module #{inflector.camelize(app)}
+            Types = Dry.Types
+
+            module Types
+              # Define your custom types here
+            end
+          end
+        EXPECTED
+        expect(fs.read("lib/#{app}/types.rb")).to eq(types)
+        expect(output).to include("Created lib/bookshelf/types.rb")
+
+        # public/ error pages
+        expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
+        expect(fs.read("public/500.html")).to include %(<title>We’re sorry, but something went wrong (500)</title>)
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -453,6 +453,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         module #{inflector.camelize(app)}
           class Operation < Dry::Operation
+            # Provide `transaction do ... end` method for database transactions
+            include Dry::Operation::Extensions::ROM
           end
         end
       EXPECTED
@@ -989,7 +991,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.exist?("app/db/struct.rb")).to be(false)
         expect(fs.exist?("app/db/relation.rb")).to be(false)
         expect(fs.exist?("config/db/")).to be(false)
-
+        expect(fs.read("app/operation.rb")).to_not match("ROM")
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # .env
       env = <<~EXPECTED
+        # This is checked into source control, so put sensitive values into `.env.local`
         DATABASE_URL=sqlite://db/#{app}.sqlite
       EXPECTED
       expect(fs.read(".env")).to eq(env)
@@ -567,6 +568,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         # .env
         env = <<~EXPECTED
+          # This is checked into source control, so put sensitive values into `.env.local`
           DATABASE_URL=sqlite://db/#{app}.sqlite
         EXPECTED
         expect(fs.read(".env")).to eq(env)
@@ -986,7 +988,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       fs.chdir(app) do
         expect(fs.read("Gemfile")).to_not match(/hanami-db/)
-        expect(fs.read(".env")).to be_empty
+        expect(fs.read(".env")).to_not include("DATABASE_URL")
         expect(fs.exist?("app/db/repo.rb")).to be(false)
         expect(fs.exist?("app/db/struct.rb")).to be(false)
         expect(fs.exist?("app/db/relation.rb")).to be(false)
@@ -1161,7 +1163,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("sqlite3")
-          expect(fs.read(".env")).to eq("DATABASE_URL=sqlite://db/#{app}.sqlite\n")
+          expect(fs.read(".env")).to include("DATABASE_URL=sqlite://db/#{app}.sqlite")
         end
       end
 
@@ -1171,7 +1173,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("sqlite3")
-          expect(fs.read(".env")).to eq("DATABASE_URL=sqlite://db/#{app}.sqlite\n")
+          expect(fs.read(".env")).to include("DATABASE_URL=sqlite://db/#{app}.sqlite")
         end
       end
     end
@@ -1183,7 +1185,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("pg")
-          expect(fs.read(".env")).to eq("DATABASE_URL=postgres://localhost/#{app}\n")
+          expect(fs.read(".env")).to include("DATABASE_URL=postgres://localhost/#{app}")
         end
       end
 
@@ -1193,7 +1195,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("pg")
-          expect(fs.read(".env")).to eq("DATABASE_URL=postgres://localhost/#{app}\n")
+          expect(fs.read(".env")).to include("DATABASE_URL=postgres://localhost/#{app}")
         end
       end
 
@@ -1203,7 +1205,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("pg")
-          expect(fs.read(".env")).to eq("DATABASE_URL=postgres://localhost/#{app}\n")
+          expect(fs.read(".env")).to include("DATABASE_URL=postgres://localhost/#{app}")
         end
       end
     end
@@ -1215,7 +1217,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
-          expect(fs.read(".env")).to eq("DATABASE_URL=mysql://localhost/#{app}\n")
+          expect(fs.read(".env")).to include("DATABASE_URL=mysql://localhost/#{app}")
         end
       end
 
@@ -1225,7 +1227,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
-          expect(fs.read(".env")).to eq("DATABASE_URL=mysql://localhost/#{app}\n")
+          expect(fs.read(".env")).to include("DATABASE_URL=mysql://localhost/#{app}")
         end
       end
     end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -532,6 +532,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         expect(fs.read("app/structs/.keep")).to eq("")
         expect(fs.read("app/repos/.keep")).to eq("")
+        expect(fs.read("config/db/migrate/.keep")).to eq("")
 
         # lib/bookshelf/types.rb
         types = <<~EXPECTED
@@ -773,6 +774,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.exist?("app/db/struct.rb")).to be(false)
         expect(fs.directory?("app/structs")).to be(false)
         expect(fs.directory?("app/repos")).to be(false)
+        expect(fs.directory?("config/db/migrate")).to be(false)
+        expect(fs.directory?("config/db")).to be(false)
 
         # app/views/helpers.rb
         helpers = <<~RUBY

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -420,9 +420,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           require "hanami/db/repo"
 
           module #{inflector.camelize(app)}
-            # FIXME: Change to Hanami::Repo once that exists
             class Repo < Hanami::DB::Repo
-              include Deps[container: "db.rom"]
             end
           end
         EXPECTED

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1019,30 +1019,72 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         .and_return(successful_system_call_result)
     end
 
-    it "generates app for sqlite database" do
-      subject.call(app: app, database: "sqlite")
+    describe "sqlite database" do
+      it "generates app for --database=sqlite" do
+        subject.call(app: app, database: "sqlite")
 
-      fs.chdir(app) do
-        expect(fs.read("Gemfile")).to include("hanami-db")
-        expect(fs.read("Gemfile")).to include("sqlite3")
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("sqlite3")
+        end
+      end
+
+      it "generates app for --database=sqlite3" do
+        subject.call(app: app, database: "sqlite3")
+
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("sqlite3")
+        end
       end
     end
 
-    it "generates app for postgres database" do
-      subject.call(app: app, database: "postgres")
+    describe "postgres database" do
+      it "generates app for --database=postgres" do
+        subject.call(app: app, database: "postgres")
 
-      fs.chdir(app) do
-        expect(fs.read("Gemfile")).to include("hanami-db")
-        expect(fs.read("Gemfile")).to include("pg")
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("pg")
+        end
+      end
+
+      it "generates app for --database=postgresql" do
+        subject.call(app: app, database: "postgresql")
+
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("pg")
+        end
       end
     end
 
-    it "generates app for mysql database" do
-      subject.call(app: app, database: "mysql")
+    describe "mysql database" do
+      it "generates app for --database=mysql" do
+        subject.call(app: app, database: "mysql")
 
-      fs.chdir(app) do
-        expect(fs.read("Gemfile")).to include("hanami-db")
-        expect(fs.read("Gemfile")).to include("mysql2")
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("mysql2")
+        end
+      end
+
+      it "generates app for --database=mysql2" do
+        subject.call(app: app, database: "mysql2")
+
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("mysql2")
+        end
+      end
+
+      it "generates app for --database=pg" do
+        subject.call(app: app, database: "pg")
+
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("pg")
+        end
       end
     end
 
@@ -1056,7 +1098,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       )
     end
 
-    it "doesn't allow --skip-db && --database=..." do
+    it "doesn't allow --skip-db && --database" do
       expect {
         subject.call(app: app, database: "sqlite", skip_db: true)
       }.to raise_error(

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1019,7 +1019,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         .and_return(successful_system_call_result)
     end
 
-    it "generates for sqlite database" do
+    it "generates app for sqlite database" do
       subject.call(app: app, database: "sqlite")
 
       fs.chdir(app) do
@@ -1028,12 +1028,21 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       end
     end
 
-    it "generates for postgres database" do
+    it "generates app for postgres database" do
       subject.call(app: app, database: "postgres")
 
       fs.chdir(app) do
         expect(fs.read("Gemfile")).to include("hanami-db")
         expect(fs.read("Gemfile")).to include("pg")
+      end
+    end
+
+    it "generates app for mysql database" do
+      subject.call(app: app, database: "mysql")
+
+      fs.chdir(app) do
+        expect(fs.read("Gemfile")).to include("hanami-db")
+        expect(fs.read("Gemfile")).to include("mysql2")
       end
     end
 

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   let(:inflector) { Dry::Inflector.new }
   let(:system_call) { instance_double(Hanami::CLI::SystemCall, call: successful_system_call_result) }
   let(:app) { "bookshelf" }
-  let(:kwargs) { {head: hanami_head, skip_db: skip_db, skip_assets: skip_assets} }
+  let(:kwargs) { {head: hanami_head, skip_assets: skip_assets, skip_db: skip_db} }
 
   let(:hanami_head) { false }
   let(:skip_assets) { false }
@@ -97,6 +97,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "hanami", github: "hanami/hanami", branch: "main"
           gem "hanami-assets", github: "hanami/assets", branch: "main"
           gem "hanami-controller", github: "hanami/controller", branch: "main"
+          gem "hanami-db", github: "hanami/db", branch: "main"
           gem "hanami-router", github: "hanami/router", branch: "main"
           gem "hanami-validations", github: "hanami/validations", branch: "main"
           gem "hanami-view", github: "hanami/view", branch: "main"
@@ -127,10 +128,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     end
   end
 
-  context "without hanami-db" do
-    let(:skip_db) { true }
-
-    it "generates an app" do
+  context "default configuration" do
+    it "generates an app with hanami-assets and hanami-db" do
       expect(bundler).to receive(:install!)
         .and_return(true)
 
@@ -187,6 +186,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "hanami", "#{hanami_version}"
           gem "hanami-assets", "#{hanami_version}"
           gem "hanami-controller", "#{hanami_version}"
+          gem "hanami-db", "#{hanami_version}"
           gem "hanami-router", "#{hanami_version}"
           gem "hanami-validations", "#{hanami_version}"
           gem "hanami-view", "#{hanami_version}"
@@ -213,6 +213,351 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("Gemfile")).to eq(gemfile)
         expect(output).to include("Created Gemfile")
+
+        # package.json
+        hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
+        package_json = <<~EXPECTED
+          {
+            "name": "#{app}",
+            "private": true,
+            "type": "module",
+            "dependencies": {
+              "hanami-assets": "#{hanami_npm_version}"
+            }
+          }
+        EXPECTED
+        expect(fs.read("package.json")).to eq(package_json)
+        expect(output).to include("Created package.json")
+
+        # Procfile.dev
+        procfile = <<~EXPECTED
+          web: bundle exec hanami server
+          assets: bundle exec hanami assets watch
+        EXPECTED
+        expect(fs.read("Procfile.dev")).to eq(procfile)
+        expect(output).to include("Created Procfile.dev")
+
+        # Rakefile
+        rakefile = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/rake_tasks"
+        EXPECTED
+        expect(fs.read("Rakefile")).to eq(rakefile)
+        expect(output).to include("Created Rakefile")
+
+        # config.ru
+        config_ru = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/boot"
+
+          run Hanami.app
+        EXPECTED
+        expect(fs.read("config.ru")).to eq(config_ru)
+        expect(output).to include("Created config.ru")
+
+        # bin/dev
+        bin_dev = <<~EXPECTED
+          #!/usr/bin/env sh
+
+          if ! gem list foreman -i --silent; then
+            echo "Installing foreman..."
+            gem install foreman
+          fi
+
+          exec foreman start -f Procfile.dev "$@"
+        EXPECTED
+        expect(fs.read("bin/dev")).to eq(bin_dev)
+        expect(fs.executable?("bin/dev")).to be(true)
+        expect(output).to include("Created bin/dev")
+
+        # config/app.rb
+        hanami_app = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami"
+
+          module Bookshelf
+            class App < Hanami::App
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/app.rb")).to eq(hanami_app)
+        expect(output).to include("Created config/app.rb")
+
+        # config/assets.js
+        assets = <<~EXPECTED
+          import * as assets from "hanami-assets";
+
+          await assets.run();
+
+          // To provide additional esbuild (https://esbuild.github.io) options, use the following:
+          //
+          // Read more at: https://guides.hanamirb.org/assets/customization/
+          //
+          // await assets.run({
+          //   esbuildOptionsFn: (args, esbuildOptions) => {
+          //     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
+          //     // compile vs watch.
+          //
+          //     return esbuildOptions;
+          //   }
+          // });
+        EXPECTED
+        expect(fs.read("config/assets.js")).to eq(assets)
+        expect(output).to include("Created config/assets.js")
+
+        # config/settings.rb
+        settings = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Bookshelf
+            class Settings < Hanami::Settings
+              # Define your app settings here, for example:
+              #
+              # setting :my_flag, default: false, constructor: Types::Params::Bool
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/settings.rb")).to eq(settings)
+        expect(output).to include("Created config/settings.rb")
+
+        # config/routes.rb
+        routes = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Bookshelf
+            class Routes < Hanami::Routes
+              # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/routes.rb")).to eq(routes)
+        expect(output).to include("Created config/routes.rb")
+
+        # config/puma.rb
+        puma = <<~EXPECTED
+          # frozen_string_literal: true
+
+          #
+          # Environment and port
+          #
+          port ENV.fetch("HANAMI_PORT", 2300)
+          environment ENV.fetch("HANAMI_ENV", "development")
+
+          #
+          # Threads within each Puma/Ruby process (aka worker)
+          #
+
+          # Configure the minimum and maximum number of threads to use to answer requests.
+          max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
+          min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
+
+          threads min_threads_count, max_threads_count
+
+          #
+          # Workers (aka Puma/Ruby processes)
+          #
+
+          puma_concurrency = Integer(ENV.fetch("HANAMI_WEB_CONCURRENCY", 0))
+          puma_cluster_mode = puma_concurrency > 1
+
+          # How many worker (Puma/Ruby) processes to run.
+          # Typically this is set to the number of available cores.
+          workers puma_concurrency
+
+          #
+          # Cluster mode (aka multiple workers)
+          #
+
+          if puma_cluster_mode
+            # Preload the application before starting the workers. Only in cluster mode.
+            preload_app!
+
+            # Code to run immediately before master process forks workers (once on boot).
+            #
+            # These hooks can block if necessary to wait for background operations unknown
+            # to puma to finish before the process terminates. This can be used to close
+            # any connections to remote servers (database, redis, …) that were opened when
+            # preloading the code.
+            before_fork do
+              Hanami.shutdown
+            end
+          end
+        EXPECTED
+        expect(fs.read("config/puma.rb")).to eq(puma)
+        expect(output).to include("Created config/puma.rb")
+
+        # lib/tasks/.keep
+        tasks_keep = <<~EXPECTED
+        EXPECTED
+        expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
+        expect(output).to include("Created lib/tasks/.keep")
+
+        # app/action.rb
+        action = <<~EXPECTED
+          # auto_register: false
+          # frozen_string_literal: true
+
+          require "hanami/action"
+
+          module #{inflector.camelize(app)}
+            class Action < Hanami::Action
+            end
+          end
+        EXPECTED
+        expect(fs.read("app/action.rb")).to eq(action)
+        expect(output).to include("Created app/action.rb")
+
+        # app/view.rb
+        view = <<~RUBY
+          # auto_register: false
+          # frozen_string_literal: true
+
+          require "hanami/view"
+
+          module #{inflector.camelize(app)}
+            class View < Hanami::View
+            end
+          end
+        RUBY
+        expect(fs.read("app/view.rb")).to eq(view)
+        expect(output).to include("Created app/view.rb")
+
+        # app/views/helpers.rb
+        helpers = <<~RUBY
+          # auto_register: false
+          # frozen_string_literal: true
+
+          module #{inflector.camelize(app)}
+            module Views
+              module Helpers
+                # Add your view helpers here
+              end
+            end
+          end
+        RUBY
+        expect(fs.read("app/views/helpers.rb")).to eq(helpers)
+        expect(output).to include("Created app/views/helpers.rb")
+
+        # app/templates/layouts/app.html.erb
+        layout = <<~ERB
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>#{inflector.humanize(app)}</title>
+              <%= favicon_tag %>
+              <%= stylesheet_tag "app" %>
+            </head>
+            <body>
+              <%= yield %>
+              <%= javascript_tag "app" %>
+            </body>
+          </html>
+        ERB
+        expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
+        expect(output).to include("Created app/templates/layouts/app.html.erb")
+
+        # app/assets/js/app.js
+        app_js = <<~EXPECTED
+          import "../css/app.css";
+        EXPECTED
+        expect(fs.read("app/assets/js/app.js")).to eq(app_js)
+        expect(output).to include("Created app/assets/js/app.js")
+
+        # app/assets/css/app.css
+        app_css = <<~EXPECTED
+          body {
+            background-color: #fff;
+            color: #000;
+            font-family: sans-serif;
+          }
+        EXPECTED
+        expect(fs.read("app/assets/css/app.css")).to eq(app_css)
+        expect(output).to include("Created app/assets/css/app.css")
+
+        # app/assets/images/favicon.ico
+        expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
+
+        # lib/bookshelf/types.rb
+        types = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "dry/types"
+
+          module #{inflector.camelize(app)}
+            Types = Dry.Types
+
+            module Types
+              # Define your custom types here
+            end
+          end
+        EXPECTED
+        expect(fs.read("lib/#{app}/types.rb")).to eq(types)
+        expect(output).to include("Created lib/bookshelf/types.rb")
+
+        # public/ error pages
+        expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
+        expect(fs.read("public/500.html")).to include %(<title>We’re sorry, but something went wrong (500)</title>)
+      end
+    end
+  end
+
+  context "without hanami-db" do
+    let(:skip_db) { true }
+
+    it "generates an app without hanami-db files" do
+      expect(bundler).to receive(:install!)
+        .and_return(true)
+
+      expect(bundler).to receive(:exec)
+        .with("hanami install")
+        .and_return(successful_system_call_result)
+
+      expect(bundler).to receive(:exec)
+        .with("check")
+        .at_least(1)
+        .and_return(successful_system_call_result)
+
+      expect(system_call).to receive(:call).with("npm", ["install"])
+
+      subject.call(app: app, **kwargs)
+
+      expect(fs.directory?(app)).to be(true)
+      expect(output).to include("Created #{app}/")
+      expect(output).to include("-> Within #{app}/")
+      expect(output).to include("Running Bundler install...")
+      expect(output).to include("Running Hanami install...")
+
+      fs.chdir(app) do
+        # .gitignore
+        gitignore = <<~EXPECTED
+          .env
+          log/*
+          public/
+          node_modules/
+        EXPECTED
+        expect(fs.read(".gitignore")).to eq(gitignore)
+        expect(output).to include("Created .gitignore")
+
+        # .env
+        env = <<~EXPECTED
+        EXPECTED
+        expect(fs.read(".env")).to eq(env)
+        expect(output).to include("Created .env")
+
+        # README.md
+        readme = <<~EXPECTED
+          # #{inflector.camelize(app)}
+        EXPECTED
+        expect(fs.read("README.md")).to eq(readme)
+        expect(output).to include("Created README.md")
+
+        # Gemfile
+        expect(fs.read("Gemfile")).to_not match(/hanami-db/)
 
         # package.json
         hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -827,7 +827,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           require "hanami/db/repo"
 
           module #{inflector.camelize(app)}
-            class Repo < Hanami::DB::Repo
+            module DB
+              class Repo < Hanami::DB::Repo
+              end
             end
           end
         EXPECTED

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       # .env
       env = <<~EXPECTED
+        DATABASE_URL=sqlite://db/#{app}.sqlite
       EXPECTED
       expect(fs.read(".env")).to eq(env)
       expect(output).to include("Created .env")
@@ -564,6 +565,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         # .env
         env = <<~EXPECTED
+          DATABASE_URL=sqlite://db/#{app}.sqlite
         EXPECTED
         expect(fs.read(".env")).to eq(env)
         expect(output).to include("Created .env")
@@ -981,12 +983,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       subject.call(app: app, **kwargs)
 
       fs.chdir(app) do
-        # Gemfile
         expect(fs.read("Gemfile")).to_not match(/hanami-db/)
+        expect(fs.read(".env")).to be_empty
         expect(fs.exist?("app/db/repo.rb")).to be(false)
         expect(fs.exist?("app/db/struct.rb")).to be(false)
         expect(fs.exist?("app/db/relation.rb")).to be(false)
         expect(fs.exist?("config/db/")).to be(false)
+
       end
     end
   end
@@ -1156,6 +1159,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("sqlite3")
+          expect(fs.read(".env")).to eq("DATABASE_URL=sqlite://db/#{app}.sqlite\n")
         end
       end
 
@@ -1165,6 +1169,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("sqlite3")
+          expect(fs.read(".env")).to eq("DATABASE_URL=sqlite://db/#{app}.sqlite\n")
         end
       end
     end
@@ -1176,6 +1181,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("pg")
+          expect(fs.read(".env")).to eq("DATABASE_URL=postgres://localhost/#{app}\n")
         end
       end
 
@@ -1185,6 +1191,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("pg")
+          expect(fs.read(".env")).to eq("DATABASE_URL=postgres://localhost/#{app}\n")
         end
       end
 
@@ -1194,6 +1201,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("pg")
+          expect(fs.read(".env")).to eq("DATABASE_URL=postgres://localhost/#{app}\n")
         end
       end
     end
@@ -1205,6 +1213,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
+          expect(fs.read(".env")).to eq("DATABASE_URL=mysql://localhost/#{app}\n")
         end
       end
 
@@ -1214,6 +1223,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
+          expect(fs.read(".env")).to eq("DATABASE_URL=mysql://localhost/#{app}\n")
         end
       end
     end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gem "hanami", "#{hanami_version}"
         gem "hanami-assets", "#{hanami_version}"
         gem "hanami-controller", "#{hanami_version}"
+        gem "hanami-db", "#{hanami_version}"
         gem "hanami-router", "#{hanami_version}"
         gem "hanami-validations", "#{hanami_version}"
         gem "hanami-view", "#{hanami_version}"
@@ -133,6 +134,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gem "dry-operation", github: "dry-rb/dry-operation"
         gem "puma"
         gem "rake"
+        gem "sqlite3"
 
         group :development do
           gem "hanami-webconsole", "#{hanami_version}"
@@ -589,6 +591,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "hanami-view", "#{hanami_version}"
 
           gem "dry-types", "~> 1.0", ">= 1.6.1"
+          gem "dry-operation", github: "dry-rb/dry-operation"
           gem "puma"
           gem "rake"
           gem "sqlite3"
@@ -799,9 +802,12 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           # frozen_string_literal: true
 
           require "hanami/action"
+          require "dry/monads"
 
           module #{inflector.camelize(app)}
             class Action < Hanami::Action
+              # Provide `Success` and `Failure` for pattern matching on operation results
+              include Dry::Monads[:result]
             end
           end
         EXPECTED

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
   let(:hanami_head) { false }
   let(:skip_assets) { false }
   let(:skip_db) { false }
-  let(:database) { "sqlite" }
+  let(:database) { nil }
 
   let(:output) { out.rewind && out.read.chomp }
 
@@ -1052,10 +1052,16 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       }.to raise_error(
         Hanami::CLI::DatabaseNotSupportedError
       ).with_message(
-        "`foodb' is not a supported database. Supported databases are: sqlite, postgres"
+        "`foodb' is not a supported database. Supported databases are: sqlite, postgres, mysql"
       )
     end
 
-    xit "doesn't allow --skip-db && --database=..."
+    it "doesn't allow --skip-db && --database=..." do
+      expect {
+        subject.call(app: app, database: "sqlite", skip_db: true)
+      }.to raise_error(
+        Hanami::CLI::ConflictingOptionsError
+      ).with_message("`--skip-db' and `--database' cannot be used together")
+    end
   end
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -514,6 +514,22 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.read("app/db/relation.rb")).to eq(relation)
         expect(output).to include("Created app/db/relation.rb")
 
+        # app/db/struct.rb
+        struct = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/db/struct"
+
+          module #{inflector.camelize(app)}
+            module DB
+              class Struct < Hanami::DB::Struct
+              end
+            end
+          end
+        EXPECTED
+        expect(fs.read("app/db/struct.rb")).to eq(struct)
+        expect(output).to include("Created app/db/struct.rb")
+
         # lib/bookshelf/types.rb
         types = <<~EXPECTED
           # frozen_string_literal: true
@@ -751,6 +767,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         expect(fs.exist?("app/repo.rb")).to be(false)
         expect(fs.exist?("app/db/relation.rb")).to be(false)
+        expect(fs.exist?("app/db/struct.rb")).to be(false)
 
         # app/views/helpers.rb
         helpers = <<~RUBY

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -498,6 +498,22 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         # app/assets/images/favicon.ico
         expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
 
+        # app/db/relation.rb
+        relation = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/db/relation"
+
+          module #{inflector.camelize(app)}
+            module DB
+              class Relation < Hanami::DB::Relation
+              end
+            end
+          end
+        EXPECTED
+        expect(fs.read("app/db/relation.rb")).to eq(relation)
+        expect(output).to include("Created app/db/relation.rb")
+
         # lib/bookshelf/types.rb
         types = <<~EXPECTED
           # frozen_string_literal: true
@@ -697,59 +713,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.read("config/routes.rb")).to eq(routes)
         expect(output).to include("Created config/routes.rb")
 
-        # config/puma.rb
-        puma = <<~EXPECTED
-          # frozen_string_literal: true
-
-          #
-          # Environment and port
-          #
-          port ENV.fetch("HANAMI_PORT", 2300)
-          environment ENV.fetch("HANAMI_ENV", "development")
-
-          #
-          # Threads within each Puma/Ruby process (aka worker)
-          #
-
-          # Configure the minimum and maximum number of threads to use to answer requests.
-          max_threads_count = ENV.fetch("HANAMI_MAX_THREADS", 5)
-          min_threads_count = ENV.fetch("HANAMI_MIN_THREADS") { max_threads_count }
-
-          threads min_threads_count, max_threads_count
-
-          #
-          # Workers (aka Puma/Ruby processes)
-          #
-
-          puma_concurrency = Integer(ENV.fetch("HANAMI_WEB_CONCURRENCY", 0))
-          puma_cluster_mode = puma_concurrency > 1
-
-          # How many worker (Puma/Ruby) processes to run.
-          # Typically this is set to the number of available cores.
-          workers puma_concurrency
-
-          #
-          # Cluster mode (aka multiple workers)
-          #
-
-          if puma_cluster_mode
-            # Preload the application before starting the workers. Only in cluster mode.
-            preload_app!
-
-            # Code to run immediately before master process forks workers (once on boot).
-            #
-            # These hooks can block if necessary to wait for background operations unknown
-            # to puma to finish before the process terminates. This can be used to close
-            # any connections to remote servers (database, redis, …) that were opened when
-            # preloading the code.
-            before_fork do
-              Hanami.shutdown
-            end
-          end
-        EXPECTED
-        expect(fs.read("config/puma.rb")).to eq(puma)
-        expect(output).to include("Created config/puma.rb")
-
         # lib/tasks/.keep
         tasks_keep = <<~EXPECTED
         EXPECTED
@@ -785,6 +748,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         RUBY
         expect(fs.read("app/view.rb")).to eq(view)
         expect(output).to include("Created app/view.rb")
+
+        expect(fs.exist?("app/repo.rb")).to be(false)
+        expect(fs.exist?("app/db/relation.rb")).to be(false)
 
         # app/views/helpers.rb
         helpers = <<~RUBY

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -424,8 +424,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
             end
           end
         EXPECTED
-        expect(fs.read("app/repo.rb")).to eq(repo)
-        expect(output).to include("Created app/repo.rb")
+        expect(fs.read("app/db/repo.rb")).to eq(repo)
+        expect(output).to include("Created app/db/repo.rb")
 
         # app/view.rb
         view = <<~RUBY
@@ -579,282 +579,13 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       subject.call(app: app, **kwargs)
 
-      expect(fs.directory?(app)).to be(true)
-      expect(output).to include("Created #{app}/")
-      expect(output).to include("-> Within #{app}/")
-      expect(output).to include("Running Bundler install...")
-      expect(output).to include("Running Hanami install...")
-
       fs.chdir(app) do
-        # .gitignore
-        gitignore = <<~EXPECTED
-          .env
-          log/*
-          public/
-          node_modules/
-        EXPECTED
-        expect(fs.read(".gitignore")).to eq(gitignore)
-        expect(output).to include("Created .gitignore")
-
-        # .env
-        env = <<~EXPECTED
-        EXPECTED
-        expect(fs.read(".env")).to eq(env)
-        expect(output).to include("Created .env")
-
-        # README.md
-        readme = <<~EXPECTED
-          # #{inflector.camelize(app)}
-        EXPECTED
-        expect(fs.read("README.md")).to eq(readme)
-        expect(output).to include("Created README.md")
-
         # Gemfile
         expect(fs.read("Gemfile")).to_not match(/hanami-db/)
-
-        # package.json
-        hanami_npm_version = Hanami::CLI::Generators::Version.npm_package_requirement
-        package_json = <<~EXPECTED
-          {
-            "name": "#{app}",
-            "private": true,
-            "type": "module",
-            "dependencies": {
-              "hanami-assets": "#{hanami_npm_version}"
-            }
-          }
-        EXPECTED
-        expect(fs.read("package.json")).to eq(package_json)
-        expect(output).to include("Created package.json")
-
-        # Procfile.dev
-        procfile = <<~EXPECTED
-          web: bundle exec hanami server
-          assets: bundle exec hanami assets watch
-        EXPECTED
-        expect(fs.read("Procfile.dev")).to eq(procfile)
-        expect(output).to include("Created Procfile.dev")
-
-        # Rakefile
-        rakefile = <<~EXPECTED
-          # frozen_string_literal: true
-
-          require "hanami/rake_tasks"
-        EXPECTED
-        expect(fs.read("Rakefile")).to eq(rakefile)
-        expect(output).to include("Created Rakefile")
-
-        # config.ru
-        config_ru = <<~EXPECTED
-          # frozen_string_literal: true
-
-          require "hanami/boot"
-
-          run Hanami.app
-        EXPECTED
-        expect(fs.read("config.ru")).to eq(config_ru)
-        expect(output).to include("Created config.ru")
-
-        # bin/dev
-        bin_dev = <<~EXPECTED
-          #!/usr/bin/env sh
-
-          if ! gem list foreman -i --silent; then
-            echo "Installing foreman..."
-            gem install foreman
-          fi
-
-          exec foreman start -f Procfile.dev "$@"
-        EXPECTED
-        expect(fs.read("bin/dev")).to eq(bin_dev)
-        expect(fs.executable?("bin/dev")).to be(true)
-        expect(output).to include("Created bin/dev")
-
-        # config/app.rb
-        hanami_app = <<~EXPECTED
-          # frozen_string_literal: true
-
-          require "hanami"
-
-          module Bookshelf
-            class App < Hanami::App
-            end
-          end
-        EXPECTED
-        expect(fs.read("config/app.rb")).to eq(hanami_app)
-        expect(output).to include("Created config/app.rb")
-
-        # config/assets.js
-        assets = <<~EXPECTED
-          import * as assets from "hanami-assets";
-
-          await assets.run();
-
-          // To provide additional esbuild (https://esbuild.github.io) options, use the following:
-          //
-          // Read more at: https://guides.hanamirb.org/assets/customization/
-          //
-          // await assets.run({
-          //   esbuildOptionsFn: (args, esbuildOptions) => {
-          //     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
-          //     // compile vs watch.
-          //
-          //     return esbuildOptions;
-          //   }
-          // });
-        EXPECTED
-        expect(fs.read("config/assets.js")).to eq(assets)
-        expect(output).to include("Created config/assets.js")
-
-        # config/settings.rb
-        settings = <<~EXPECTED
-          # frozen_string_literal: true
-
-          module Bookshelf
-            class Settings < Hanami::Settings
-              # Define your app settings here, for example:
-              #
-              # setting :my_flag, default: false, constructor: Types::Params::Bool
-            end
-          end
-        EXPECTED
-        expect(fs.read("config/settings.rb")).to eq(settings)
-        expect(output).to include("Created config/settings.rb")
-
-        # config/routes.rb
-        routes = <<~EXPECTED
-          # frozen_string_literal: true
-
-          module Bookshelf
-            class Routes < Hanami::Routes
-              # Add your routes here. See https://guides.hanamirb.org/routing/overview/ for details.
-            end
-          end
-        EXPECTED
-        expect(fs.read("config/routes.rb")).to eq(routes)
-        expect(output).to include("Created config/routes.rb")
-
-        # lib/tasks/.keep
-        tasks_keep = <<~EXPECTED
-        EXPECTED
-        expect(fs.read("lib/tasks/.keep")).to eq(tasks_keep)
-        expect(output).to include("Created lib/tasks/.keep")
-
-        # app/action.rb
-        action = <<~EXPECTED
-          # auto_register: false
-          # frozen_string_literal: true
-
-          require "hanami/action"
-
-          module #{inflector.camelize(app)}
-            class Action < Hanami::Action
-            end
-          end
-        EXPECTED
-        expect(fs.read("app/action.rb")).to eq(action)
-        expect(output).to include("Created app/action.rb")
-
-        # app/view.rb
-        view = <<~RUBY
-          # auto_register: false
-          # frozen_string_literal: true
-
-          require "hanami/view"
-
-          module #{inflector.camelize(app)}
-            class View < Hanami::View
-            end
-          end
-        RUBY
-        expect(fs.read("app/view.rb")).to eq(view)
-        expect(output).to include("Created app/view.rb")
-
-        expect(fs.exist?("app/repo.rb")).to be(false)
-        expect(fs.exist?("app/db/relation.rb")).to be(false)
+        expect(fs.exist?("app/db/repo.rb")).to be(false)
         expect(fs.exist?("app/db/struct.rb")).to be(false)
-        expect(fs.directory?("app/structs")).to be(false)
-        expect(fs.directory?("app/repos")).to be(false)
-        expect(fs.directory?("config/db/migrate")).to be(false)
-        expect(fs.directory?("config/db")).to be(false)
-
-        # app/views/helpers.rb
-        helpers = <<~RUBY
-          # auto_register: false
-          # frozen_string_literal: true
-
-          module #{inflector.camelize(app)}
-            module Views
-              module Helpers
-                # Add your view helpers here
-              end
-            end
-          end
-        RUBY
-        expect(fs.read("app/views/helpers.rb")).to eq(helpers)
-        expect(output).to include("Created app/views/helpers.rb")
-
-        # app/templates/layouts/app.html.erb
-        layout = <<~ERB
-          <!DOCTYPE html>
-          <html lang="en">
-            <head>
-              <meta charset="UTF-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-              <title>#{inflector.humanize(app)}</title>
-              <%= favicon_tag %>
-              <%= stylesheet_tag "app" %>
-            </head>
-            <body>
-              <%= yield %>
-              <%= javascript_tag "app" %>
-            </body>
-          </html>
-        ERB
-        expect(fs.read("app/templates/layouts/app.html.erb")).to eq(layout)
-        expect(output).to include("Created app/templates/layouts/app.html.erb")
-
-        # app/assets/js/app.js
-        app_js = <<~EXPECTED
-          import "../css/app.css";
-        EXPECTED
-        expect(fs.read("app/assets/js/app.js")).to eq(app_js)
-        expect(output).to include("Created app/assets/js/app.js")
-
-        # app/assets/css/app.css
-        app_css = <<~EXPECTED
-          body {
-            background-color: #fff;
-            color: #000;
-            font-family: sans-serif;
-          }
-        EXPECTED
-        expect(fs.read("app/assets/css/app.css")).to eq(app_css)
-        expect(output).to include("Created app/assets/css/app.css")
-
-        # app/assets/images/favicon.ico
-        expect(fs.exist?("app/assets/images/favicon.ico")).to be(true)
-
-        # lib/bookshelf/types.rb
-        types = <<~EXPECTED
-          # frozen_string_literal: true
-
-          require "dry/types"
-
-          module #{inflector.camelize(app)}
-            Types = Dry.Types
-
-            module Types
-              # Define your custom types here
-            end
-          end
-        EXPECTED
-        expect(fs.read("lib/#{app}/types.rb")).to eq(types)
-        expect(output).to include("Created lib/bookshelf/types.rb")
-
-        # public/ error pages
-        expect(fs.read("public/404.html")).to include %(<title>The page you were looking for doesn’t exist (404)</title>)
-        expect(fs.read("public/500.html")).to include %(<title>We’re sorry, but something went wrong (500)</title>)
+        expect(fs.exist?("app/db/relation.rb")).to be(false)
+        expect(fs.exist?("config/db/")).to be(false)
       end
     end
   end
@@ -1055,6 +786,15 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read("Gemfile")).to include("pg")
         end
       end
+
+      it "generates app for --database=pg" do
+        subject.call(app: app, database: "pg")
+
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to include("hanami-db")
+          expect(fs.read("Gemfile")).to include("pg")
+        end
+      end
     end
 
     describe "mysql database" do
@@ -1073,15 +813,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
-        end
-      end
-
-      it "generates app for --database=pg" do
-        subject.call(app: app, database: "pg")
-
-        fs.chdir(app) do
-          expect(fs.read("Gemfile")).to include("hanami-db")
-          expect(fs.read("Gemfile")).to include("pg")
         end
       end
     end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -530,6 +530,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.read("app/db/struct.rb")).to eq(struct)
         expect(output).to include("Created app/db/struct.rb")
 
+        expect(fs.read("app/structs/.keep")).to eq("")
+        expect(fs.read("app/repos/.keep")).to eq("")
+
         # lib/bookshelf/types.rb
         types = <<~EXPECTED
           # frozen_string_literal: true
@@ -768,6 +771,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.exist?("app/repo.rb")).to be(false)
         expect(fs.exist?("app/db/relation.rb")).to be(false)
         expect(fs.exist?("app/db/struct.rb")).to be(false)
+        expect(fs.directory?("app/structs")).to be(false)
+        expect(fs.directory?("app/repos")).to be(false)
 
         # app/views/helpers.rb
         helpers = <<~RUBY


### PR DESCRIPTION
Resolves #147.

A couple things.
1. I didn't add any `DATABASE_URL` to `.env` yet. I like the pattern of putting those into `.env.development` and `.env.test`. I know there was some discussion about an automatic translation from a development DATABASE_URL to a test one but not sure where we landed on that. When deploying to production, it's a feature that it won't deploy without DATABASE_URL set on the production server, so the development one isn't used accidentally.
2. I added some constants without `private_constant` so I can re-use them. I don't really like where they are now, any ideas of a better place to put them?
3. I removed passing along the rest of the kwargs to the context, due to some syntax errors on 3.0 and 3.1 since I broke up the method calls (I think). Not sure if this is a problem for extensibility?
4. I have the base repo inherit from `Hanami::DB::Repo` and added a FIXME for [when rename that to `Hanami::Repo`](https://discourse.hanamirb.org/t/integrating-rom-into-hanami-2-2/971)
5. Do we want to [add ROM transaction support in our base Operation](https://github.com/hanami/cli/pull/171#issuecomment-2181575260)? I think so.
