### PR TITLE
[Fix] Console default engine

### DIFF
--- a/lib/hanami/cli/commands/app/console.rb
+++ b/lib/hanami/cli/commands/app/console.rb
@@ -51,11 +51,7 @@ module Hanami
           private
 
           def resolve_engine(engine, opts)
-            if engine
-              ENGINES.fetch(engine).(app, opts)
-            else
-              ENGINES.map { |(_, loader)| loader.(app, opts) }.compact.first
-            end
+            ENGINES.fetch(engine, ENGINES[DEFAULT_ENGINE]).call(app, opts)
           end
         end
       end


### PR DESCRIPTION
The existing code would fallback to "pry" as it is the first element of the ENGINES constant. This commit makes it fallback to the engined described on the DEFAULT_ENGINE variable

PS: I also noticed that the "reload" method doesn't consider the `--engine=something`, [here](https://github.com/hanami/cli/blob/07b8c55790d8f5e8d21bdce8caba02f418cae768/lib/hanami/console/context.rb#L39)

but I'm not sure how to fix this one