### PR TITLE
Add .keep file for app/relations, reorder expectations

### DIFF
--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -69,11 +69,11 @@ module Hanami
             end
 
             if context.generate_db?
-              fs.write("app/db/repo.rb", t("repo.erb", context))
-              fs.write("app/repos/.keep", t("keep.erb", context))
-
               fs.write("app/db/relation.rb", t("relation.erb", context))
               fs.write("app/relations/.keep", t("keep.erb", context))
+
+              fs.write("app/db/repo.rb", t("repo.erb", context))
+              fs.write("app/repos/.keep", t("keep.erb", context))
 
               fs.write("app/db/struct.rb", t("struct.erb", context))
               fs.write("app/structs/.keep", t("keep.erb", context))

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -70,11 +70,15 @@ module Hanami
 
             if context.generate_db?
               fs.write("app/db/repo.rb", t("repo.erb", context))
+              fs.write("app/repos/.keep", t("keep.erb", context))
+
               fs.write("app/db/relation.rb", t("relation.erb", context))
+              fs.write("app/relations/.keep", t("keep.erb", context))
+
               fs.write("app/db/struct.rb", t("struct.erb", context))
-              fs.touch("app/structs/.keep")
-              fs.touch("app/repos/.keep")
-              fs.touch("config/db/migrate/.keep")
+              fs.write("app/structs/.keep", t("keep.erb", context))
+
+              fs.write("config/db/migrate/.keep" , t("keep.erb", context))
             end
 
             fs.write("app/operation.rb", t("operation.erb", context))

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -79,7 +79,10 @@ module Hanami
               fs.write("app/structs/.keep", t("keep.erb", context))
 
               fs.write("config/db/migrate/.keep" , t("keep.erb", context))
-              fs.write("db/.keep" , t("keep.erb", context))
+
+              if context.generate_sqlite?
+                fs.write("db/.keep" , t("keep.erb", context))
+              end
             end
 
             fs.write("app/operation.rb", t("operation.erb", context))

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -79,6 +79,7 @@ module Hanami
               fs.write("app/structs/.keep", t("keep.erb", context))
 
               fs.write("config/db/migrate/.keep" , t("keep.erb", context))
+              fs.write("db/.keep" , t("keep.erb", context))
             end
 
             fs.write("app/operation.rb", t("operation.erb", context))

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -822,7 +822,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.read("app/actions/.keep")).to eq("")
         expect(output).to include("Created app/actions/.keep")
 
-        # app/repo.rb
+        # app/db/repo.rb
         repo = <<~EXPECTED
           # frozen_string_literal: true
 

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -819,6 +819,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("app/action.rb")).to eq(action)
         expect(output).to include("Created app/action.rb")
+        expect(fs.read("app/actions/.keep")).to eq("")
+        expect(output).to include("Created app/actions/.keep")
 
         # app/repo.rb
         repo = <<~EXPECTED
@@ -835,6 +837,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("app/db/repo.rb")).to eq(repo)
         expect(output).to include("Created app/db/repo.rb")
+        expect(fs.read("app/repos/.keep")).to eq("")
+        expect(output).to include("Created app/repos/.keep")
 
         # app/view.rb
         view = <<~RUBY
@@ -923,6 +927,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("app/db/relation.rb")).to eq(relation)
         expect(output).to include("Created app/db/relation.rb")
+        expect(fs.read("app/relations/.keep")).to eq("")
+        expect(output).to include("Created app/relations/.keep")
 
         # app/db/struct.rb
         struct = <<~EXPECTED
@@ -941,7 +947,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(output).to include("Created app/db/struct.rb")
 
         expect(fs.read("app/structs/.keep")).to eq("")
-        expect(fs.read("app/repos/.keep")).to eq("")
         expect(fs.read("config/db/migrate/.keep")).to eq("")
 
         # lib/bookshelf/types.rb

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -822,24 +822,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.read("app/actions/.keep")).to eq("")
         expect(output).to include("Created app/actions/.keep")
 
-        # app/db/repo.rb
-        repo = <<~EXPECTED
-          # frozen_string_literal: true
-
-          require "hanami/db/repo"
-
-          module #{inflector.camelize(app)}
-            module DB
-              class Repo < Hanami::DB::Repo
-              end
-            end
-          end
-        EXPECTED
-        expect(fs.read("app/db/repo.rb")).to eq(repo)
-        expect(output).to include("Created app/db/repo.rb")
-        expect(fs.read("app/repos/.keep")).to eq("")
-        expect(output).to include("Created app/repos/.keep")
-
         # app/view.rb
         view = <<~RUBY
           # auto_register: false
@@ -929,6 +911,24 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(output).to include("Created app/db/relation.rb")
         expect(fs.read("app/relations/.keep")).to eq("")
         expect(output).to include("Created app/relations/.keep")
+
+        # app/db/repo.rb
+        repo = <<~EXPECTED
+          # frozen_string_literal: true
+
+          require "hanami/db/repo"
+
+          module #{inflector.camelize(app)}
+            module DB
+              class Repo < Hanami::DB::Repo
+              end
+            end
+          end
+        EXPECTED
+        expect(fs.read("app/db/repo.rb")).to eq(repo)
+        expect(output).to include("Created app/db/repo.rb")
+        expect(fs.read("app/repos/.keep")).to eq("")
+        expect(output).to include("Created app/repos/.keep")
 
         # app/db/struct.rb
         struct = <<~EXPECTED

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -945,9 +945,14 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         EXPECTED
         expect(fs.read("app/db/struct.rb")).to eq(struct)
         expect(output).to include("Created app/db/struct.rb")
-
         expect(fs.read("app/structs/.keep")).to eq("")
+        expect(output).to include("Created app/structs/.keep")
+
+        expect(fs.read("db/.keep")).to eq("")
+        expect(output).to include("Created db/.keep")
+
         expect(fs.read("config/db/migrate/.keep")).to eq("")
+        expect(output).to include("Created config/db/migrate/.keep")
 
         # lib/bookshelf/types.rb
         types = <<~EXPECTED


### PR DESCRIPTION
Clean up for #180. I realized I missed adding `app/relations/.keep`, so this does that. 

I also:
- moved around some expectations so they're grouped logically with their base class
- added a missing expectation for `app/actions/.keep`
- changed how `app/repos/.keep` and `app/structs/.keep` are generated so their creation message is printed

Fixes #190, fixes #191 