### PR TITLE
Move constants used in generators

### DIFF
--- a/lib/hanami/cli/generators/app/action_context.rb
+++ b/lib/hanami/cli/generators/app/action_context.rb
@@ -2,6 +2,7 @@
 
 require_relative "slice_context"
 require "dry/files/path"
+require_relative "../constants"
 
 module Hanami
   module CLI
@@ -52,7 +53,7 @@ module Hanami
           # @api private
           def module_controller_declaration
             controller.each_with_index.map do |token, i|
-              "#{OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
+              "#{NESTED_OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
             end.join($/)
           end
 
@@ -60,14 +61,14 @@ module Hanami
           # @api private
           def module_controller_end
             controller.each_with_index.map do |_, i|
-              "#{OFFSET}#{INDENTATION * i}end"
+              "#{NESTED_OFFSET}#{INDENTATION * i}end"
             end.reverse.join($/)
           end
 
           # @since 2.0.0
           # @api private
           def module_controller_offset
-            "#{OFFSET}#{INDENTATION * controller.count}"
+            "#{NESTED_OFFSET}#{INDENTATION * controller.count}"
           end
 
           # @since 2.0.0
@@ -78,15 +79,6 @@ module Hanami
           end
 
           private
-
-          NAMESPACE_SEPARATOR = "::"
-          private_constant :NAMESPACE_SEPARATOR
-
-          INDENTATION = "  "
-          private_constant :INDENTATION
-
-          OFFSET = INDENTATION * 2
-          private_constant :OFFSET
 
           attr_reader :controller
 

--- a/lib/hanami/cli/generators/app/action_context.rb
+++ b/lib/hanami/cli/generators/app/action_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "slice_context"
 require "dry/files/path"
+require_relative "slice_context"
 require_relative "../constants"
 
 module Hanami

--- a/lib/hanami/cli/generators/app/component_context.rb
+++ b/lib/hanami/cli/generators/app/component_context.rb
@@ -1,23 +1,11 @@
 # frozen_string_literal: true
+require_relative "../constants"
 
 module Hanami
   module CLI
     module Generators
       module App
         class ComponentContext < SliceContext
-          # Taken from lib/hanami/cli/generators/app/view_context.rb which mentions they should be moved somewhere. Not sure where yet.
-          MATCHER_PATTERN = /::|\./
-          private_constant :MATCHER_PATTERN
-
-          NAMESPACE_SEPARATOR = "::"
-          private_constant :NAMESPACE_SEPARATOR
-
-          INDENTATION = "  "
-          private_constant :INDENTATION
-
-          OFFSET = 1
-          private_constant :OFFSET
-
           # @api private
           # @since 2.2.0
           attr_reader :key
@@ -68,23 +56,23 @@ module Hanami
           # @api private
           # @since 2.2.0
           def module_namespace_declaration
-            namespaces.each.with_index(OFFSET).map { |token, i|
-              "#{INDENTATION * i}module #{inflector.camelize(token)}"
+            namespaces.each_with_index.map { |token, i|
+              "#{OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
             }.join($/)
           end
 
           # @api private
           # @since 2.2.0
           def module_namespace_end
-            namespaces.each.with_index(OFFSET).map { |_, i|
-              "#{INDENTATION * i}end"
+            namespaces.each_with_index.map { |_, i|
+              "#{OFFSET}#{INDENTATION * i}end"
             }.reverse.join($/)
           end
 
           # @api private
           # @since 2.2.0
           def module_namespace_offset
-            (INDENTATION * (namespaces.count + OFFSET)).to_s
+            "#{OFFSET}#{INDENTATION * namespaces.count}"
           end
         end
       end

--- a/lib/hanami/cli/generators/app/component_context.rb
+++ b/lib/hanami/cli/generators/app/component_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative "../constants"
 
 module Hanami

--- a/lib/hanami/cli/generators/app/operation_context.rb
+++ b/lib/hanami/cli/generators/app/operation_context.rb
@@ -2,6 +2,7 @@
 
 require_relative "slice_context"
 require "dry/files/path"
+require_relative "../constants"
 
 module Hanami
   module CLI
@@ -12,19 +13,6 @@ module Hanami
         # @since 2.2.0
         # @api private
         class OperationContext < SliceContext
-          # TODO: move these constants somewhere that will let us reuse them
-          KEY_SEPARATOR = %r{\.|/}
-          private_constant :KEY_SEPARATOR
-
-          NAMESPACE_SEPARATOR = "::"
-          private_constant :NAMESPACE_SEPARATOR
-
-          INDENTATION = "  "
-          private_constant :INDENTATION
-
-          OFFSET = INDENTATION
-          private_constant :OFFSET
-
           # @since 2.2.0
           # @api private
           attr_reader :key

--- a/lib/hanami/cli/generators/app/operation_context.rb
+++ b/lib/hanami/cli/generators/app/operation_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "slice_context"
 require "dry/files/path"
+require_relative "slice_context"
 require_relative "../constants"
 
 module Hanami

--- a/lib/hanami/cli/generators/app/part_context.rb
+++ b/lib/hanami/cli/generators/app/part_context.rb
@@ -2,6 +2,7 @@
 
 require_relative "slice_context"
 require "dry/files/path"
+require_relative "../constants"
 
 module Hanami
   module CLI
@@ -12,23 +13,6 @@ module Hanami
         # @since 2.1.0
         # @api private
         class PartContext < SliceContext
-          # TODO: move these constants somewhere that will let us reuse them
-
-          # @since 2.1.0
-          # @api private
-          KEY_SEPARATOR = "."
-          private_constant :KEY_SEPARATOR
-
-          # @since 2.1.0
-          # @api private
-          INDENTATION = "  "
-          private_constant :INDENTATION
-
-          # @since 2.1.0
-          # @api private
-          OFFSET = INDENTATION * 2
-          private_constant :OFFSET
-
           # @since 2.1.0
           # @api private
           attr_reader :key
@@ -74,7 +58,7 @@ module Hanami
           # @api private
           def module_namespace_declaration
             namespaces.each_with_index.map { |token, i|
-              "#{OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
+              "#{NESTED_OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
             }.join($/)
           end
 
@@ -82,14 +66,14 @@ module Hanami
           # @api private
           def module_namespace_end
             namespaces.each_with_index.map { |_, i|
-              "#{OFFSET}#{INDENTATION * i}end"
+              "#{NESTED_OFFSET}#{INDENTATION * i}end"
             }.reverse.join($/)
           end
 
           # @since 2.1.0
           # @api private
           def module_namespace_offset
-            "#{OFFSET}#{INDENTATION * namespaces.count}"
+            "#{NESTED_OFFSET}#{INDENTATION * namespaces.count}"
           end
         end
       end

--- a/lib/hanami/cli/generators/app/part_context.rb
+++ b/lib/hanami/cli/generators/app/part_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "slice_context"
 require "dry/files/path"
+require_relative "slice_context"
 require_relative "../constants"
 
 module Hanami

--- a/lib/hanami/cli/generators/app/slice_context.rb
+++ b/lib/hanami/cli/generators/app/slice_context.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../context"
+require_relative "../constants"
 
 module Hanami
   module CLI

--- a/lib/hanami/cli/generators/app/view_context.rb
+++ b/lib/hanami/cli/generators/app/view_context.rb
@@ -2,6 +2,7 @@
 
 require_relative "slice_context"
 require "dry/files/path"
+require_relative "../constants"
 
 module Hanami
   module CLI
@@ -12,19 +13,6 @@ module Hanami
         # @since 2.1.0
         # @api private
         class ViewContext < SliceContext
-          # TODO: move these constants somewhere that will let us reuse them
-          KEY_SEPARATOR = "."
-          private_constant :KEY_SEPARATOR
-
-          NAMESPACE_SEPARATOR = "::"
-          private_constant :NAMESPACE_SEPARATOR
-
-          INDENTATION = "  "
-          private_constant :INDENTATION
-
-          OFFSET = INDENTATION * 2
-          private_constant :OFFSET
-
           # @since 2.1.0
           # @api private
           attr_reader :key
@@ -76,7 +64,7 @@ module Hanami
           # @api private
           def module_namespace_declaration
             namespaces.each_with_index.map { |token, i|
-              "#{OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
+              "#{NESTED_OFFSET}#{INDENTATION * i}module #{inflector.camelize(token)}"
             }.join($/)
           end
 
@@ -84,14 +72,14 @@ module Hanami
           # @api private
           def module_namespace_end
             namespaces.each_with_index.map { |_, i|
-              "#{OFFSET}#{INDENTATION * i}end"
+              "#{NESTED_OFFSET}#{INDENTATION * i}end"
             }.reverse.join($/)
           end
 
           # @since 2.1.0
           # @api private
           def module_namespace_offset
-            "#{OFFSET}#{INDENTATION * namespaces.count}"
+            "#{NESTED_OFFSET}#{INDENTATION * namespaces.count}"
           end
         end
       end

--- a/lib/hanami/cli/generators/constants.rb
+++ b/lib/hanami/cli/generators/constants.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    # @since 2.2.0
+    # @api private
+    module Generators
+
+      # @since 2.2.0
+      # @api private
+      INDENTATION = "  "
+      private_constant :INDENTATION
+
+      # @since 2.2.0
+      # @api private
+      OFFSET = INDENTATION
+      private_constant :OFFSET
+
+      # @since 2.2.0
+      # @api private
+      NESTED_OFFSET = INDENTATION * 2
+      private_constant :OFFSET
+
+      # @since 2.2.0
+      # @api private
+      KEY_SEPARATOR = %r{[.\/]}
+      private_constant :KEY_SEPARATOR
+
+      # @since 2.2.0
+      # @api private
+      MATCHER_PATTERN = /::|\./
+      private_constant :MATCHER_PATTERN
+
+      # @since 2.2.0
+      # @api private
+      NAMESPACE_SEPARATOR = "::"
+      private_constant :NAMESPACE_SEPARATOR
+    end
+  end
+end

--- a/lib/hanami/cli/generators/constants.rb
+++ b/lib/hanami/cli/generators/constants.rb
@@ -5,7 +5,6 @@ module Hanami
     # @since 2.2.0
     # @api private
     module Generators
-
       # @since 2.2.0
       # @api private
       INDENTATION = "  "


### PR DESCRIPTION
Based on https://github.com/hanami/cli/pull/130#discussion_r1627648954 I moved the constants commonly used in all generators to a common place. This also required a simple change to one of the context classes, as it was using OFFSET that was an integer, instead of the one that is an alias to INDENTATION and work better with multiplication in the code that generates the spacing in end files.