### PR TITLE
Use dry-cli's :flag type instead of :boolean

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 
 gem "dry-files", github: "dry-rb/dry-files", branch: "main"
+gem "dry-cli", github: "dry-rb/dry-cli", branch: "main"
 
 gem "rack"
 

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -14,7 +14,7 @@ module Hanami
           # @since 2.2.0
           # @api private
           class Command < App::Command
-            option :app, required: false, type: :boolean, default: false, desc: "Use app database"
+            option :app, required: false, type: :flag, default: false, desc: "Use app database"
             option :slice, required: false, desc: "Use database for slice"
 
             attr_reader :system_call

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -10,8 +10,8 @@ module Hanami
             desc "Migrates database"
 
             option :target, desc: "Target migration number", aliases: ["-t"]
-            option :dump, required: false, type: :flag, default: true,
-              desc: "Dump the database structure after migrating"
+            option :dump, required: false, type: :boolean, default: true,
+                          desc: "Dump the database structure after migrating"
 
             def call(target: nil, app: false, slice: nil, dump: true, command_exit: method(:exit), **)
               databases(app: app, slice: slice).each do |database|

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -10,7 +10,7 @@ module Hanami
             desc "Migrates database"
 
             option :target, desc: "Target migration number", aliases: ["-t"]
-            option :dump, required: false, type: :boolean, default: true,
+            option :dump, required: false, type: :flag, default: true,
               desc: "Dump the database structure after migrating"
 
             def call(target: nil, app: false, slice: nil, dump: true, command_exit: method(:exit), **)

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -32,13 +32,13 @@ module Hanami
             option \
               :skip_view,
               required: false,
-              type: :boolean,
+              type: :flag,
               default: DEFAULT_SKIP_VIEW,
               desc: "Skip view and template generation"
             option \
               :skip_tests,
               required: false,
-              type: :boolean,
+              type: :flag,
               default: DEFAULT_SKIP_TESTS,
               desc: "Skip test generation"
             option :slice, required: false, desc: "Slice name"

--- a/lib/hanami/cli/commands/app/generate/part.rb
+++ b/lib/hanami/cli/commands/app/generate/part.rb
@@ -20,7 +20,7 @@ module Hanami
             option \
               :skip_tests,
               required: false,
-              type: :boolean,
+              type: :flag,
               default: DEFAULT_SKIP_TESTS,
               desc: "Skip test generation"
 

--- a/lib/hanami/cli/commands/app/install.rb
+++ b/lib/hanami/cli/commands/app/install.rb
@@ -31,7 +31,7 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          option :head, type: :boolean, desc: "Install head deps", default: DEFAULT_HEAD
+          option :head, type: :flag, desc: "Install head deps", default: DEFAULT_HEAD
 
           # @since 2.0.0
           # @api private

--- a/lib/hanami/cli/commands/app/middleware.rb
+++ b/lib/hanami/cli/commands/app/middleware.rb
@@ -34,7 +34,7 @@ module Hanami
           private_constant :DEFAULT_WITH_ARGUMENTS
 
           option :with_arguments, default: DEFAULT_WITH_ARGUMENTS, required: false,
-                                  desc: "Include inspected arguments", type: :boolean
+                                  desc: "Include inspected arguments", type: :flag
 
           example [
             "middleware                  # Print app Rack middleware stack",

--- a/lib/hanami/cli/commands/app/server.rb
+++ b/lib/hanami/cli/commands/app/server.rb
@@ -41,8 +41,8 @@ module Hanami
           option :port, default: Hanami::Port::DEFAULT, required: false,
                         desc: "The port to run the server on (falls back to the rack handler)"
           option :config, default: DEFAULT_CONFIG_PATH, required: false, desc: "Rack configuration file"
-          option :debug, default: false, required: false, desc: "Turn on/off debug output", type: :boolean
-          option :warn, default: false, required: false, desc: "Turn on/off warnings", type: :boolean
+          option :debug, default: false, required: false, desc: "Turn on/off debug output", type: :flag
+          option :warn, default: false, required: false, desc: "Turn on/off warnings", type: :flag
 
           # @since 2.0.0
           # @api private

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -54,25 +54,25 @@ module Hanami
 
           # @since 2.0.0
           # @api private
-          option :skip_install, type: :boolean, required: false,
+          option :skip_install, type: :flag, required: false,
                                 default: SKIP_INSTALL_DEFAULT,
                                 desc: "Skip app installation (Bundler, third-party Hanami plugins)"
 
           # @since 2.1.0
           # @api private
-          option :head, type: :boolean, required: false,
+          option :head, type: :flag, required: false,
                         default: HEAD_DEFAULT,
                         desc: "Use Hanami HEAD version (from GitHub `main` branches)"
 
           # @since 2.1.0
           # @api private
-          option :skip_assets, type: :boolean, required: false,
+          option :skip_assets, type: :flag, required: false,
                                default: SKIP_ASSETS_DEFAULT,
                                desc: "Skip including hanami-assets"
 
           # @since 2.2.0
           # @api private
-          option :skip_db, type: :boolean, required: false,
+          option :skip_db, type: :flag, required: false,
                            default: SKIP_DB_DEFAULT,
                            desc: "Skip including hanami-db"
 


### PR DESCRIPTION
I saw a bunch of `--[no]-skip-view` etc, which doesn't make sense. I realized it's because we're using `type: :boolean` instead of `type: :flag`.

I went though each one and I think they can all be converted to flags without losing anything, so that's what I did here.

This **does not currently work** so should not be merged, but it should work once https://github.com/dry-rb/dry-cli/pull/117 is brought up-to-date and merged. I'll handle fixing that up tomorrow, and change this PR to a non-draft once that's merged.