### PR TITLE
Change component generator examples to domain-specific ones

### DIFF
--- a/lib/hanami/cli/commands/app/generate/component.rb
+++ b/lib/hanami/cli/commands/app/generate/component.rb
@@ -15,10 +15,10 @@ module Hanami
             option :slice, required: false, desc: "Slice name"
 
             example [
-              %(services.create_user               (MyApp::Services::CreateUser)),
-              %(services.user.create               (MyApp::Services::Create::User)),
-              %(services.create_user --slice=admin (Admin::Services::CreateUser)),
-              %(Services::CreateUser               (MyApp::Services::CreateUser)),
+              %(isbn_decoder               (MyApp::IsbnDecoder)),
+              %(recommenders.fiction       (MyApp::Recommenders::Fiction)),
+              %(isbn_decoder --slice=admin (Admin::IsbnDecoder)),
+              %(Exporters::Complete::CSV   (MyApp::Exporters::Complete::CSV)),
             ]
             attr_reader :generator
             private :generator

--- a/lib/hanami/cli/commands/app/generate/component.rb
+++ b/lib/hanami/cli/commands/app/generate/component.rb
@@ -15,10 +15,10 @@ module Hanami
             option :slice, required: false, desc: "Slice name"
 
             example [
-              %(operations.create_user               (MyApp::Operations::CreateUser)),
-              %(operations.user.create               (MyApp::Operations::Create::User)),
-              %(operations.create_user --slice=admin (Admin::Operations::CreateUser)),
-              %(Operations::CreateUser               (MyApp::Operations::CreateUser)),
+              %(services.create_user               (MyApp::Services::CreateUser)),
+              %(services.user.create               (MyApp::Services::Create::User)),
+              %(services.create_user --slice=admin (Admin::Services::CreateUser)),
+              %(Services::CreateUser               (MyApp::Services::CreateUser)),
             ]
             attr_reader :generator
             private :generator

--- a/lib/hanami/cli/commands/app/generate/component.rb
+++ b/lib/hanami/cli/commands/app/generate/component.rb
@@ -17,7 +17,7 @@ module Hanami
             example [
               %(operations.create_user               (MyApp::Operations::CreateUser)),
               %(operations.user.create               (MyApp::Operations::Create::User)),
-              %(operations.create_user               --slice=admin (Admin::Operations::CreateUser)),
+              %(operations.create_user --slice=admin (Admin::Operations::CreateUser)),
               %(Operations::CreateUser               (MyApp::Operations::CreateUser)),
             ]
             attr_reader :generator

--- a/lib/hanami/cli/generators/app/component.rb
+++ b/lib/hanami/cli/generators/app/component.rb
@@ -2,6 +2,7 @@
 
 require "erb"
 require "dry/files"
+
 module Hanami
   module CLI
     module Generators


### PR DESCRIPTION
The component generator was created before the operation generator. It's potentially confusing to generate a component called "operation", since we have an operation generator.

~I don't think services is a terrific alternative (since it's often used in the same way as operation) so please let me know if anyone has any better ideas. Just wanted to open this so I don't forget~
I brainstormed some domain-specific components someone could want for a bookshelf app. Open to other suggestions (in particular ISBN should be an acronym, but it's not in the default inflector, so I think it's find to render it as `Isbn`, but it's not ideal)