### PR TITLE
Add `generate migration` command and generator

### DIFF
--- a/lib/hanami/cli/commands/app/generate/migration.rb
+++ b/lib/hanami/cli/commands/app/generate/migration.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Generate
+          # @since 2.2.0
+          # @api private
+          class Migration < App::Command
+            argument :name, required: true, desc: "Migration name"
+            option :slice, required: false, desc: "Slice name"
+
+            example [
+              %(create_posts),
+              %(add_published_at_to_posts),
+              %(create_users --slice=admin),
+            ]
+
+            attr_reader :generator
+            private :generator
+
+            # @since 2.2.0
+            # @api private
+            def initialize(
+              fs:, inflector:,
+              generator: Generators::App::Migration.new(fs: fs, inflector: inflector),
+              **opts
+            )
+              super(fs: fs, inflector: inflector, **opts)
+              @generator = generator
+            end
+
+            # @since 2.2.0
+            # @api private
+            def call(name:, slice: nil, **)
+              generator.call(name, slice)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -107,5 +107,17 @@ module Hanami
         super("`#{option1}' and `#{option2}' cannot be used together")
       end
     end
+
+    # @since 2.2.0
+    # @api public
+    class InvalidMigrationNameError < Error
+      def initialize(name)
+        super(<<~TEXT)
+          Invalid migration name: #{name}
+
+          Name must contain only letters, numbers, and underscores.
+        TEXT
+      end
+    end
   end
 end

--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    module Generators
+      module App
+        # @since 2.2.0
+        # @api private
+        class Migration
+          # @since 2.2.0
+          # @api private
+          def initialize(fs:, inflector:, out: $stdout)
+            @fs = fs
+            @inflector = inflector
+            @out = out
+          end
+
+          # @since 2.2.0
+          # @api private
+          def call(name, slice)
+            ensure_valid_name name
+
+            name = inflector.underscore(name)
+            slice = inflector.underscore(slice) if slice
+
+            if slice
+              generate_for_slice(name, slice)
+            else
+              generate_for_app(name)
+            end
+          end
+
+          private
+
+          attr_reader :fs, :inflector, :out
+
+          VALID_NAME_REGEX = /^[_a-z0-9]+$/
+          private_constant :VALID_NAME_REGEX
+
+          def ensure_valid_name(name)
+            unless VALID_NAME_REGEX.match?(name.downcase)
+              raise InvalidMigrationNameError.new(name)
+            end
+          end
+
+          def generate_for_slice(name, slice)
+            slice_dir = fs.join("slices", slice)
+            raise MissingSliceError.new(slice) unless fs.directory?(slice_dir)
+
+            migrate_dir = fs.join(slice_dir, "config", "db", "migrate")
+            fs.mkdir_p migrate_dir
+
+            fs.write fs.join(migrate_dir, file_name(name)), FILE_CONTENTS
+          end
+
+          def generate_for_app(name)
+            migrate_dir = fs.join("config", "db", "migrate")
+            fs.mkdir_p migrate_dir
+
+            fs.write fs.join(migrate_dir, file_name(name)), FILE_CONTENTS
+          end
+
+          def file_name(name)
+            "#{Time.now.strftime(VERSION_FORMAT)}_#{name}.rb"
+          end
+
+          VERSION_FORMAT = "%Y%m%d%H%M%S"
+          private_constant :VERSION_FORMAT
+
+          FILE_CONTENTS = <<~RUBY
+            # frozen_string_literal: true
+
+            ROM::SQL.migration do
+              # Add your migration here.
+              #
+              # See https://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html for details.
+            end
+          RUBY
+          private_constant :FILE_CONTENTS
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "hanami"
+
+RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
+  subject { described_class.new(fs: fs) }
+
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+
+  let(:out) { StringIO.new }
+  def output; out.string; end
+
+  let(:app) { Hanami.app.namespace }
+
+  let(:migration_file_contents) {
+    <<~RUBY
+      # frozen_string_literal: true
+
+      ROM::SQL.migration do
+        # Add your migration here.
+        #
+        # See https://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html for details.
+      end
+    RUBY
+  }
+
+  before do
+    allow(Time).to receive(:now) { Time.new(2024, 07, 13, 14, 06, 00) }
+  end
+
+  context "generating for app" do
+    it "generates a migration" do
+      subject.call(name: "create_posts")
+
+      expect(fs.read("config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
+      expect(output.strip).to eq "Created config/db/migrate/20240713140600_create_posts.rb"
+    end
+
+    it "generates a migration with underscored version of camel cased name" do
+      subject.call(name: "CreatePosts")
+
+      expect(fs.read("config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
+      expect(output.strip).to eq "Created config/db/migrate/20240713140600_create_posts.rb"
+    end
+
+    it "raises an error if given an invalid name" do
+      expect {
+        subject.call(name: "create posts")
+      }.to raise_error(include_in_order(
+        "Invalid migration name: create posts",
+        "Name must contain only letters, numbers, and underscores."
+      ))
+    end
+  end
+
+  context "generating for a slice" do
+    it "generates a migration" do
+      fs.mkdir("slices/main")
+      out.truncate 0
+
+      subject.call(name: "create_posts", slice: "main")
+
+      expect(fs.read("slices/main/config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
+      expect(output.strip).to eq "Created slices/main/config/db/migrate/20240713140600_create_posts.rb"
+    end
+  end
+end


### PR DESCRIPTION
Resolves #179 

As I was building this, I realised we have quite a bit of double handling across our `generate <foo>` CLI commands and the actual generators they call. To help centralise the logic in this case, I moved the generator-specific validation checks into the generator itself.

This keeps the command class much thinner and mostly just responsible for "writing".

We could consider refactoring our other commands/generators like this in the future, but it's not urgent.