### PR TITLE
Generate relation

### DIFF
--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -45,6 +45,7 @@ module Hanami
               prefix.register "component", Generate::Component
               prefix.register "operation", Generate::Operation
               prefix.register "part", Generate::Part
+              prefix.register "relation", Generate::Relation
               prefix.register "repo", Generate::Repo
               prefix.register "slice", Generate::Slice
               prefix.register "struct", Generate::Struct

--- a/lib/hanami/cli/commands/app/generate/relation.rb
+++ b/lib/hanami/cli/commands/app/generate/relation.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Generate
+          # @since 2.2.0
+          # @api private
+          class Relation < Command
+            argument :name, required: true, desc: "Relation name"
+            option :slice, required: false, desc: "Slice name"
+
+            example [
+              %(books               (MyApp::Relation::Book)),
+              %(books/drafts        (MyApp::Relations::Books::Drafts)),
+              %(books --slice=admin (Admin::Relations::Books)),
+            ]
+
+            # @since 2.2.0
+            # @api private
+            def generator_class
+              Generators::App::Relation
+            end
+
+            # @since 2.2.0
+            # @api private
+            def call(name:, slice: nil, **opts)
+              normalized_name = if name.end_with?("_relation")
+                                  name
+                                else
+                                  inflector.pluralize(name)
+                                end
+
+              super(name: normalized_name, slice: slice, **opts)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/operation.rb
+++ b/lib/hanami/cli/generators/app/operation.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "erb"
-require "dry/files"
 require_relative "../constants"
-require_relative "../../errors"
 
 module Hanami
   module CLI

--- a/lib/hanami/cli/generators/app/relation.rb
+++ b/lib/hanami/cli/generators/app/relation.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "erb"
+require "dry/files"
+require_relative "../constants"
+require_relative "../../errors"
+
+module Hanami
+  module CLI
+    module Generators
+      module App
+        # @since 2.2.0
+        # @api private
+        class Relation
+          # @since 2.2.0
+          # @api private
+          def initialize(fs:, inflector:, out: $stdout)
+            @fs = fs
+            @inflector = inflector
+            @out = out
+          end
+
+          # @since 2.2.0
+          # @api private
+          def call(app_namespace, key, slice)
+            RubyFileWriter.new(
+              fs: fs,
+              inflector: inflector,
+              app_namespace: app_namespace,
+              key: key,
+              slice: slice,
+              extra_namespace: "Relations",
+              relative_parent_class: "DB::Relation",
+              body: [],
+            ).call
+          end
+
+          private
+
+          attr_reader :fs, :inflector, :out
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/relation.rb
+++ b/lib/hanami/cli/generators/app/relation.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "erb"
-require "dry/files"
-require_relative "../constants"
-require_relative "../../errors"
-
 module Hanami
   module CLI
     module Generators

--- a/lib/hanami/cli/generators/app/repo.rb
+++ b/lib/hanami/cli/generators/app/repo.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "erb"
-require "dry/files"
-require_relative "../constants"
-require_relative "../../errors"
-
 module Hanami
   module CLI
     module Generators

--- a/lib/hanami/cli/generators/app/struct.rb
+++ b/lib/hanami/cli/generators/app/struct.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "erb"
-require "dry/files"
-require_relative "../constants"
-require_relative "../../errors"
-
 module Hanami
   module CLI
     module Generators

--- a/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, :app do
+  subject { described_class.new(fs: fs, inflector: inflector, out: out) }
+
+  let(:out) { StringIO.new }
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+  let(:inflector) { Dry::Inflector.new }
+  let(:app) { Hanami.app.namespace }
+  let(:dir) { inflector.underscore(app) }
+
+  def output
+    out.rewind && out.read.chomp
+  end
+
+  context "generating for app" do
+    describe "without namespace" do
+      it "generates a relation and pluralizes name properly" do
+        subject.call(name: "book")
+
+        relation_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Relations
+              class Books < Test::DB::Relation
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/relations/books.rb")).to eq(relation_file)
+        expect(output).to include("Created app/relations/books.rb")
+      end
+
+      it "generates a relation and doesn't pluralize if they want to add a _relation suffix" do
+        subject.call(name: "book_relation")
+
+        relation_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Relations
+              class BookRelation < Test::DB::Relation
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/relations/book_relation.rb")).to eq(relation_file)
+        expect(output).to include("Created app/relations/book_relation.rb")
+      end
+    end
+
+    it "generates a relation in a namespace with default separator" do
+      subject.call(name: "books.drafts")
+
+      relation_file = <<~EXPECTED
+        # frozen_string_literal: true
+
+        module Test
+          module Relations
+            module Books
+              class Drafts < Test::DB::Relation
+              end
+            end
+          end
+        end
+      EXPECTED
+
+      expect(fs.read("app/relations/books/drafts.rb")).to eq(relation_file)
+      expect(output).to include("Created app/relations/books/drafts.rb")
+    end
+
+    it "generates an relation in a namespace with slash separators" do
+      subject.call(name: "books/published_books")
+
+      relation_file = <<~EXPECTED
+        # frozen_string_literal: true
+
+        module Test
+          module Relations
+            module Books
+              class PublishedBooks < Test::DB::Relation
+              end
+            end
+          end
+        end
+      EXPECTED
+
+      expect(fs.read("app/relations/books/published_books.rb")).to eq(relation_file)
+      expect(output).to include("Created app/relations/books/published_books.rb")
+    end
+  end
+
+  context "generating for a slice" do
+    it "generates a relation and pluralizes name properly" do
+      fs.mkdir("slices/main")
+      subject.call(name: "book", slice: "main")
+
+      relation_file = <<~EXPECTED
+        # frozen_string_literal: true
+
+        module Main
+          module Relations
+            class Books < Main::DB::Relation
+            end
+          end
+        end
+      EXPECTED
+
+      expect(fs.read("slices/main/relations/books.rb")).to eq(relation_file)
+      expect(output).to include("Created slices/main/relations/books.rb")
+    end
+
+    it "generates a relation in a nested namespace" do
+      fs.mkdir("slices/main")
+      subject.call(name: "book.drafts", slice: "main")
+
+      relation_file = <<~EXPECTED
+        # frozen_string_literal: true
+
+        module Main
+          module Relations
+            module Book
+              class Drafts < Main::DB::Relation
+              end
+            end
+          end
+        end
+      EXPECTED
+
+      expect(fs.read("slices/main/relations/book/drafts.rb")).to eq(relation_file)
+      expect(output).to include("Created slices/main/relations/book/drafts.rb")
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       end
     end
 
-    it "generates a repo in a deep namespace with default separator" do
+    it "generates a repo in a namespace with default separator" do
       subject.call(name: "books.drafts_repo")
 
       repo_file = <<~EXPECTED
@@ -73,7 +73,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
     end
 
     it "generates an repo in a deep namespace with slash separators" do
-      subject.call(name: "books/published_repo")
+      subject.call(name: "books/published/hardcover_repo")
 
       repo_file = <<~EXPECTED
         # frozen_string_literal: true
@@ -81,15 +81,17 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
         module Test
           module Repos
             module Books
-              class PublishedRepo < Test::DB::Repo
+              module Published
+                class HardcoverRepo < Test::DB::Repo
+                end
               end
             end
           end
         end
       EXPECTED
 
-      expect(fs.read("app/repos/books/published_repo.rb")).to eq(repo_file)
-      expect(output).to include("Created app/repos/books/published_repo.rb")
+      expect(fs.read("app/repos/books/published/hardcover_repo.rb")).to eq(repo_file)
+      expect(output).to include("Created app/repos/books/published/hardcover_repo.rb")
     end
   end
 

--- a/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       expect(output).to include("Created app/structs/book.rb")
     end
 
-    it "generates a struct in a deep namespace with default separator" do
+    it "generates a struct in a namespace with default separator" do
       subject.call(name: "book.book_draft")
 
       struct_file = <<~EXPECTED
@@ -53,7 +53,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
     end
 
     it "generates an struct in a deep namespace with slash separators" do
-      subject.call(name: "book/published_book")
+      subject.call(name: "book/published/hardcover")
 
       struct_file = <<~EXPECTED
         # frozen_string_literal: true
@@ -61,15 +61,17 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
         module Test
           module Structs
             module Book
-              class PublishedBook < Test::DB::Struct
+              module Published
+                class Hardcover < Test::DB::Struct
+                end
               end
             end
           end
         end
       EXPECTED
 
-      expect(fs.read("app/structs/book/published_book.rb")).to eq(struct_file)
-      expect(output).to include("Created app/structs/book/published_book.rb")
+      expect(fs.read("app/structs/book/published/hardcover.rb")).to eq(struct_file)
+      expect(output).to include("Created app/structs/book/published/hardcover.rb")
     end
   end
 


### PR DESCRIPTION
Resolves #188 

Pretty straight-forward. I made the decision to pluralize the name so `generate relation book` generates a `Books` relation.

And there's no way to allow a singularized relation, which is fine I think because that'd likely conflict with the associated Struct.

But I did make it so that if people choose to use a `_relation` suffix (which we don't recommend) we allow them to do that and keep their core name as what they specified. The reason is that we don't want to make `BookRelations`, that'd be very wrong.

I also cleaned up/expanded some specs for struct/repo/operation.