### PR TITLE
Fix redundant name arg in generate commands

### DIFF
--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -14,7 +14,6 @@ module Hanami
           # @since 2.2.0
           # @api private
           class Command < App::Command
-            argument :name, required: true, desc: "Name"
             option :slice, required: false, desc: "Slice name"
 
             attr_reader :generator

--- a/lib/hanami/cli/commands/app/generate/migration.rb
+++ b/lib/hanami/cli/commands/app/generate/migration.rb
@@ -9,7 +9,6 @@ module Hanami
           # @api private
           class Migration < Command
             argument :name, required: true, desc: "Migration name"
-            option :slice, required: false, desc: "Slice name"
 
             example [
               %(create_posts),

--- a/lib/hanami/cli/commands/app/generate/operation.rb
+++ b/lib/hanami/cli/commands/app/generate/operation.rb
@@ -7,7 +7,9 @@ module Hanami
         module Generate
           # @since 2.2.0
           # @api private
-          class Operation < Generate::Command
+          class Operation < Command
+            argument :name, required: true, desc: "Operation name"
+
             example [
               %(books.add               (MyApp::Books::Add)),
               %(books.add --slice=admin (Admin::Books::Add)),

--- a/lib/hanami/cli/commands/app/generate/relation.rb
+++ b/lib/hanami/cli/commands/app/generate/relation.rb
@@ -9,7 +9,6 @@ module Hanami
           # @api private
           class Relation < Command
             argument :name, required: true, desc: "Relation name"
-            option :slice, required: false, desc: "Slice name"
 
             example [
               %(books               (MyApp::Relation::Book)),

--- a/lib/hanami/cli/commands/app/generate/repo.rb
+++ b/lib/hanami/cli/commands/app/generate/repo.rb
@@ -15,7 +15,6 @@ module Hanami
           # @api private
           class Repo < Command
             argument :name, required: true, desc: "Repo name"
-            option :slice, required: false, desc: "Slice name"
 
             example [
               %(books               (MyApp::Repos::BooksRepo)),

--- a/lib/hanami/cli/commands/app/generate/struct.rb
+++ b/lib/hanami/cli/commands/app/generate/struct.rb
@@ -9,7 +9,6 @@ module Hanami
           # @api private
           class Struct < Command
             argument :name, required: true, desc: "Struct name"
-            option :slice, required: false, desc: "Slice name"
 
             example [
               %(book                (MyApp::Structs::Book)),


### PR DESCRIPTION
Our recently updated `generate` subcommands are using a new `Commands::App::Generate::Command` base class, which had `argument :name` defined.

However, many of these subclasses _also_ had their own `argument :name` defined too, which led to these commands expecting _two_ name arguments to be given, which is incorrect.

I've fixed this by removing the `argument :name` from the base class, since having this in the subclasses allows them to provide their own specific `desc:` help text. After this change, commands like `generate relation create_posts` work again.