### PR TITLE
Improve db/migrations misconfigurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+In order to run all of the tests, you should run `docker compose up` separately, to run a `postgres` server.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/hanami/cli. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/hanami/cli/blob/main/CODE_OF_CONDUCT.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   postgres:
     image: postgres:latest

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -102,8 +102,9 @@ module Hanami
 
                 STR
               elsif slices.length < 1
+                relative_path = database.slice.root.relative_path_from(database.slice.app.root).join("config", "db").to_s
                 out.puts <<~STR
-                  WARNING: Database #{database.name} has no config/db/ directory.
+                  WARNING: Database #{database.name} expects the folder #{relative_path}/ to exist but it does not.
 
                 STR
               end

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -48,21 +48,27 @@ module Hanami
             end
 
             def warn_on_missing_migrations_dir(database)
-              relative_path = database.slice.root.relative_path_from(database.slice.app.root).join("config", "db", "migrate").to_s
               out.puts <<~STR
-                WARNING: Database #{database.name} expects migrations to be located within #{relative_path}/ but that folder does not exist.
+                WARNING: Database #{database.name} expects migrations to be located within #{relative_migrations_dir(database)} but that folder does not exist.
 
                 No database migrations can be run for this database.
               STR
             end
 
             def warn_on_empty_migrations_dir(database)
-              relative_path = database.slice.root.relative_path_from(database.slice.app.root).join("config", "db", "migrate").to_s
               out.puts <<~STR
-                WARNING: Database #{database.name} has the correct migrations folder #{relative_path}/ but that folder is empty.
+                WARNING: Database #{database.name} has the correct migrations folder #{relative_migrations_dir(database)} but that folder is empty.
 
                 No database migrations can be run for this database.
               STR
+            end
+
+            def relative_migrations_dir(database)
+              database
+                .slice
+                .root
+                .relative_path_from(database.slice.app.root)
+                .join("config", "db", "migrate") + "/"
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -57,9 +57,7 @@ module Hanami
 
             def warn_on_empty_migrations_dir(database)
               out.puts <<~STR
-                WARNING: Database #{database.name} has the correct migrations folder #{relative_migrations_dir(database)} but that folder is empty.
-
-                No database migrations can be run for this database.
+                NOTE: Empty database migrations folder (#{relative_migrations_dir(database)}) for #{database.name}
               STR
             end
 

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -68,7 +68,8 @@ module Hanami
                 .slice
                 .root
                 .relative_path_from(database.slice.app.root)
-                .join("config", "db", "migrate") + "/"
+                .join("config", "db", "migrate")
+                .to_s + "/"
             end
           end
         end

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -15,10 +15,12 @@ module Hanami
 
             def call(target: nil, app: false, slice: nil, dump: true, command_exit: method(:exit), **)
               databases(app: app, slice: slice).each do |database|
-                if database.migrations_dir?
-                  migrate_database(database, target: target)
-                else
+                if migrations_dir_missing?(database)
                   warn_on_missing_migrations_dir(database)
+                elsif no_migrations?(database)
+                  warn_on_empty_migrations_dir(database)
+                else
+                  migrate_database(database, target: target)
                 end
               end
 
@@ -28,27 +30,36 @@ module Hanami
             private
 
             def migrate_database(database, target:)
-              return true unless migrations?(database)
-
               measure "database #{database.name} migrated" do
                 if target
                   database.run_migrations(target: Integer(target))
                 else
                   database.run_migrations
                 end
-
-                true
               end
             end
 
-            def migrations?(database)
-              database.migrations_dir? && database.sequel_migrator.files.any?
+            def migrations_dir_missing?(database)
+              !database.migrations_dir?
+            end
+
+            def no_migrations?(database)
+              database.sequel_migrator.files.empty?
             end
 
             def warn_on_missing_migrations_dir(database)
               relative_path = database.slice.root.relative_path_from(database.slice.app.root).join("config", "db", "migrate").to_s
               out.puts <<~STR
                 WARNING: Database #{database.name} expects migrations to be located within #{relative_path}/ but that folder does not exist.
+
+                No database migrations can be run for this database.
+              STR
+            end
+
+            def warn_on_empty_migrations_dir(database)
+              relative_path = database.slice.root.relative_path_from(database.slice.app.root).join("config", "db", "migrate").to_s
+              out.puts <<~STR
+                WARNING: Database #{database.name} has the correct migrations folder #{relative_path}/ but that folder is empty.
 
                 No database migrations can be run for this database.
               STR

--- a/spec/support/postgres.rb
+++ b/spec/support/postgres.rb
@@ -5,7 +5,7 @@ require "uri"
 
 # Default to a URL that should work with postgres as installed by asdf/mise.
 POSTGRES_BASE_DB_NAME = "hanami_cli_test"
-POSTGRES_BASE_URL = ENV.fetch("POSTGRES_BASE_URL", "postgres://postgres@localhost:5432/#{POSTGRES_BASE_DB_NAME}")
+POSTGRES_BASE_URL = ENV.fetch("POSTGRES_BASE_URL", "postgres://postgres:postgres@localhost:5433/#{POSTGRES_BASE_DB_NAME}")
 POSTGRES_BASE_URI = URI(POSTGRES_BASE_URL)
 
 RSpec.configure do |config|

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
   end
 
-  context "no db config dir" do
+  context "no db/config dir" do
     def before_prepare
       write "app/relations/.keep", ""
     end
@@ -335,7 +335,9 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     it "prints a warning, and does not migrate the database" do
       command.call
 
-      expect(output).to match %{WARNING:.+no config/db/ directory.}
+      expect(output).to include(
+        "WARNING: Database db/app.sqlite3 expects the folder config/db/ to exist but it does not."
+      )
       expect(output).not_to include "migrated"
     end
   end

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
   end
 
-  context "no db/config dir" do
+  context "no db/config/" do
     def before_prepare
       write "app/relations/.keep", ""
     end
@@ -338,6 +338,27 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       expect(output).to include(
         "WARNING: Database db/app.sqlite3 expects the folder config/db/ to exist but it does not."
       )
+      expect(output).not_to include "migrated"
+    end
+  end
+
+  context "no db/config/migrate/" do
+    def before_prepare
+      write "app/relations/.keep", ""
+      write "config/db/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+    end
+
+    it "prints a warning, and does not migrate the database" do
+      command.call
+
+      expect(output).to include(
+        "WARNING: Database db/app.sqlite3 expects migrations to be located within config/db/migrate/ but that folder does not exist."
+      )
+      expect(output).to include("No database migrations can be run for this database.")
       expect(output).not_to include "migrated"
     end
   end

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -240,22 +240,6 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
     end
   end
 
-  context "no migration files" do
-    def before_prepare
-      write "config/db/migrate/.keep", ""
-    end
-
-    before do
-      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
-      db_create
-    end
-
-    it "does nothing" do
-      command.call
-      expect(output).to be_empty
-    end
-  end
-
   context "multiple dbs with identical database_url" do
     def before_prepare
       write "slices/admin/config/db/migrate/20240602201330_create_posts.rb", <<~RUBY
@@ -357,6 +341,29 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
 
       expect(output).to include(
         "WARNING: Database db/app.sqlite3 expects migrations to be located within config/db/migrate/ but that folder does not exist."
+      )
+      expect(output).to include("No database migrations can be run for this database.")
+      expect(output).not_to include "migrated"
+    end
+  end
+
+  context "empty db/config/migrate/" do
+    def before_prepare
+      write "app/relations/.keep", ""
+      write "config/db/.keep", ""
+      write "config/db/migrate/.keep", ""
+    end
+
+    before do
+      ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+      db_create
+    end
+
+    it "prints a warning, and does not migrate the database" do
+      command.call
+
+      expect(output).to include(
+        "WARNING: Database db/app.sqlite3 has the correct migrations folder config/db/migrate/ but that folder is empty."
       )
       expect(output).to include("No database migrations can be run for this database.")
       expect(output).not_to include "migrated"

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -363,9 +363,8 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       command.call
 
       expect(output).to include(
-        "WARNING: Database db/app.sqlite3 has the correct migrations folder config/db/migrate/ but that folder is empty."
+        "NOTE: Empty database migrations folder (config/db/migrate/) for db/app.sqlite3"
       )
-      expect(output).to include("No database migrations can be run for this database.")
       expect(output).not_to include "migrated"
     end
   end


### PR DESCRIPTION
Came to fix one thing and found a few more :)

1. Fix the docker-compose configuration: use correct port, provide the password, add a note to the readme about `docker compose up` (successor to docker-compose)

2. Re-word the warning when the user is missing `config/db/`. I found this from upgrading to 2.2.0.beta1 and the message I got was `WARNING: Database ./db/bookshelf_development.sqlite has no config/db/ directory` which doesn't make a ton of sense. Now it'll say `WARNING: Database ./db/bookshelf_development.sqlite expects the folder config/db/ to exist but it does not.`

3. Add a specific warning when the user is missing `config/db/migrate/` (but has `config/db`)

4. Add a specific warning when the user has `config/db/migrate/` but it's empty (they might _have_ this folder but then have their migrations in a different folder, e.g. with the name 'migrations' which is incorrect)

I also added the line "No database migrations can be run for this database." to the last two, just to be really explicit. I'm not 100% sure it's true, though, if they have migrations in a slice instead of the main app. Happy to get rid of it, or re-word it so that it's always accurate.


After these changes, if they're missing `config/db/` this is what they see when they run `hanami db prepare`
```
WARNING: Database ./db/bookshelf_development.sqlite expects the folder config/db/ to exist but it does not.

WARNING: Database ./db/bookshelf_development.sqlite expects migrations to be located within config/db/migrate/ but that folder does not exist.

No database migrations can be run for this database.
sh: ~/hanami/bookshelf/config/db/structure.sql: No such file or directory
!!! => "./db/bookshelf_development.sqlite structure dumped to config/db/structure.sql" FAILED
```
Which is pretty redundant but I'd rather give more info than too little. We can make it more concise later, and also skip attempting to dump the structure if we can know it'll fail beforehand.