### PR TITLE
Disable auto registration for base classes

### DIFF
--- a/lib/hanami/cli/generators/app/slice/relation.erb
+++ b/lib/hanami/cli/generators/app/slice/relation.erb
@@ -1,3 +1,4 @@
+# auto_register: false
 # frozen_string_literal: true
 
 module <%= camelized_slice_name %>

--- a/lib/hanami/cli/generators/app/slice/repo.erb
+++ b/lib/hanami/cli/generators/app/slice/repo.erb
@@ -1,3 +1,4 @@
+# auto_register: false
 # frozen_string_literal: true
 
 module <%= camelized_slice_name %>

--- a/lib/hanami/cli/generators/app/slice/struct.erb
+++ b/lib/hanami/cli/generators/app/slice/struct.erb
@@ -1,3 +1,4 @@
+# auto_register: false
 # frozen_string_literal: true
 
 module <%= camelized_slice_name %>

--- a/lib/hanami/cli/generators/gem/app/relation.erb
+++ b/lib/hanami/cli/generators/gem/app/relation.erb
@@ -1,3 +1,4 @@
+# auto_register: false
 # frozen_string_literal: true
 
 require "hanami/db/relation"

--- a/lib/hanami/cli/generators/gem/app/repo.erb
+++ b/lib/hanami/cli/generators/gem/app/repo.erb
@@ -1,3 +1,4 @@
+# auto_register: false
 # frozen_string_literal: true
 
 require "hanami/db/repo"

--- a/lib/hanami/cli/generators/gem/app/struct.erb
+++ b/lib/hanami/cli/generators/gem/app/struct.erb
@@ -1,3 +1,4 @@
+# auto_register: false
 # frozen_string_literal: true
 
 require "hanami/db/struct"

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
 
       # Relation
       relation = <<~EXPECTED
+        # auto_register: false
         # frozen_string_literal: true
 
         module Admin
@@ -87,6 +88,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
 
       # Repo
       repo = <<~EXPECTED
+        # auto_register: false
         # frozen_string_literal: true
 
         module Admin
@@ -103,6 +105,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
 
       # Struct
       struct = <<~EXPECTED
+        # auto_register: false
         # frozen_string_literal: true
 
         module Admin

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -898,6 +898,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         # app/db/relation.rb
         relation = <<~EXPECTED
+          # auto_register: false
           # frozen_string_literal: true
 
           require "hanami/db/relation"
@@ -916,6 +917,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         # app/db/repo.rb
         repo = <<~EXPECTED
+          # auto_register: false
           # frozen_string_literal: true
 
           require "hanami/db/repo"
@@ -934,6 +936,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         # app/db/struct.rb
         struct = <<~EXPECTED
+          # auto_register: false
           # frozen_string_literal: true
 
           require "hanami/db/struct"


### PR DESCRIPTION
Cleanup for #180 and #197. 

We don't want the base classes to be auto_registered in the app's container, since they're meant to be used as parent classes, not used as instances directly.