### PR TITLE
Refactor RubyFileWriter

### DIFF
--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -38,12 +38,17 @@ module Hanami
             # @since 2.2.0
             # @api private
             def call(name:, slice: nil, **)
-              namespace = if slice
-                            inflector.camelize(slice).gsub(/[^\p{Alnum}]/, "")
-                          else
-                            app.namespace
-                          end
-              generator.call(namespace, name)
+              generator.call(namespace: namespace(slice), key: name)
+            end
+
+            private
+
+            def namespace(slice)
+              if slice
+                inflector.camelize(slice).gsub(/[^\p{Alnum}]/, "")
+              else
+                app.namespace
+              end
             end
           end
         end

--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -38,8 +38,12 @@ module Hanami
             # @since 2.2.0
             # @api private
             def call(name:, slice: nil, **)
-              normalized_slice = inflector.underscore(slice) if slice
-              generator.call(app.namespace, name, normalized_slice)
+              namespace = if slice
+                            inflector.camelize(slice).gsub(/[^\p{Alnum}]/, "")
+                          else
+                            app.namespace
+                          end
+              generator.call(namespace, name)
             end
           end
         end

--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -38,10 +38,22 @@ module Hanami
             # @since 2.2.0
             # @api private
             def call(name:, slice: nil, **)
-              generator.call(namespace: namespace(slice), key: name)
+              generator.call(
+                key: name,
+                namespace: namespace(slice),
+                base_path: base_path(slice)
+              )
             end
 
             private
+
+            def base_path(slice)
+              if slice
+                fs.join("slices", inflector.underscore(slice))
+              else
+                "app"
+              end
+            end
 
             def namespace(slice)
               if slice

--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -38,28 +38,18 @@ module Hanami
             # @since 2.2.0
             # @api private
             def call(name:, slice: nil, **)
-              generator.call(
-                key: name,
-                namespace: namespace(slice),
-                base_path: base_path(slice)
-              )
-            end
-
-            private
-
-            def base_path(slice)
               if slice
-                fs.join("slices", inflector.underscore(slice))
+                generator.call(
+                  key: name,
+                  namespace: slice,
+                  base_path: fs.join("slices", inflector.underscore(slice))
+                )
               else
-                "app"
-              end
-            end
-
-            def namespace(slice)
-              if slice
-                inflector.camelize(slice).gsub(/[^\p{Alnum}]/, "")
-              else
-                app.namespace
+                generator.call(
+                  key: name,
+                  namespace: app.namespace,
+                  base_path: "app"
+                )
               end
             end
           end

--- a/lib/hanami/cli/commands/app/generate/relation.rb
+++ b/lib/hanami/cli/commands/app/generate/relation.rb
@@ -21,12 +21,6 @@ module Hanami
             def generator_class
               Generators::App::Relation
             end
-
-            # @since 2.2.0
-            # @api private
-            def call(name:, slice: nil, **opts)
-              super(name: name, slice: slice, **opts)
-            end
           end
         end
       end

--- a/lib/hanami/cli/commands/app/generate/repo.rb
+++ b/lib/hanami/cli/commands/app/generate/repo.rb
@@ -30,13 +30,9 @@ module Hanami
 
             # @since 2.2.0
             # @api private
-            def call(name:, slice: nil, **opts)
-              normalized_name = if name.end_with?("_repo")
-                                  name
-                                else
-                                  "#{inflector.singularize(name)}_repo"
-                                end
-              super(name: normalized_name, slice: slice, **opts)
+            def call(name:, **opts)
+              name = "#{inflector.singularize(name)}_repo" unless name.end_with?("_repo")
+              super
             end
           end
         end

--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -17,7 +17,7 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(_app_namespace, name, slice, **_opts)
+          def call(_namespace, name, slice, **_opts)
             normalized_name = inflector.underscore(name)
             ensure_valid_name(normalized_name)
 

--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -17,8 +17,7 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace:, key:, base_path:, **_opts)
-            _namespace = namespace
+          def call(key:, base_path:, **_opts)
             name = inflector.underscore(key)
             ensure_valid_name(name)
 

--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -17,11 +17,12 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(_namespace, name, slice, **_opts)
+          def call(namespace:, name:, base_path:, **_opts)
+            _namespace = namespace
             normalized_name = inflector.underscore(name)
             ensure_valid_name(normalized_name)
 
-            base = if slice
+            base = if base_path == "app"
                      fs.join("slices", slice, "config", "db", "migrate")
                    else
                      fs.join("config", "db", "migrate")

--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -17,18 +17,13 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace:, name:, base_path:, **_opts)
+          def call(namespace:, key:, base_path:, **_opts)
             _namespace = namespace
-            normalized_name = inflector.underscore(name)
-            ensure_valid_name(normalized_name)
+            name = inflector.underscore(key)
+            ensure_valid_name(name)
 
-            base = if base_path == "app"
-                     fs.join("slices", slice, "config", "db", "migrate")
-                   else
-                     fs.join("config", "db", "migrate")
-                   end
-
-            path = fs.join(base, file_name(normalized_name))
+            base_path = "" if base_path == "app" # Migrations are in root dir, not app/
+            path = fs.join(base_path, "config", "db", "migrate", file_name(name))
 
             fs.write(path, FILE_CONTENTS)
           end

--- a/lib/hanami/cli/generators/app/operation.rb
+++ b/lib/hanami/cli/generators/app/operation.rb
@@ -19,13 +19,12 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace, key, slice)
+          def call(namespace, key)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
               namespace: namespace,
               key: key,
-              slice: slice,
               relative_parent_class: "Operation",
               body: ["def call", "end"],
             ).call

--- a/lib/hanami/cli/generators/app/operation.rb
+++ b/lib/hanami/cli/generators/app/operation.rb
@@ -19,7 +19,7 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace, key)
+          def call(namespace:, key:)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,

--- a/lib/hanami/cli/generators/app/operation.rb
+++ b/lib/hanami/cli/generators/app/operation.rb
@@ -23,12 +23,13 @@ module Hanami
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
+            ).call(
               namespace: namespace,
               base_path: base_path,
               key: key,
               relative_parent_class: "Operation",
               body: ["def call", "end"],
-            ).call
+            )
 
             unless key.match?(KEY_SEPARATOR)
               out.puts(

--- a/lib/hanami/cli/generators/app/operation.rb
+++ b/lib/hanami/cli/generators/app/operation.rb
@@ -19,11 +19,12 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace:, key:)
+          def call(key:, namespace:, base_path:)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
               namespace: namespace,
+              base_path: base_path,
               key: key,
               relative_parent_class: "Operation",
               body: ["def call", "end"],

--- a/lib/hanami/cli/generators/app/operation.rb
+++ b/lib/hanami/cli/generators/app/operation.rb
@@ -19,11 +19,11 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(app_namespace, key, slice)
+          def call(namespace, key, slice)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
-              app_namespace: app_namespace,
+              namespace: namespace,
               key: key,
               slice: slice,
               relative_parent_class: "Operation",

--- a/lib/hanami/cli/generators/app/relation.rb
+++ b/lib/hanami/cli/generators/app/relation.rb
@@ -19,13 +19,13 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(app_namespace, key, slice)
+          def call(namespace, key, slice)
             schema_name = key.split(KEY_SEPARATOR).last
 
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
-              app_namespace: app_namespace,
+              namespace: namespace,
               key: key,
               slice: slice,
               extra_namespace: "Relations",

--- a/lib/hanami/cli/generators/app/relation.rb
+++ b/lib/hanami/cli/generators/app/relation.rb
@@ -25,13 +25,14 @@ module Hanami
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
+            ).call(
               namespace: namespace,
               key: key,
               base_path: base_path,
               extra_namespace: "Relations",
               relative_parent_class: "DB::Relation",
               body: ["schema :#{schema_name}, infer: true"],
-            ).call
+            )
           end
 
           private

--- a/lib/hanami/cli/generators/app/relation.rb
+++ b/lib/hanami/cli/generators/app/relation.rb
@@ -19,7 +19,7 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace, key, slice)
+          def call(key:, namespace:, base_path:)
             schema_name = key.split(KEY_SEPARATOR).last
 
             RubyFileWriter.new(
@@ -27,7 +27,7 @@ module Hanami
               inflector: inflector,
               namespace: namespace,
               key: key,
-              slice: slice,
+              base_path: base_path,
               extra_namespace: "Relations",
               relative_parent_class: "DB::Relation",
               body: ["schema :#{schema_name}, infer: true"],

--- a/lib/hanami/cli/generators/app/repo.rb
+++ b/lib/hanami/cli/generators/app/repo.rb
@@ -17,11 +17,11 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(app_namespace, key, slice)
+          def call(namespace, key, slice)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
-              app_namespace: app_namespace,
+              namespace: namespace,
               key: key,
               slice: slice,
               extra_namespace: "Repos",

--- a/lib/hanami/cli/generators/app/repo.rb
+++ b/lib/hanami/cli/generators/app/repo.rb
@@ -17,13 +17,13 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace, key, slice)
+          def call(key:, namespace:, base_path:)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
-              namespace: namespace,
               key: key,
-              slice: slice,
+              namespace: namespace,
+              base_path: base_path,
               extra_namespace: "Repos",
               relative_parent_class: "DB::Repo",
               body: [],

--- a/lib/hanami/cli/generators/app/repo.rb
+++ b/lib/hanami/cli/generators/app/repo.rb
@@ -21,13 +21,14 @@ module Hanami
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
+            ).call(
               key: key,
               namespace: namespace,
               base_path: base_path,
               extra_namespace: "Repos",
               relative_parent_class: "DB::Repo",
               body: [],
-            ).call
+            )
           end
 
           private

--- a/lib/hanami/cli/generators/app/ruby_file_writer.rb
+++ b/lib/hanami/cli/generators/app/ruby_file_writer.rb
@@ -14,6 +14,35 @@ module Hanami
         class RubyFileWriter
           # @since 2.2.0
           # @api private
+          def initialize(fs:, inflector:)
+            @fs = fs
+            @inflector = inflector
+            # raise_missing_slice_error_if_missing(slice) unless slice.app?
+          end
+
+          # @since 2.2.0
+          # @api private
+          def call(key:, namespace:, base_path:, relative_parent_class:, extra_namespace: nil, body: [])
+            Definition.new(
+              fs: fs,
+              inflector: inflector,
+              key: key,
+              namespace: namespace,
+              base_path: base_path,
+              relative_parent_class: relative_parent_class,
+              extra_namespace: extra_namespace,
+              body: body,
+            ).write
+          end
+
+          private
+
+          # @since 2.2.0
+          # @api private
+          attr_reader :fs, :inflector
+        end
+
+        class Definition
           def initialize(
             fs:,
             inflector:,
@@ -26,19 +55,15 @@ module Hanami
           )
             @fs = fs
             @inflector = inflector
-            @namespace = namespace
             @key = key
+            @namespace = namespace
             @base_path = base_path
             @extra_namespace = extra_namespace&.downcase
             @relative_parent_class = relative_parent_class
             @body = body
-            # raise_missing_slice_error_if_missing(slice) unless slice.app?
           end
 
-          # @since 2.2.0
-          # @api private
-          def call
-            fs.mkdir(directory)
+          def write
             fs.write(path, file_contents)
           end
 
@@ -119,15 +144,6 @@ module Hanami
           # @api private
           def normalize(name)
             inflector.camelize(name).gsub(/[^\p{Alnum}]/, "")
-          end
-
-          # @since 2.2.0
-          # @api private
-          def raise_missing_slice_error_if_missing(slice)
-            # FIXME: Rename or remove?
-            unless fs.directory?(slice.source_path)
-              raise MissingSliceError.new(slice)
-            end
           end
         end
       end

--- a/lib/hanami/cli/generators/app/ruby_file_writer.rb
+++ b/lib/hanami/cli/generators/app/ruby_file_writer.rb
@@ -17,7 +17,6 @@ module Hanami
           def initialize(fs:, inflector:)
             @fs = fs
             @inflector = inflector
-            # raise_missing_slice_error_if_missing(slice) unless slice.app?
           end
 
           # @since 2.2.0

--- a/lib/hanami/cli/generators/app/ruby_file_writer.rb
+++ b/lib/hanami/cli/generators/app/ruby_file_writer.rb
@@ -17,7 +17,7 @@ module Hanami
           def initialize(
             fs:,
             inflector:,
-            app_namespace:,
+            namespace:,
             key:,
             slice:,
             relative_parent_class:,
@@ -26,7 +26,7 @@ module Hanami
           )
             @fs = fs
             @inflector = inflector
-            @app_namespace = app_namespace
+            @namespace = namespace
             @key = key
             @slice = slice
             @extra_namespace = extra_namespace&.downcase
@@ -49,7 +49,7 @@ module Hanami
           attr_reader(
             :fs,
             :inflector,
-            :app_namespace,
+            :namespace,
             :key,
             :slice,
             :extra_namespace,
@@ -76,7 +76,7 @@ module Hanami
           # @since 2.2.0
           # @api private
           def container_namespace
-            slice || app_namespace
+            slice || namespace
           end
 
           # @since 2.2.0

--- a/lib/hanami/cli/generators/app/ruby_file_writer.rb
+++ b/lib/hanami/cli/generators/app/ruby_file_writer.rb
@@ -17,8 +17,9 @@ module Hanami
           def initialize(
             fs:,
             inflector:,
-            namespace:,
             key:,
+            namespace:,
+            base_path:,
             relative_parent_class:,
             extra_namespace: nil,
             body: []
@@ -27,6 +28,7 @@ module Hanami
             @inflector = inflector
             @namespace = namespace
             @key = key
+            @base_path = base_path
             @extra_namespace = extra_namespace&.downcase
             @relative_parent_class = relative_parent_class
             @body = body
@@ -47,8 +49,9 @@ module Hanami
           attr_reader(
             :fs,
             :inflector,
-            :namespace,
             :key,
+            :namespace,
+            :base_path,
             :extra_namespace,
             :relative_parent_class,
             :body,
@@ -79,18 +82,10 @@ module Hanami
           # @api private
           def directory
             @directory ||= if local_namespaces.any?
-                             fs.join(source_path, local_namespaces)
+                             fs.join(base_path, local_namespaces)
                            else
-                             source_path
+                             base_path
                            end
-          end
-
-          def source_path
-            if namespace == Hanami.app.namespace
-              "app"
-            else
-              fs.join("slices", inflector.underscore(namespace))
-            end
           end
 
           # @since 2.2.0

--- a/lib/hanami/cli/generators/app/ruby_file_writer.rb
+++ b/lib/hanami/cli/generators/app/ruby_file_writer.rb
@@ -23,7 +23,7 @@ module Hanami
           # @since 2.2.0
           # @api private
           def call(key:, namespace:, base_path:, relative_parent_class:, extra_namespace: nil, body: [])
-            Definition.new(
+            ClassFile.new(
               fs: fs,
               inflector: inflector,
               key: key,
@@ -42,7 +42,7 @@ module Hanami
           attr_reader :fs, :inflector
         end
 
-        class Definition
+        class ClassFile
           def initialize(
             fs:,
             inflector:,

--- a/lib/hanami/cli/generators/app/struct.rb
+++ b/lib/hanami/cli/generators/app/struct.rb
@@ -17,11 +17,11 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(app_namespace, key, slice)
+          def call(namespace, key, slice)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
-              app_namespace: app_namespace,
+              namespace: namespace,
               key: key,
               slice: slice,
               extra_namespace: "Structs",

--- a/lib/hanami/cli/generators/app/struct.rb
+++ b/lib/hanami/cli/generators/app/struct.rb
@@ -17,13 +17,13 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(namespace, key, slice)
+          def call(key:, namespace:, base_path:)
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
-              namespace: namespace,
               key: key,
-              slice: slice,
+              namespace: namespace,
+              base_path: base_path,
               extra_namespace: "Structs",
               relative_parent_class: "DB::Struct",
             ).call

--- a/lib/hanami/cli/generators/app/struct.rb
+++ b/lib/hanami/cli/generators/app/struct.rb
@@ -21,12 +21,13 @@ module Hanami
             RubyFileWriter.new(
               fs: fs,
               inflector: inflector,
+            ).call(
               key: key,
               namespace: namespace,
               base_path: base_path,
               extra_namespace: "Structs",
               relative_parent_class: "DB::Struct",
-            ).call
+            )
           end
 
           private


### PR DESCRIPTION
Addresses #202

Although, I ended up not using `slice.source_path`. I had an implementation working that just took a `Hanami::Slice` and used `.namespace` and `.source_path` but it proved hard to test. I couldn't figure out how to register a slice into the `Test::App`. 

Instead, the RubyFileWriter takes `namespace` and `base_path`, and we do the mapping in `Generate::Command`.

Happy to change this over if we can figure out a simple way to test that, to simplify the code, but I also feel like it's reasonable that a "File Writer" would require a namespace and a path as separate args, even though they're coupled in our apps.

I also changed the RubyFileWriter implementation so that `call` takes the file-specific args, instead of no args for `call` and all of them being passed to the initializer. I implemented this via helper class, as passing around all the variables that need to be passed around proved to make the code very messy.

I want to handle this refactoring before using RubyFileWriter in other generators.