### PR TITLE
Deleting .keep files using the generators

### DIFF
--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -11,7 +11,7 @@ module Hanami
         module Assets
           # Base class for assets commands.
           #
-          # Finds slices with assets present (anything in an `assets/` dir), then forks a child
+          # Finds slices with assets present (anything in an `assets/` dir), then forks or spawns a child
           # process for each slice to run the assets command (`config/assets.js`) for the slice.
           #
           # Prefers the slice's own `config/assets.js` if present, otherwise falls back to the
@@ -85,6 +85,8 @@ module Hanami
               Process.fork do
                 cmd, *args = assets_command(slice)
                 system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
+              # Handle Process.fork not being implemented on non-POSIX OS's
+              # by only spawning a child process of the main process
               rescue NotImplementedError
                 cmd, *args = assets_command(slice)
                 system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -88,8 +88,10 @@ module Hanami
               # Handle Process.fork not being implemented on non-POSIX OS's
               # by only spawning a child process of the main process
               rescue NotImplementedError
-                cmd, *args = assets_command(slice)
-                system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
+                Thread.new do
+                  cmd, *args = assets_command(slice)
+                  system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
+                end
               rescue Interrupt
                 # When this has been interrupted (by the Signal.trap handler in #call), catch the
                 # interrupt and exit cleanly, without showing the default full backtrace.

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -85,6 +85,9 @@ module Hanami
               Process.fork do
                 cmd, *args = assets_command(slice)
                 system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
+              rescue NotImplementedError
+                cmd, *args = assets_command(slice)
+                system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
               rescue Interrupt
                 # When this has been interrupted (by the Signal.trap handler in #call), catch the
                 # interrupt and exit cleanly, without showing the default full backtrace.

--- a/lib/hanami/cli/files.rb
+++ b/lib/hanami/cli/files.rb
@@ -18,6 +18,15 @@ module Hanami
       # @api private
       def write(path, *content)
         already_exists = exist?(path)
+
+        # delete .keep file on generate, excluding running `hanami new`
+        base = path.split('/')[0]
+        keepfile = Dir.glob('**/.keep', base:)
+
+        if caller_locations(1,1)[0].label != 'generate_app' && keepfile.any? && exist?("#{base}/#{keepfile[0]}")
+          delete("#{base}/#{keepfile[0]}")
+        end
+
         super
         if already_exists
           updated(path)


### PR DESCRIPTION
closes [#209 ](https://github.com/hanami/cli/issues/209)

I took @cllns 's advice and implemented this in `Hanami::CLI::Files#write`

Had to take care to skip this behavior when running `hanami new`, or else we'd never "keep" ( 😏 ) the files to begin with!  Let me know if there are any suggestions on improvements

Thanks!