### PR TITLE
Deleting .keep files using the generators

### DIFF
--- a/lib/hanami/cli/command.rb
+++ b/lib/hanami/cli/command.rb
@@ -23,7 +23,7 @@ module Hanami
       def self.new(
         out: $stdout,
         err: $stderr,
-        fs: Hanami::CLI::Files.new,
+        fs: Hanami::CLI::Files.new(out: out),
         inflector: Dry::Inflector.new,
         **opts
       )

--- a/lib/hanami/cli/files.rb
+++ b/lib/hanami/cli/files.rb
@@ -19,15 +19,18 @@ module Hanami
       def write(path, *content)
         already_exists = exist?(path)
 
-        # delete .keep files unless running `hanami new`
-        base = path.split('/')[0]
-        keepfile = Dir.glob('**/.keep', base:)
+        if !directory?(path)
+          file = Pathname.new(path)
 
-        if caller_locations(1,1)[0].label != 'generate_app' && keepfile.any? && exist?("#{base}/#{keepfile[0]}")
-          delete("#{base}/#{keepfile[0]}")
+          file.ascend do |part|
+            potential_keepfile = (part.dirname + '.keep').to_path
+            delete(potential_keepfile) if exist?(potential_keepfile)
+          end
+
         end
 
         super
+
         if already_exists
           updated(path)
         else

--- a/lib/hanami/cli/files.rb
+++ b/lib/hanami/cli/files.rb
@@ -18,6 +18,15 @@ module Hanami
       # @api private
       def write(path, *content)
         already_exists = exist?(path)
+
+        # delete .keep files unless running `hanami new`
+        base = path.split('/')[0]
+        keepfile = Dir.glob('**/.keep', base:)
+
+        if caller_locations(1,1)[0].label != 'generate_app' && keepfile.any? && exist?("#{base}/#{keepfile[0]}")
+          delete("#{base}/#{keepfile[0]}")
+        end
+
         super
         if already_exists
           updated(path)

--- a/lib/hanami/cli/files.rb
+++ b/lib/hanami/cli/files.rb
@@ -21,6 +21,7 @@ module Hanami
 
         if !directory?(path)
           file = Pathname.new(path)
+          file = file.relative_path_from(Pathname.new('/')) unless file.relative?
 
           file.ascend do |part|
             potential_keepfile = (part.dirname + '.keep').to_path


### PR DESCRIPTION
(re-opened with correct commit history)

closes [#209 ](https://github.com/hanami/cli/issues/209)

I took @cllns  's advice and implemented this in `Hanami::CLI::Files#write`

Had to take care to skip this behavior when running hanami new, or else we'd never "keep" ( 😏 ) the files to begin with! Let me know if there are any suggestions on improvements

Thanks!