### PR TITLE
Add MySQL support for `db` commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,17 @@ jobs:
       - name: Run all tests
         run: bundle exec rake spec
     services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
       postgres:
         # Use postgres:14 for CLI compatibility with ubuntu-latest, currently ubuntu-22.04
         # See https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
@@ -48,10 +59,10 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports:
-          - 5432:5432

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 
 gem "rack"
 
+gem "mysql2"
 gem "pg"
 gem "sqlite3"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  mysql:
+    image: mysql:latest
+    ports:
+      - 3307:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: password
   postgres:
     image: postgres:latest
     ports:

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -29,7 +29,7 @@ module Hanami
                   require_relative("postgres")
                   Postgres
                 },
-                "mysql" => -> {
+                "mysql2" => -> {
                   require_relative("mysql")
                   Mysql
                 }

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -34,6 +34,7 @@ module Hanami
               end
 
               # @api private
+              # @since 2.2.0
               def exec_dump_command
                 exec_cli(
                   "mysqldump",
@@ -42,13 +43,12 @@ module Hanami
               end
 
               # @api private
+              # @since 2.2.0
               def exec_load_command
                 exec_cli(
                   "mysql",
                   %(--execute "SET FOREIGN_KEY_CHECKS = 0; SOURCE #{structure_file}; SET FOREIGN_KEY_CHECKS = 1" --database #{escaped_name})
                 )
-
-                # binding.irb
               end
 
               private

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -19,6 +19,14 @@ module Hanami
 
               # @api private
               # @since 2.2.0
+              def exec_drop_command
+                return true unless exists?
+
+                exec_mysql_cli(%(-e "DROP DATABASE #{escaped_name}"))
+              end
+
+              # @api private
+              # @since 2.2.0
               def exists?
                 result = exec_mysql_cli(%(-e "SHOW DATABASES LIKE '#{name}'" --batch))
 

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -14,7 +14,7 @@ module Hanami
               def exec_create_command
                 return true if exists?
 
-                exec_mysql_cli(%(-e "CREATE DATABASE #{escaped_name}"))
+                exec_cli("mysql", %(-e "CREATE DATABASE #{escaped_name}"))
               end
 
               # @api private
@@ -22,20 +22,23 @@ module Hanami
               def exec_drop_command
                 return true unless exists?
 
-                exec_mysql_cli(%(-e "DROP DATABASE #{escaped_name}"))
+                exec_cli("mysql", %(-e "DROP DATABASE #{escaped_name}"))
               end
 
               # @api private
               # @since 2.2.0
               def exists?
-                result = exec_mysql_cli(%(-e "SHOW DATABASES LIKE '#{name}'" --batch))
+                result = exec_cli("mysql", %(-e "SHOW DATABASES LIKE '#{name}'" --batch))
 
                 result.successful? && result.out != ""
               end
 
               # @api private
               def exec_dump_command
-                raise Hanami::CLI::NotImplementedError
+                exec_cli(
+                  "mysqldump",
+                  "--no-data --routines --skip-comments --result-file=#{structure_file} #{escaped_name}"
+                )
               end
 
               # @api private
@@ -49,9 +52,9 @@ module Hanami
                 Shellwords.escape(name)
               end
 
-              def exec_mysql_cli(cli_args)
+              def exec_cli(cli_name, cli_args)
                 system_call.call(
-                  "mysql #{cli_options} #{cli_args}",
+                  "#{cli_name} #{cli_options} #{cli_args}",
                   env: cli_env_vars
                 )
               end

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -43,7 +43,12 @@ module Hanami
 
               # @api private
               def exec_load_command
-                raise Hanami::CLI::NotImplementedError
+                exec_cli(
+                  "mysql",
+                  %(--execute "SET FOREIGN_KEY_CHECKS = 0; SOURCE #{structure_file}; SET FOREIGN_KEY_CHECKS = 1" --database #{escaped_name})
+                )
+
+                # binding.irb
               end
 
               private

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -54,6 +54,16 @@ module Hanami
                 )
               end
 
+              def schema_migrations_sql_dump
+                search_path = slice["db.gateway"].connection
+                  .fetch("SHOW search_path").to_a.first
+                  .fetch(:search_path)
+
+                +"SET search_path TO #{search_path};\n\n" << super
+              end
+
+              private
+
               def escaped_name
                 Shellwords.escape(name)
               end
@@ -65,14 +75,6 @@ module Hanami
                   vars["PGUSER"] = database_uri.user.to_s if database_uri.user
                   vars["PGPASSWORD"] = database_uri.password.to_s if database_uri.password
                 end
-              end
-
-              def schema_migrations_sql_dump
-                search_path = slice["db.gateway"].connection
-                  .fetch("SHOW search_path").to_a.first
-                  .fetch(:search_path)
-
-                +"SET search_path TO #{search_path};\n\n" << super
               end
             end
           end

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -112,7 +112,7 @@ module Hanami
           elsif generate_postgres?
             "postgres://localhost/#{app}"
           elsif generate_mysql?
-            "mysql://localhost/#{app}"
+            "mysql2://localhost/#{app}"
           else
             raise "Unknown database option: #{database_option}"
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,4 +68,4 @@ RSpec.configure do |config|
   end
 end
 
-Dir.glob("#{__dir__}/support/**/*.rb").each(&method(:require))
+Dir.glob("#{__dir__}/support/**/*.rb").each { require _1 }

--- a/spec/support/mysql.rb
+++ b/spec/support/mysql.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "open3"
+require "uri"
+
+MYSQL_BASE_DB_NAME = "hanami_cli_test"
+# Use "127.0.0.1" instead of "localhost" so MySQL connects with TCP instead of a Unix socket
+MYSQL_BASE_URL = ENV.fetch("MYSQL_BASE_URL", "mysql2://root:password@127.0.0.1:3307/#{MYSQL_BASE_DB_NAME}")
+MYSQL_BASE_URI = URI(MYSQL_BASE_URL)
+
+RSpec.configure do |config|
+  # Drop all databases with names starting with MYSQL_URL_BASE
+  config.after :each, :mysql do
+    mysql_cli_env = {"MYSQL_PWD" => MYSQL_BASE_URI.password}
+    mysql_cli_args = [
+      "mysql",
+      "--host=#{MYSQL_BASE_URI.host}",
+      "--port=#{MYSQL_BASE_URI.port}",
+      "--protocol=TCP",
+      "--user=#{MYSQL_BASE_URI.user}",
+      "--batch"
+    ].join(" ")
+
+    mysql_databases, _ = Open3.capture2(
+      mysql_cli_env, mysql_cli_args + %( -e "SHOW DATABASES")
+    )
+
+    test_db_prefix = MYSQL_BASE_URI.path.sub(%r{^/}, "")
+    test_databases = mysql_databases
+      .split("\n")
+      .then { Array(_1[1..]) } # Ignore the header row
+      .select { _1.start_with?(test_db_prefix) }
+
+    test_databases.each do |database|
+      system(mysql_cli_env, mysql_cli_args + %( -e "DROP DATABASE #{database}"))
+    end
+  end
+end

--- a/spec/support/mysql.rb
+++ b/spec/support/mysql.rb
@@ -4,7 +4,7 @@ require "open3"
 require "uri"
 
 MYSQL_BASE_DB_NAME = "hanami_cli_test"
-# Use "127.0.0.1" instead of "localhost" so MySQL connects with TCP instead of a Unix socket
+# Connect to "127.0.0.1" instead of "localhost" so MySQL uses TCP rather than a Unix socket
 MYSQL_BASE_URL = ENV.fetch("MYSQL_BASE_URL", "mysql2://root:password@127.0.0.1:3307/#{MYSQL_BASE_DB_NAME}")
 MYSQL_BASE_URI = URI(MYSQL_BASE_URL)
 

--- a/spec/support/postgres.rb
+++ b/spec/support/postgres.rb
@@ -3,7 +3,6 @@
 require "open3"
 require "uri"
 
-# Default to a URL that should work with postgres as installed by asdf/mise.
 POSTGRES_BASE_DB_NAME = "hanami_cli_test"
 POSTGRES_BASE_URL = ENV.fetch("POSTGRES_BASE_URL", "postgres://postgres:postgres@localhost:5433/#{POSTGRES_BASE_DB_NAME}")
 POSTGRES_BASE_URI = URI(POSTGRES_BASE_URL)

--- a/spec/unit/hanami/cli/commands/app/db/create_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
   let(:system_call) { Hanami::CLI::SystemCall.new }
 
   let(:out) { StringIO.new }
-  def output; out.string; end
+  def output = out.string
 
   before do
     # Prevent the command from exiting the spec run in the case of unexpected system call failures
@@ -94,6 +94,22 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
         expect(output).to include "database #{POSTGRES_BASE_DB_NAME}_app created"
+      end
+    end
+
+    describe "mysql", :mysql do
+      before do
+        ENV["DATABASE_URL"] = "#{MYSQL_BASE_URL}_app"
+      end
+
+      it "creates the database" do
+        command.call
+
+        # binding.irb
+
+        expect { Hanami.app["db.gateway"] }.not_to raise_error
+
+        expect(output).to include "database #{MYSQL_BASE_DB_NAME}_app created"
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/db/create_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_spec.rb
@@ -105,7 +105,16 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
       it "creates the database" do
         command.call
 
-        # binding.irb
+        expect { Hanami.app["db.gateway"] }.not_to raise_error
+
+        expect(output).to include "database #{MYSQL_BASE_DB_NAME}_app created"
+      end
+
+      it "does not create the database if it already exists" do
+        command.run_command(Hanami::CLI::Commands::App::DB::Create)
+        out.truncate(0)
+
+        command.call
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1243,7 +1243,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
-          expect(fs.read(".env")).to include("DATABASE_URL=mysql://localhost/#{app}")
+          expect(fs.read(".env")).to include("DATABASE_URL=mysql2://localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
         end
@@ -1255,7 +1255,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
-          expect(fs.read(".env")).to include("DATABASE_URL=mysql://localhost/#{app}")
+          expect(fs.read(".env")).to include("DATABASE_URL=mysql2://localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
         end


### PR DESCRIPTION
Make `Hanami::CLI::Commands::App::DB::Utils::Mysql` a working implementation, so that MySQL databases can be used for the `db create`, `db drop`, `db structure dump` and `db structure load` commands.

In new apps generated with the `--database mysql` option, generate `mysql2://` database URLs, since this is the URL scheme required to connect using the mysql2 gem with Sequel (which underpins rom-sql).

Add a working MySQL database and support code for testing.

Resolves #157



