### PR TITLE
Add --skip-route flag for action and slice generators

### DIFF
--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -25,6 +25,9 @@ module Hanami
             DEFAULT_SKIP_TESTS = false
             private_constant :DEFAULT_SKIP_TESTS
 
+            DEFAULT_SKIP_ROUTE = false
+            private_constant :DEFAULT_SKIP_ROUTE
+
             argument :name, required: true, desc: "Action name"
             option :url, required: false, type: :string, desc: "Action URL"
             option :http, required: false, type: :string, desc: "Action HTTP method"
@@ -41,6 +44,12 @@ module Hanami
               type: :flag,
               default: DEFAULT_SKIP_TESTS,
               desc: "Skip test generation"
+            option \
+              :skip_route,
+              required: false,
+              type: :flag,
+              default: DEFAULT_SKIP_ROUTE,
+              desc: "Skip route generation"
             option :slice, required: false, desc: "Slice name"
 
             # rubocop:disable Layout/LineLength
@@ -83,7 +92,8 @@ module Hanami
               http: nil,
               format: DEFAULT_FORMAT,
               skip_view: DEFAULT_SKIP_VIEW,
-              skip_tests: DEFAULT_SKIP_TESTS, # rubocop:disable Lint/UnusedMethodArgument
+              skip_tests: DEFAULT_SKIP_TESTS, # rubocop:disable Lint/UnusedMethodArgument,
+              skip_route: DEFAULT_SKIP_ROUTE,
               slice: nil,
               context: nil,
               **
@@ -96,7 +106,7 @@ module Hanami
                 raise InvalidActionNameError.new(name)
               end
 
-              generator.call(app.namespace, controller, action, url, http, format, skip_view, slice, context: context)
+              generator.call(app.namespace, controller, action, url, http, format, skip_view, skip_route, slice, context: context)
             end
 
             # rubocop:enable Metrics/ParameterLists

--- a/lib/hanami/cli/commands/app/generate/slice.rb
+++ b/lib/hanami/cli/commands/app/generate/slice.rb
@@ -23,11 +23,24 @@ module Hanami
 
             # @since 2.2.0
             # @api private
+            DEFAULT_SKIP_ROUTE = false
+            private_constant :DEFAULT_SKIP_ROUTE
+
+            # @since 2.2.0
+            # @api private
             option :skip_db,
               type: :boolean,
               required: false,
               default: SKIP_DB_DEFAULT,
               desc: "Skip database"
+            # @since 2.2.0
+            # @api private
+            option :skip_route,
+              type: :boolean,
+              required: false,
+              type: :flag,
+              default: DEFAULT_SKIP_ROUTE,
+              desc: "Skip route generation"
 
             example [
               "admin          # Admin slice (/admin URL prefix)",
@@ -50,7 +63,8 @@ module Hanami
             def call(
               name:,
               url: nil,
-              skip_db: SKIP_DB_DEFAULT
+              skip_db: SKIP_DB_DEFAULT,
+              skip_route: DEFAULT_SKIP_ROUTE
             )
               require "hanami/setup"
 
@@ -58,7 +72,7 @@ module Hanami
               name = inflector.underscore(Shellwords.shellescape(name))
               url = sanitize_url_prefix(name, url)
 
-              generator.call(app, name, url, skip_db: skip_db)
+              generator.call(app, name, url, skip_db: skip_db, skip_route: skip_route)
             end
 
             private

--- a/lib/hanami/cli/generators/app/slice.rb
+++ b/lib/hanami/cli/generators/app/slice.rb
@@ -22,9 +22,11 @@ module Hanami
           def call(app, slice, url, context: nil, **opts)
             context ||= SliceContext.new(inflector, app, slice, url, **opts)
 
-            fs.inject_line_at_class_bottom(
-              fs.join("config", "routes.rb"), "class Routes", t("routes.erb", context).chomp
-            )
+            if context.generate_route?
+              fs.inject_line_at_class_bottom(
+                fs.join("config", "routes.rb"), "class Routes", t("routes.erb", context).chomp
+              )
+            end
 
             fs.mkdir(directory = "slices/#{slice}")
 

--- a/lib/hanami/cli/generators/app/slice_context.rb
+++ b/lib/hanami/cli/generators/app/slice_context.rb
@@ -54,6 +54,12 @@ module Hanami
             !options.fetch(:skip_db, false)
           end
 
+          # @since 2.2.0
+          # @api private
+          def generate_route?
+            !options.fetch(:skip_route, false)
+          end
+
           private
 
           attr_reader :slice

--- a/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_spec.rb
@@ -316,6 +316,29 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Slice, :app do
     end
   end
 
+  context "with --skip-route" do
+    it "generates a slice without corresponding route" do
+      within_application_directory do
+        subject.call(name: slice, skip_route: true)
+
+        # Route
+        blank_routes = <<~CODE
+          # frozen_string_literal: true
+
+          require "hanami/routes"
+
+          module #{app}
+            class Routes < Hanami::Routes
+              root { "Hello from Hanami" }
+            end
+          end
+        CODE
+
+        expect(fs.read("config/routes.rb")).to include(blank_routes)
+      end
+    end
+  end
+
   private
 
   def within_application_directory


### PR DESCRIPTION
closes [#196](https://github.com/hanami/cli/issues/196)

i tried to mirror the existing implementation of the other flags, even if we ended up with goofy functions like `Generators::App::Action#generate_route?`

lmk if you'd like to see any changes, thanks!