### PR TITLE
Require dry/operation/extensions/rom in default Operation

### DIFF
--- a/lib/hanami/cli/generators/gem/app/operation.erb
+++ b/lib/hanami/cli/generators/gem/app/operation.erb
@@ -2,6 +2,9 @@
 # frozen_string_literal: true
 
 require "dry/operation"
+<%- if generate_db? -%>
+require "dry/operation/extensions/rom"
+<%- end -%>
 
 module <%= camelized_app_name %>
   class Operation < Dry::Operation

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -452,6 +452,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         # frozen_string_literal: true
 
         require "dry/operation"
+        require "dry/operation/extensions/rom"
 
         module #{inflector.camelize(app)}
           class Operation < Dry::Operation


### PR DESCRIPTION
Now necessary due to https://github.com/dry-rb/dry-operation/pull/20