### PR TITLE
Update DB commands to support multiple gateways per slice

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,5 @@ Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/StringConcatenation:
   Enabled: false
+Style/ZeroLengthPredicate:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ unless ENV["CI"]
   gem "yard-junk"
 end
 
-gem "hanami", github: "hanami/hanami", branch: "main"
+gem "hanami", github: "hanami/hanami", branch: "multiple-gateways"
 gem "hanami-assets", github: "hanami/assets", branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-db", github: "hanami/db", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ unless ENV["CI"]
   gem "yard-junk"
 end
 
-gem "hanami", github: "hanami/hanami", branch: "multiple-gateways"
+gem "hanami", github: "hanami/hanami", branch: "main"
 gem "hanami-assets", github: "hanami/assets", branch: "main"
 gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-db", github: "hanami/db", branch: "main"

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -40,6 +40,11 @@ module Hanami
             private
 
             def databases(app: false, slice: nil, gateway: nil)
+              if gateway && !app && !slice
+                err.puts "When specifying --gateway, an --app or --slice must also be given"
+                exit 1
+              end
+
               databases =
                 if slice
                   [database_for_slice(slice, gateway: gateway)]
@@ -61,7 +66,10 @@ module Hanami
               databases = build_databases(slice)
 
               if gateway
-                databases.fetch(gateway.to_sym) # TODO: raise unknown gateway error for missing key
+                databases.fetch(gateway.to_sym) do
+                  err.puts %(No gateway "#{gateway}" in #{slice})
+                  exit 1
+                end
               else
                 databases.values
               end

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -77,7 +77,7 @@ module Hanami
               end
             end
 
-            def all_databases
+            def all_databases # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
               slices = [app] + app.slices.with_nested
 
               slices_by_database_url = slices.each_with_object({}) { |slice, hsh|
@@ -90,10 +90,10 @@ module Hanami
                 end
               }
 
-              slices_by_database_url.each_with_object([]) { |(url, slices), arr|
-                slices_with_config = slices.select { _1.root.join("config", "db").directory? }
+              slices_by_database_url.each_with_object([]) { |(_url, slices_for_url), arr|
+                slices_with_config = slices_for_url.select { _1.root.join("config", "db").directory? }
 
-                databases = build_databases(slices_with_config.first || slices.first).values
+                databases = build_databases(slices_with_config.first || slices_for_url.first).values
 
                 databases.each do |database|
                   warn_on_misconfigured_database database, slices_with_config
@@ -114,7 +114,7 @@ module Hanami
               exit 1
             end
 
-            def warn_on_misconfigured_database(database, slices)
+            def warn_on_misconfigured_database(database, slices) # rubocop:disable Metrics/AbcSize
               if slices.length > 1
                 out.puts <<~STR
                   WARNING: Database #{database.name} is configured for multiple config/db/ directories:

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -63,6 +63,8 @@ module Hanami
                 slice = app.slices[slice_name]
               end
 
+              ensure_database_slice slice
+
               databases = build_databases(slice)
 
               if gateway
@@ -103,6 +105,13 @@ module Hanami
 
             def build_databases(slice)
               Utils::Database.from_slice(slice: slice, system_call: system_call)
+            end
+
+            def ensure_database_slice(slice)
+              return if slice.container.providers[:db]
+
+              out.puts "#{slice} does not have a :db provider."
+              exit 1
             end
 
             def warn_on_misconfigured_database(database, slices)

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -119,14 +119,16 @@ module Hanami
                 out.puts <<~STR
                   WARNING: Database #{database.name} is configured for multiple config/db/ directories:
 
-                  #{slices.map { '- ' + _1.root.relative_path_from(_1.app.root).join('config', 'db').to_s }.join("\n")}
+                  #{slices.map { "- " + _1.root.relative_path_from(_1.app.root).join("config", "db").to_s }.join("\n")}
 
                   Migrating database using #{database.slice.slice_name.to_s.inspect} slice only.
 
                 STR
               elsif slices.length < 1
-                relative_path = database.slice.root.relative_path_from(database.slice.app.root).join("config",
-                                                                                                     "db").to_s
+                relative_path = database.slice.root
+                  .relative_path_from(database.slice.app.root)
+                  .join("config", "db").to_s
+
                 out.puts <<~STR
                   WARNING: Database #{database.name} expects the folder #{relative_path}/ to exist but it does not.
 

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -41,12 +41,9 @@ module Hanami
 
             def databases(app: false, slice: nil, gateway: nil)
               databases =
-                if app
-                  [database_for_app(gateway: gateway)]
-                elsif slice
+                if slice
                   [database_for_slice(slice, gateway: gateway)]
-                elsif gateway
-                  # TODO: fix these conditions, it's a bit messy now
+                elsif app
                   [database_for_app(gateway: gateway)]
                 else
                   all_databases

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -44,23 +44,12 @@ module Hanami
                 if slice
                   [database_for_slice(slice, gateway: gateway)]
                 elsif app
-                  [database_for_app(gateway: gateway)]
+                  [database_for_slice(self.app, gateway: gateway)]
                 else
                   all_databases
                 end
 
               databases.flatten
-            end
-
-            def database_for_app(gateway: nil)
-              databases = build_databases(app)
-
-              # TODO: see if we can unify this methid with database_for_slice
-              if gateway
-                databases.fetch(gateway.to_sym) # TODO: raise unknown gateway error for missing key
-              else
-                databases.values
-              end
             end
 
             def database_for_slice(slice, gateway: nil)

--- a/lib/hanami/cli/commands/app/db/create.rb
+++ b/lib/hanami/cli/commands/app/db/create.rb
@@ -9,10 +9,12 @@ module Hanami
           class Create < DB::Command
             desc "Create databases"
 
-            def call(app: false, slice: nil, command_exit: method(:exit), **)
+            option :gateway, required: false, desc: "Use database for gateway"
+
+            def call(app: false, slice: nil, gateway: nil, command_exit: method(:exit), **)
               exit_codes = []
 
-              databases(app: app, slice: slice).each do |database|
+              databases(app: app, slice: slice, gateway: gateway).each do |database|
                 result = database.exec_create_command
                 exit_codes << result.exit_code if result.respond_to?(:exit_code)
 

--- a/lib/hanami/cli/commands/app/db/drop.rb
+++ b/lib/hanami/cli/commands/app/db/drop.rb
@@ -9,10 +9,12 @@ module Hanami
           class Drop < DB::Command
             desc "Delete databases"
 
-            def call(app: false, slice: nil, **)
+            option :gateway, required: false, desc: "Use database for gateway"
+
+            def call(app: false, slice: nil, gateway: nil, **)
               exit_codes = []
 
-              databases(app: app, slice: slice).each do |database|
+              databases(app: app, slice: slice, gateway: gateway).each do |database|
                 result = database.exec_drop_command
                 exit_codes << result.exit_code if result.respond_to?(:exit_code)
 

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -9,12 +9,13 @@ module Hanami
           class Migrate < DB::Command
             desc "Migrates database"
 
+            option :gateway, required: false, desc: "Use database for gateway"
             option :target, desc: "Target migration number", aliases: ["-t"]
             option :dump, required: false, type: :boolean, default: true,
                           desc: "Dump the database structure after migrating"
 
-            def call(target: nil, app: false, slice: nil, dump: true, command_exit: method(:exit), **)
-              databases(app: app, slice: slice).each do |database|
+            def call(target: nil, app: false, slice: nil, gateway: nil, dump: true, command_exit: method(:exit), **)
+              databases(app: app, slice: slice, gateway: gateway).each do |database|
                 if migrations_dir_missing?(database)
                   warn_on_missing_migrations_dir(database)
                 elsif no_migrations?(database)
@@ -24,7 +25,7 @@ module Hanami
                 end
               end
 
-              run_command(Structure::Dump, app: app, slice: slice, command_exit: command_exit) if dump
+              run_command(Structure::Dump, app: app, slice: slice, gateway: gateway, command_exit: command_exit) if dump
             end
 
             private
@@ -36,6 +37,8 @@ module Hanami
                 else
                   database.run_migrations
                 end
+
+                true
               end
             end
 

--- a/lib/hanami/cli/commands/app/db/structure/load.rb
+++ b/lib/hanami/cli/commands/app/db/structure/load.rb
@@ -14,15 +14,17 @@ module Hanami
 
               desc "Loads database from config/db/structure.sql file"
 
+              option :gateway, required: false, desc: "Use database for gateway"
+
               # @api private
-              def call(app: false, slice: nil, command_exit: method(:exit), **)
+              def call(app: false, slice: nil, gateway: nil, command_exit: method(:exit), **)
                 exit_codes = []
 
-                databases(app: app, slice: slice).each do |database|
-                  structure_path = database.slice.root.join(STRUCTURE_PATH)
-                  next unless structure_path.exist?
+                databases(app: app, slice: slice, gateway: gateway).each do |database|
+                  next unless database.structure_file.exist?
 
-                  relative_structure_path = structure_path.relative_path_from(database.slice.app.root)
+                  relative_structure_path = database.structure_file
+                    .relative_path_from(database.slice.app.root)
 
                   measure("#{database.name} structure loaded from #{relative_structure_path}") do
                     catch :load_failed do

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -34,7 +34,7 @@ module Hanami
 
               def self.from_slice(slice:, system_call:)
                 provider = slice.container.providers[:db]
-                raise "this is not a db slice" unless provider
+                raise "No :db provider for #{slice}" unless provider
 
                 provider.source.database_urls.map { |(gateway_name, database_url)|
                   database_scheme = URI(database_url).scheme

--- a/lib/hanami/cli/commands/app/db/version.rb
+++ b/lib/hanami/cli/commands/app/db/version.rb
@@ -9,9 +9,11 @@ module Hanami
           class Version < DB::Command
             desc "Print schema version"
 
+            option :gateway, required: false, desc: "Use database for gateway"
+
             # @api private
-            def call(app: false, slice: nil, **)
-              databases(app: app, slice: slice).each do |database|
+            def call(app: false, slice: nil, gateway: nil, **)
+              databases(app: app, slice: slice, gateway: gateway).each do |database|
                 unless database.migrations_dir?
                   out.puts "=> Cannot find version for slice #{database.slice.slice_name.to_s.inspect}: missing config/db/migrate/ dir"
                   return

--- a/lib/hanami/cli/commands/app/generate/migration.rb
+++ b/lib/hanami/cli/commands/app/generate/migration.rb
@@ -9,15 +9,35 @@ module Hanami
           # @api private
           class Migration < Command
             argument :name, required: true, desc: "Migration name"
+            option :gateway, desc: "Generate migration for gateway"
 
             example [
               %(create_posts),
               %(add_published_at_to_posts),
               %(create_users --slice=admin),
+              %(create_comments --slice=admin --gateway=extra),
             ]
 
             def generator_class
               Generators::App::Migration
+            end
+
+            def call(name:, slice: nil, gateway: nil)
+              if slice
+                generator.call(
+                  key: name,
+                  namespace: slice,
+                  base_path: fs.join("slices", inflector.underscore(slice)),
+                  gateway: gateway
+                )
+              else
+                generator.call(
+                  key: name,
+                  namespace: app.namespace,
+                  base_path: "app",
+                  gateway: gateway
+                )
+              end
             end
           end
         end

--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -17,12 +17,14 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(key:, base_path:, **_opts)
+          def call(key:, base_path:, gateway: nil, **_opts)
             name = inflector.underscore(key)
             ensure_valid_name(name)
 
             base_path = "" if base_path == "app" # Migrations are in root dir, not app/
-            path = fs.join(base_path, "config", "db", "migrate", file_name(name))
+            migrate_dir = gateway ? "#{gateway}_migrate" : "migrate"
+
+            path = fs.join(base_path, "config", "db", migrate_dir, file_name(name))
 
             fs.write(path, FILE_CONTENTS)
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,8 @@ RSpec.configure do |config|
     example.run
     $LOADED_FEATURES.delete(SPEC_ROOT.join("fixtures/test/config/app.rb").to_s)
   end
+
+  RSpec::Matchers.define_negated_matcher :not_change, :change
 end
 
 Dir.glob("#{__dir__}/support/**/*.rb").each { require _1 }

--- a/spec/unit/hanami/cli/commands/app/db/create_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/create_spec.rb
@@ -49,26 +49,26 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "sqlite" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/bookshelf_development.sqlite3"
+        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
       end
 
       it "creates the database" do
         command.call
 
-        expect(Hanami.app.root.join("db", "bookshelf_development.sqlite3").exist?).to be true
+        expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be true
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/bookshelf_development.sqlite3 created"
+        expect(output).to include "database db/app.sqlite3 created"
       end
 
       it "does not create the database if it already exists" do
         FileUtils.mkdir(@dir.join("db"))
-        FileUtils.touch(@dir.join("db", "bookshelf_development.sqlite3"))
+        FileUtils.touch(@dir.join("db", "app.sqlite3"))
 
         command.call
 
-        expect(output).to include "database db/bookshelf_development.sqlite3 created"
+        expect(output).to include "database db/app.sqlite3 created"
       end
     end
 
@@ -133,67 +133,121 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Create, :app_integration do
 
     describe "sqlite" do
       before do
-        ENV["DATABASE_URL"] = "sqlite://db/bookshelf_development.sqlite3"
-        ENV["MAIN__DATABASE_URL"] = "sqlite://db/bookshelf_main_development.sqlite3"
+        ENV["DATABASE_URL"] = "sqlite://db/app.sqlite3"
+        ENV["MAIN__DATABASE_URL"] = "sqlite://db/main.sqlite3"
       end
 
       it "creates each database" do
         command.call
 
-        expect(Hanami.app.root.join("db", "bookshelf_development.sqlite3").exist?).to be true
-        expect(Hanami.app.root.join("db", "bookshelf_main_development.sqlite3").exist?).to be true
+        expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be true
+        expect(Hanami.app.root.join("db", "main.sqlite3").exist?).to be true
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/bookshelf_development.sqlite3 created"
-        expect(output).to include "database db/bookshelf_main_development.sqlite3 created"
+        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).to include "database db/main.sqlite3 created"
       end
 
       it "creates the app database when given --app" do
         command.call(app: true)
 
-        expect(Hanami.app.root.join("db", "bookshelf_development.sqlite3").exist?).to be true
-        expect(Hanami.app.root.join("db", "bookshelf_main_development.sqlite3").exist?).to be false
+        expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be true
+        expect(Hanami.app.root.join("db", "main.sqlite3").exist?).to be false
 
         expect { Hanami.app["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/bookshelf_development.sqlite3 created"
-        expect(output).not_to include "db/bookshelf_main_development.sqlite3"
+        expect(output).to include "database db/app.sqlite3 created"
+        expect(output).not_to include "db/main.sqlite3"
       end
 
       it "creates a slice database when given --slice" do
         command.call(slice: "main")
 
-        expect(Hanami.app.root.join("db", "bookshelf_main_development.sqlite3").exist?).to be true
-        expect(Hanami.app.root.join("db", "bookshelf_development.sqlite3").exist?).to be false
+        expect(Hanami.app.root.join("db", "main.sqlite3").exist?).to be true
+        expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be false
 
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(output).to include "database db/bookshelf_main_development.sqlite3 created"
-        expect(output).not_to include "db/bookshelf_development.sqlite3"
+        expect(output).to include "database db/main.sqlite3 created"
+        expect(output).not_to include "db/app.sqlite3"
       end
 
       it "prints errors for any create commands that fail and exits with non-zero status" do
         allow(system_call).to receive(:call).and_call_original
         allow(system_call)
           .to receive(:call)
-          .with(a_string_matching(/sqlite3.+bookshelf_development.sqlite3/))
+          .with(a_string_matching(/sqlite3.+app.sqlite3/))
           .and_return Hanami::CLI::SystemCall::Result.new(exit_code: 2, out: "", err: "app-db-err")
 
         command.call
 
         expect { Main::Slice["db.gateway"] }.not_to raise_error
 
-        expect(Hanami.app.root.join("db", "bookshelf_development.sqlite3").exist?).to be false
-        expect(Hanami.app.root.join("db", "bookshelf_main_development.sqlite3").exist?).to be true
+        expect(Hanami.app.root.join("db", "app.sqlite3").exist?).to be false
+        expect(Hanami.app.root.join("db", "main.sqlite3").exist?).to be true
 
-        expect(output).to include "failed to create database db/bookshelf_development.sqlite3"
+        expect(output).to include "failed to create database db/app.sqlite3"
         expect(output).to include "app-db-err"
 
-        expect(output).to include "database db/bookshelf_main_development.sqlite3 created"
+        expect(output).to include "database db/main.sqlite3 created"
 
         expect(command).to have_received(:exit).with(2).once
+      end
+
+      context "app with gateways" do
+        def before_prepare
+          write "config/db/.keep", ""
+          ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+        end
+
+        it "creates the databases for all the app's gateways when given --app" do
+          expect { command.call(app: true) }
+            .to change { Hanami.app.root.join("db", "app.sqlite3").exist? }.to(true)
+            .and change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
+
+          expect(output).to include_in_order(
+            "database db/app.sqlite3 created",
+            "database db/app_extra.sqlite3 created",
+          )
+        end
+
+        it "creates the database for an app's gateway when given --app and --gateway" do
+          expect { command.call(app: true, gateway: "extra") }
+            .to change { Hanami.app.root.join("db", "app_extra.sqlite3").exist? }.to(true)
+            .and not_change { Hanami.app.root.join("db", "app.sqlite3").exist? }.from(false)
+
+          expect(output).to include "database db/app_extra.sqlite3 created"
+          expect(output).not_to include "database/app.sqlite3"
+        end
+      end
+
+      context "slice with gateways" do
+        def before_prepare
+          write "slices/main/config/db/.keep", ""
+          ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+        end
+
+        it "creates the databases for all the slices's gateways when given --slice" do
+          expect { command.call(slice: "main") }
+            .to change { Hanami.app.root.join("db", "main.sqlite3").exist? }.to(true)
+            .and change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
+
+          expect(output).to include_in_order(
+            "database db/main.sqlite3 created",
+            "database db/main_extra.sqlite3 created",
+          )
+        end
+
+        it "creates the database for an app's gateway when given --app and --gateway" do
+          expect { command.call(slice: "main", gateway: "extra") }
+            .to change { Hanami.app.root.join("db", "main_extra.sqlite3").exist? }.to(true)
+            .and not_change { Hanami.app.root.join("db", "main.sqlite3").exist? }.from(false)
+
+          expect(output).to include "database db/main_extra.sqlite3 created"
+          expect(output).not_to include "database/main.sqlite3"
+        end
       end
     end
 

--- a/spec/unit/hanami/cli/commands/app/db/version_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/version_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
   subject(:command) { described_class.new(out: out) }
 
   let(:out) { StringIO.new }
-  def output; out.string; end
+  def output = out.string
 
   before do
     @env = ENV.to_h
@@ -98,5 +98,71 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Version, :app_integration do
 
     expect(output).to include %(Cannot find version for slice "admin")
     expect(output).not_to include "current schema version"
+  end
+
+  context "app with gateways" do
+    def before_prepare
+      write "config/db/extra_migrate/20240921211330_create_users.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :users do
+              primary_key :id
+              column :name, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      ENV["DATABASE_URL__EXTRA"] = "sqlite://db/app_extra.sqlite3"
+    end
+
+    it "prints the versions for all an app's databases when given --app" do
+      command.call(app: true)
+
+      expect(output).to include_in_order(
+        "db/app.sqlite3 current schema version is 20240602191330_create_categories",
+        "db/app_extra.sqlite3 current schema version is 20240921211330_create_users",
+      )
+    end
+
+    it "prints the version for a single gateway database when given --app and --gateway" do
+      command.call(app: true, gateway: "extra")
+
+      expect(output).to include "db/app_extra.sqlite3 current schema version is 20240921211330_create_users"
+      expect(output).not_to include "db/app.sqlite3"
+    end
+  end
+
+  context "slice with gateways" do
+    def before_prepare
+      write "slices/main/config/db/extra_migrate/20240921211330_create_users.rb", <<~RUBY
+        ROM::SQL.migration do
+          change do
+            create_table :users do
+              primary_key :id
+              column :name, :text, null: false
+            end
+          end
+        end
+      RUBY
+
+      ENV["MAIN__DATABASE_URL__EXTRA"] = "sqlite://db/main_extra.sqlite3"
+    end
+
+    it "prints the versions for all an app's databases when given --app" do
+      command.call(slice: "main")
+
+      expect(output).to include_in_order(
+        "db/main.sqlite3 current schema version is 20240602211330_create_comments",
+        "db/main_extra.sqlite3 current schema version is 20240921211330_create_users"
+      )
+    end
+
+    it "prints the version for a single gateway database when given --app and --gateway" do
+      command.call(slice: "main", gateway: "extra")
+
+      expect(output).to include "db/main_extra.sqlite3 current schema version is 20240921211330_create_users"
+      expect(output).not_to include "db/main.sqlite3"
+    end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
       expect(output).to eq("Created config/db/migrate/20240713140600_create_posts.rb")
     end
 
+    it "generates a migration for a gateway" do
+      subject.call(name: "create_posts", gateway: "extra")
+
+      expect(fs.read("config/db/extra_migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
+      expect(output).to eq("Created config/db/extra_migrate/20240713140600_create_posts.rb")
+    end
+
     it "generates a migration with underscored version of camel cased name" do
       subject.call(name: "CreatePosts")
 


### PR DESCRIPTION
Update the CLI for the DB gateway support introduced in https://github.com/hanami/hanami/pull/1452:

Add `--gateway` option to the following CLI commands:

- `db structure dump`
- `db structure load`
- `db create`
- `db drop`
- `db migrate`
- `db version`
- `generate migration`

These commands will operate on an individual gateway when the `--gateway` is given. Otherwise, they will operate on all the gateways for a given app or slice (or the app and all slices) based on the other args given, as before.

The above commands work with the following new file structures:

- Migrations for gateways in `config/db/[gateway_name]_migrate/` directories
- Structure files for gateways at `config/db/[gateway_name]_structure.sql`

The `db prepare` and `db seed` commands do _not_ support a `--gateway` option. This is because these commands are intended to operate on an app or slice as a whole. For example, there is only one `db/seeds.rb` file for a slice, and it should seed the tables across  the slice's gateways as appropriate.


