### PR TITLE
Tweak db prepare/migrate/seed for multiple gateways

### DIFF
--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -31,7 +31,7 @@ module Hanami
             def run_command(klass, ...)
               klass.new(
                 out: out,
-                inflector: fs,
+                inflector: inflector,
                 fs: fs,
                 system_call: system_call,
               ).call(...)

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -31,6 +31,8 @@ module Hanami
             private
 
             def migrate_database(database, target:)
+              return true unless database.migrations_dir?
+
               measure "database #{database.name} migrated" do
                 if target
                   database.run_migrations(target: Integer(target))

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -12,7 +12,7 @@ module Hanami
             option :gateway, required: false, desc: "Use database for gateway"
             option :target, desc: "Target migration number", aliases: ["-t"]
             option :dump, required: false, type: :boolean, default: true,
-                          desc: "Dump the database structure after migrating"
+              desc: "Dump the database structure after migrating"
 
             def call(target: nil, app: false, slice: nil, gateway: nil, dump: true, command_exit: method(:exit), **)
               databases(app: app, slice: slice, gateway: gateway).each do |database|

--- a/lib/hanami/cli/commands/app/db/migrate.rb
+++ b/lib/hanami/cli/commands/app/db/migrate.rb
@@ -54,7 +54,7 @@ module Hanami
 
             def warn_on_missing_migrations_dir(database)
               out.puts <<~STR
-                WARNING: Database #{database.name} expects migrations to be located within #{relative_migrations_dir(database)} but that folder does not exist.
+                WARNING: Database #{database.name} expects migrations to be located within #{relative_migrations_path(database)} but that folder does not exist.
 
                 No database migrations can be run for this database.
               STR
@@ -62,16 +62,14 @@ module Hanami
 
             def warn_on_empty_migrations_dir(database)
               out.puts <<~STR
-                NOTE: Empty database migrations folder (#{relative_migrations_dir(database)}) for #{database.name}
+                NOTE: Empty database migrations folder (#{relative_migrations_path(database)}) for #{database.name}
               STR
             end
 
-            def relative_migrations_dir(database)
+            def relative_migrations_path(database)
               database
-                .slice
-                .root
+                .migrations_path
                 .relative_path_from(database.slice.app.root)
-                .join("config", "db", "migrate")
                 .to_s + "/"
             end
           end

--- a/lib/hanami/cli/commands/app/db/prepare.rb
+++ b/lib/hanami/cli/commands/app/db/prepare.rb
@@ -13,12 +13,11 @@ module Hanami
               command_exit = -> code { throw :command_exited, code }
               command_exit_arg = {command_exit: command_exit}
 
-              # Since we're operating on potentially multiple gateways for a given slice, we need to
-              # run our operatiopns in a particular order to satisfy our ROM/Sequel's migrator
-              # setup, which requires _all_ the databases in a slice to be created before we can use
-              # the migrator.
+              # Since any slice may have multiple databases, we need to run the steps below in a
+              # particular order to satisfy our ROM/Sequel's migrator, which requires _all_ the
+              # databases in a slice to be created before we can use it.
               #
-              # So, create/load every database first, before any other operations.
+              # So before we do anything else, make sure to create/load every database first.
               databases(app: app, slice: slice).each do |database|
                 command_args = {
                   **command_exit_arg,

--- a/lib/hanami/cli/commands/app/db/prepare.rb
+++ b/lib/hanami/cli/commands/app/db/prepare.rb
@@ -12,23 +12,47 @@ module Hanami
             def call(app: false, slice: nil, **)
               exit_codes = []
 
+              command_exit = -> code { throw :command_exited, code }
+              command_args = {slice: slice, command_exit: command_exit}
+
+              # Since we're operating on potentially multiple gateways for a given slice, we need to
+              # run our operatiopns in a particular order to satisfy our ROM/Sequel's migrator
+              # setup, which requires _all_ the databases in a slice to be created before we can use
+              # the migrator.
+              #
+              # So, create/load every database first, before any other operations.
               databases(app: app, slice: slice).each do |database|
-                command_exit = -> code { throw :command_exited, code }
-                command_args = {slice: database.slice, command_exit: command_exit}
+                db_command_args = {
+                  **command_args,
+                  app: !slice,
+                  gateway: database.gateway_name.to_s
+                }
 
                 exit_code = catch :command_exited do
                   unless database.exists?
-                    run_command(DB::Create, **command_args)
-                    run_command(DB::Structure::Load, **command_args)
+                    run_command(DB::Create, **db_command_args)
+                    run_command(DB::Structure::Load, **db_command_args)
                   end
 
-                  run_command(DB::Migrate, **command_args)
-                  run_command(DB::Seed, **command_args)
                   nil
                 end
 
                 exit_codes << exit_code if exit_code
               end
+
+              # Once all databases are created, the migrator will load, and we can migrate each one.
+              databases(app: app, slice: slice).each do |database|
+                db_command_args = {
+                  **command_args,
+                  app: !slice,
+                  gateway: database.gateway_name.to_s
+                }
+
+                run_command(DB::Migrate, **db_command_args)
+              end
+
+              # Finally, load the seeds for the slice overall, which is a once-per-slice operation.
+              run_command(DB::Seed, **command_args)
 
               exit_codes.each do |code|
                 break exit code if code > 0

--- a/lib/hanami/cli/commands/app/db/utils/database.rb
+++ b/lib/hanami/cli/commands/app/db/utils/database.rb
@@ -162,6 +162,8 @@ module Hanami
               end
 
               def schema_migrations_sql_dump
+                return unless migrations_dir?
+
                 sql = +"INSERT INTO schema_migrations (filename) VALUES\n"
                 sql << applied_migrations.map { |v| "('#{v}')" }.join(",\n")
                 sql << ";"


### PR DESCRIPTION
Fix a range of issues detected during manual testing with a (soon-to-be) 2.2.beta2 app with multiple DB gateways configured for the app:

- `db prepare` was failing, since the ROM/Sequel migrator needs every configured getaway to have its database created before the migrator can run. To fix this, change the order of the nested `db prepare` commands, so that `db create` and `db structure load` are run first for _every_ detected database. After that is done, move onto `db migrate` for each detected database. Finally, run `db seed`.
- Given that `db prepare` now runs commands in a mixed order (i.e. no longer a single slice at a time), change the handling of command failures such that they halt and exit the entire command immediately. This should make it easier for the user to identify and address failures, and reduces the chance of unexpected outcomes from latter steps being impacted by earlier failures.
- `db seed` should run only once for each slice, but our internal `#databases` method will yield for each database, so when a slice has multiple gateways, we were trying to seed it multiple times. To fix this, track the seeded slices and skip seeding for subsequence detected databases if the slice has already been seeded.
- Various errors were raised from the ROM/Sequel migrator if a gateway is configured but does not yet have a real migrations dir (e.g. `config/db/[gateway_name]_migrate/`). This would occur in both `db migrate` as well as `db structure dump` (which uses the migrator to know the applied migrations to include at the bottom of the structure file). To fix these, skip attempting to load the migrator for a gateway database if there is no matching migration dir found.
- Update the warnings around empty migration paths to respect the naming of migration dirs for gateways.
- Fix bug arising in `db prepare` from us accidentally assigning the `fs` as a DB command's `inflector`.

I've updated the existing `db prepare` specs to reflect this new behaviour, where applicable. We would do well to add another couple of examples for the edge cases above (e.g. missing migration dirs), but I'm going to defer those until later, so we don't delay a timely 2.2.0.beta2 release this week. See #235 as a reminder to come back and add those tests.