### PR TITLE
Fix error dumping structure when no migrations

### DIFF
--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -31,8 +31,11 @@ module Hanami
                         throw :dump_failed, false
                       end
 
-                      File.open(database.structure_file, "a") do |f|
-                        f.puts "#{database.schema_migrations_sql_dump}\n"
+                      migrations_sql = database.schema_migrations_sql_dump
+                      if migrations_sql
+                        File.open(database.structure_file, "a") do |f|
+                          f.puts "#{migrations_sql}\n"
+                        end
                       end
 
                       true

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -55,11 +55,14 @@ module Hanami
               end
 
               def schema_migrations_sql_dump
+                migrations_sql = super
+                return unless migrations_sql
+                
                 search_path = slice["db.gateway"].connection
                   .fetch("SHOW search_path").to_a.first
                   .fetch(:search_path)
 
-                +"SET search_path TO #{search_path};\n\n" << super
+                +"SET search_path TO #{search_path};\n\n" << migrations_sql
               end
 
               private


### PR DESCRIPTION
Address the error attmpting to implicitly convert nil into a string.

While here, avoid appending spurious newlines to the structure file when there are no migrations.

Fixes #239