### PR TITLE
Use relevant gateway for fetching search_path

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -58,7 +58,7 @@ module Hanami
                 migrations_sql = super
                 return unless migrations_sql
                 
-                search_path = slice["db.gateway"].connection
+                search_path = gateway.connection
                   .fetch("SHOW search_path").to_a.first
                   .fetch(:search_path)
 


### PR DESCRIPTION
Now that the `db` CLI commands support multiple gateways, we need to use the relevant gateway when preparing this line of SQL.