### PR TITLE
Add `--env` (or `-e`) option to all app commands

### DIFF
--- a/lib/hanami/cli/commands/app/command.rb
+++ b/lib/hanami/cli/commands/app/command.rb
@@ -18,8 +18,8 @@ module Hanami
           # @api private
           ACTION_SEPARATOR = "." # TODO: rename to container key separator
 
-          # Overloads {Hanami::CLI::Commands::App::Command#call} to ensure an appropriate `HANAMI_ENV`
-          # environment variable is set.
+          # Overloads {Hanami::CLI::Commands::App::Command#call} to ensure an appropriate
+          # `HANAMI_ENV` environment variable is set.
           #
           # Uses an `--env` option if provided, then falls back to an already-set `HANAMI_ENV`
           # environment variable, and defaults to "development" in the absence of both.
@@ -27,6 +27,12 @@ module Hanami
           # @since 2.0.0
           # @api private
           module Environment
+            # @since 2.2.0
+            # @api private
+            def self.prepended(klass)
+              klass.option :env, desc: "App environment (development, test, production)", aliases: ["e"]
+            end
+
             # @since 2.0.0
             # @api private
             def call(*args, **opts)
@@ -37,7 +43,7 @@ module Hanami
               ENV["HANAMI_ENV"] = hanami_env
               Hanami::Env.load
 
-              super(*args, **opts)
+              super
             end
           end
 


### PR DESCRIPTION
This allows app commands to be invoked with e.g. `-e test` instead of being prepended with `HANAMI_ENV=test`, which is awkward.

This change simply adds the `option` declaration to register the `:env` option with the command classes. The handling of the `env:` argument was already in place.

Resolves #214