### PR TITLE
Make default MySQL database URL work with Homebrew

### DIFF
--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -112,7 +112,7 @@ module Hanami
           elsif generate_postgres?
             "postgres://localhost/#{app}"
           elsif generate_mysql?
-            "mysql2://localhost/#{app}"
+            "mysql2://root@localhost/#{app}"
           else
             raise "Unknown database option: #{database_option}"
           end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1243,7 +1243,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
-          expect(fs.read(".env")).to include("DATABASE_URL=mysql2://localhost/#{app}")
+          expect(fs.read(".env")).to include("DATABASE_URL=mysql2://root@localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
         end
@@ -1255,7 +1255,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         fs.chdir(app) do
           expect(fs.read("Gemfile")).to include("hanami-db")
           expect(fs.read("Gemfile")).to include("mysql2")
-          expect(fs.read(".env")).to include("DATABASE_URL=mysql2://localhost/#{app}")
+          expect(fs.read(".env")).to include("DATABASE_URL=mysql2://root@localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
         end


### PR DESCRIPTION
Specify the root user, which is required to connect to MySQL as installed by homebrew.

Resolves #248