### PR TITLE
Remove boilerplate from generated app operation

### DIFF
--- a/lib/hanami/cli/generators/gem/app/operation.erb
+++ b/lib/hanami/cli/generators/gem/app/operation.erb
@@ -5,9 +5,5 @@ require "dry/operation"
 
 module <%= camelized_app_name %>
   class Operation < Dry::Operation
-    <%- if generate_db? -%>
-    # Provide `transaction do ... end` method for database transactions
-    include Dry::Operation::Extensions::ROM
-    <%- end -%>
   end
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -455,8 +455,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         module #{inflector.camelize(app)}
           class Operation < Dry::Operation
-            # Provide `transaction do ... end` method for database transactions
-            include Dry::Operation::Extensions::ROM
           end
         end
       EXPECTED


### PR DESCRIPTION
Now that https://github.com/hanami/hanami/pull/1456 is merged and the ROM extension is automatically included in operations inside Hanami apps, we no longer need to generate the boilerplate.