### PR TITLE
Stop IRB prompt from shifting width

### DIFF
--- a/lib/hanami/cli/repl/irb.rb
+++ b/lib/hanami/cli/repl/irb.rb
@@ -24,8 +24,8 @@ module Hanami
             AUTO_INDENT: true,
             PROMPT_I: "#{prompt}> ",
             PROMPT_N: "#{prompt}> ",
-            PROMPT_S: "#{prompt} %l> ",
-            PROMPT_C: "#{prompt} ?> ",
+            PROMPT_S: "#{prompt}%l ",
+            PROMPT_C: "#{prompt}* ",
             RETURN: "=> %s\n"
           }
 


### PR DESCRIPTION
Don’t add an extra space when the prompt enters its PROMPT_S (continued strings) and PROMPT_C (continued statements) modes.