### PR TITLE
Simplify dry-types version constraint in Gemfile

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -14,7 +14,7 @@ source "https://rubygems.org"
 <%= hanami_gem("validations") %>
 <%= hanami_gem("view") %>
 
-gem "dry-types", "~> 1.0", ">= 1.6.1"
+gem "dry-types", "~> 1.7"
 gem "dry-operation"
 gem "puma"
 gem "rake"

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gem "hanami-validations", "#{hanami_version}"
         gem "hanami-view", "#{hanami_version}"
 
-        gem "dry-types", "~> 1.0", ">= 1.6.1"
+        gem "dry-types", "~> 1.7"
         gem "dry-operation"
         gem "puma"
         gem "rake"
@@ -502,7 +502,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "hanami-validations", github: "hanami/validations", branch: "main"
           gem "hanami-view", github: "hanami/view", branch: "main"
 
-          gem "dry-types", "~> 1.0", ">= 1.6.1"
+          gem "dry-types", "~> 1.7"
           gem "dry-operation"
           gem "puma"
           gem "rake"
@@ -596,7 +596,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "hanami-validations", "#{hanami_version}"
           gem "hanami-view", "#{hanami_version}"
 
-          gem "dry-types", "~> 1.0", ">= 1.6.1"
+          gem "dry-types", "~> 1.7"
           gem "dry-operation"
           gem "puma"
           gem "rake"


### PR DESCRIPTION
Now that 1.7 is out, we can get away with just a single version constraint, rather than two.