### PR TITLE
Update migration link to point to Hanami website

### DIFF
--- a/lib/hanami/cli/generators/app/migration.rb
+++ b/lib/hanami/cli/generators/app/migration.rb
@@ -55,7 +55,7 @@ module Hanami
             ROM::SQL.migration do
               # Add your migration here.
               #
-              # See https://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html for details.
+              # See https://guides.hanamirb.org/v2.2/database/migrations/ for details.
               change do
               end
             end

--- a/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
       ROM::SQL.migration do
         # Add your migration here.
         #
-        # See https://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html for details.
+        # See https://guides.hanamirb.org/v2.2/database/migrations/ for details.
         change do
         end
       end


### PR DESCRIPTION
There's an official location for Hanami docs now, it does ultimately link back to Sequel's docs but those have a bunch of extraneous information that isn't pertinent for a Hanami project.