### PR TITLE
Allow --skip-db and --database to be given, preferring --skip-db

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -126,7 +126,6 @@ module Hanami
             app = inflector.underscore(app)
 
             raise PathAlreadyExistsError.new(app) if fs.exist?(app)
-            raise ConflictingOptionsError.new("--skip-db", "--database") if skip_db && database
 
             normalized_database ||= normalize_database(database)
 

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1288,13 +1288,5 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         "`foodb' is not a supported database. Supported databases are: sqlite, postgres, mysql"
       )
     end
-
-    it "doesn't allow --skip-db && --database" do
-      expect {
-        subject.call(app: app, database: "sqlite", skip_db: true)
-      }.to raise_error(
-        Hanami::CLI::ConflictingOptionsError
-      ).with_message("`--skip-db' and `--database' cannot be used together")
-    end
   end
 end


### PR DESCRIPTION
Raising a conflicting options error when both are given is a problem, because we _default_ the `database` option to be “sqlite”, which means it’s impossible for the user to un-set.

Instead or raising an error, simply allow `—skip-db` to take priority when given. This means if it is given together with `--database`, the `--database` option will be ignored.

Fixes #267