### PR TITLE
Bundle install during hanami install

### DIFF
--- a/lib/hanami/cli/commands/app/install.rb
+++ b/lib/hanami/cli/commands/app/install.rb
@@ -33,9 +33,21 @@ module Hanami
           # @api private
           option :head, type: :flag, desc: "Install head deps", default: DEFAULT_HEAD
 
+          # @api private
+          private attr_reader :bundler
+
+          def initialize(
+            fs:,
+            bundler: CLI::Bundler.new(fs: fs),
+            **opts
+          )
+            @bundler = bundler
+          end
+
           # @since 2.0.0
           # @api private
           def call(head: DEFAULT_HEAD, **)
+            bundler.install!
           end
         end
       end

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -143,11 +143,11 @@ module Hanami
                 if skip_install
                   out.puts "Skipping installation, please enter `#{app}' directory and run `bundle exec hanami install'"
                 else
-                  out.puts "Running Bundler install..."
+                  out.puts "Running bundle install..."
                   bundler.install!
 
                   unless skip_assets
-                    out.puts "Running NPM install..."
+                    out.puts "Running npm install..."
                     system_call.call("npm", ["install"]).tap do |result|
                       unless result.successful?
                         puts "NPM ERROR:"
@@ -156,7 +156,7 @@ module Hanami
                     end
                   end
 
-                  out.puts "Running Hanami install..."
+                  out.puts "Running hanami install..."
                   run_install_command!(head: head)
                 end
               end

--- a/spec/unit/hanami/cli/commands/app/install_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/install_spec.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Install do
-  subject { described_class.new(out: stdout) }
-  let(:stdout) { StringIO.new }
+  subject { described_class.new(fs: fs, bundler: bundler, out: out) }
+
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+  let(:bundler) { Hanami::CLI::Bundler.new(fs: fs) }
+  let(:out) { StringIO.new }
 
   describe "#call" do
     it "installs third-party plugins" do
+      expect(bundler).to receive(:install!)
+        .exactly(1).time
+        .and_return(true)
+
       subject.call
 
-      stdout.rewind
-      expect(stdout.read.chomp).to eq("")
+      out.rewind
+      expect(out.read.chomp).to eq("")
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -88,8 +88,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     expect(fs.directory?(app)).to be(true)
     expect(output).to include("Created #{app}/")
     expect(output).to include("-> Within #{app}/")
-    expect(output).to include("Running Bundler install...")
-    expect(output).to include("Running Hanami install...")
+    expect(output).to include("Running bundle install...")
+    expect(output).to include("Running npm install...")
+    expect(output).to include("Running hanami install...")
 
     fs.chdir(app) do
       # .gitignore
@@ -551,8 +552,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       expect(fs.directory?(app)).to be(true)
       expect(output).to include("Created #{app}/")
       expect(output).to include("-> Within #{app}/")
-      expect(output).to include("Running Bundler install...")
-      expect(output).to include("Running Hanami install...")
+      expect(output).to include("Running bundle install...")
+      expect(output).to include("Running npm install...")
+      expect(output).to include("Running hanami install...")
 
       fs.chdir(app) do
         # .gitignore


### PR DESCRIPTION
This will ensure that gems added to the `Gemfile` by our first-party extensions (hanami-cli) are installed during `hanami new`, rather than requiring the user to run their own manual `bundle install` afterwards.

This requires the first-party extension gems to use a `before "install"` command hook, instead of the current `after "install"`.

See also https://github.com/hanami/rspec/pull/30

Fixes #265