### PR TITLE
[WIP] Only include one --env option

### DIFF
--- a/lib/hanami/cli/commands/app/command.rb
+++ b/lib/hanami/cli/commands/app/command.rb
@@ -51,7 +51,7 @@ module Hanami
           # @api private
           def self.inherited(klass)
             super
-            klass.prepend(Environment)
+            klass.prepend(Environment) unless klass.ancestors.include?(Environment)
           end
 
           # Returns the Hanami app class.


### PR DESCRIPTION
With Hanami 2.2.1, --env shows up twice for generate commands.

```
Options:
  --env=VALUE, -e VALUE             # App environment (development, test, production)
  --slice=VALUE                     # Slice name
  --env=VALUE, -e VALUE             # App environment (development, test, production)
  --help, -h                        # Print this help
```

This is due to `klass.prepend(Environment)` being run twice whenever we subclass `App::Command` (like we do for `App::Generate::Command`)

This change fixes that... but it breaks our specs for the feature that automatically runs db commands in `test` env when running them for development, from #247

I _think_ it's because the prepending the Environment module several times ensures it's at the top of the ancestors list.

For `hanami db migrate` failure:
```ruby
# self.class.ancestors inside the Migrate command, *without* this PR, manually formatted for reading
[
  Hanami::CLI::Commands::App::Command::Environment
  Hanami::CLI::Commands::App::DB::Migrate, 
  Hanami::CLI::Commands::App::Command::Environment, 
  Hanami::CLI::Commands::App::DB::Command, 
  Hanami::CLI::Commands::App::Command, 
  Hanami::CLI::Command, 
  Dry::CLI::Command, 
  Object, 
  JSON::Ext::Generator::GeneratorMethods::Object, 
  Kernel, 
  BasicObject
]
```

You can see `Environment` is duplicated there, and at the start of the list.