### PR TITLE
Fail `hanami db drop` when cannot check database existence

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -29,8 +29,9 @@ module Hanami
               # @since 2.2.0
               def exists?
                 result = exec_cli("mysql", %(-e "SHOW DATABASES LIKE '#{name}'" --batch))
+                raise Hanami::CLI::DatabaseExistenceCheckError.new(result.err) unless result.successful?
 
-                result.successful? && result.out != ""
+                result.out != ""
               end
 
               # @api private

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -33,7 +33,9 @@ module Hanami
               # @since 2.2.0
               def exists?
                 result = system_call.call("psql -t -A -c '\\list #{escaped_name}'", env: cli_env_vars)
-                result.successful? && result.out.include?("#{name}|") # start_with?
+                raise Hanami::CLI::DatabaseExistenceCheckError.new(result.err) unless result.successful?
+
+                result.out.include?("#{name}|") # start_with?
               end
 
               # @api private

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -116,6 +116,14 @@ module Hanami
 
     # @since 2.2.0
     # @api public
+    class DatabaseExistenceCheckError < Error
+      def initialize(original_message)
+        super("Could not check if the database exists. Error message:\n#{original_message}")
+      end
+    end
+
+    # @since 2.2.0
+    # @api public
     class ConflictingOptionsError < Error
       def initialize(option1, option2)
         super("`#{option1}' and `#{option2}' cannot be used together")


### PR DESCRIPTION
Currently if the existence check for a database fails (for example due to whole database server being down or user not existing), Hanami CLI will anyway return information that the database was dropped.

This changes it to failing with an explicit error message in such case. Examples:

```
$ hanami db drop
Could not check if the database exists. Error message:
psql: error: connection to server at "localhost" (::1), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
```

```
$ hanami db drop
Could not check if the database exists. Error message:
psql: error: connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "katafrakt" does not exist
```

Addresses #275 