### PR TITLE
Add Ruby 3.4 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"


### PR DESCRIPTION
Draft until https://github.com/hanami/router/pull/276 is merged, then CI _might_ pass for 3.4. I'm not sure if there's some other ROM related fixes that need to be merged first (in forthcoming rom 5.4 / rom-sql 3.7)