### PR TITLE
Add support for Rack 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ end
 
 gem "hanami", github: "hanami/hanami", branch: "main"
 gem "hanami-assets", github: "hanami/assets", branch: "main"
-gem "hanami-controller", github: "kyleplump/controller", branch: "rack3"
+gem "hanami-controller", github: "hanami/controller", branch: "main"
 gem "hanami-db", github: "hanami/db", branch: "main"
-gem "hanami-router", github: "kyleplump/router", branch: "rack3"
+gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
@@ -24,7 +24,7 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3"
 
-gem "hanami-devtools", github: "kyleplump/devtools", branch: "rack3"
+gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
 group :test do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -11,20 +11,20 @@ end
 
 gem "hanami", github: "hanami/hanami", branch: "main"
 gem "hanami-assets", github: "hanami/assets", branch: "main"
-gem "hanami-controller", github: "hanami/controller", branch: "main"
+gem "hanami-controller", github: "kyleplump/controller", branch: "rack3"
 gem "hanami-db", github: "hanami/db", branch: "main"
-gem "hanami-router", github: "hanami/router", branch: "main"
+gem "hanami-router", github: "kyleplump/router", branch: "rack3"
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
 
-gem "rack"
+gem "rack", "~> 3.1"
 
 gem "mysql2"
 gem "pg"
 gem "sqlite3"
 
-gem "hanami-devtools", github: "hanami/devtools", branch: "main"
+gem "hanami-devtools", github: "kyleplump/devtools", branch: "rack3"
 
 group :test do
   gem "pry"

--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-inflector", "~> 1.0", "< 2"
   spec.add_dependency "rake", "~> 13.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
+  spec.add_dependency "rackup"
 
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "rubocop", "~> 1.0"

--- a/lib/hanami/cli/commands/app/server.rb
+++ b/lib/hanami/cli/commands/app/server.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "rack"
 require "hanami/port"
 require_relative "../app"
 require_relative "../../server"

--- a/lib/hanami/cli/server.rb
+++ b/lib/hanami/cli/server.rb
@@ -26,7 +26,7 @@ module Hanami
 
       # @since 2.0.0
       # @api private
-      def initialize(rack_server: Rack::Server)
+      def initialize(rack_server: Rackup::Server)
         @rack_server = rack_server
       end
 

--- a/lib/hanami/cli/server.rb
+++ b/lib/hanami/cli/server.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rackup"
+
 module Hanami
   module CLI
     # @since 2.0.0


### PR DESCRIPTION
updates to Rack 3. one part of many gem updates

[list of changes](https://github.com/hanami/router/pull/277)

## highlights
adds rackup as an [explicit dependency](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#binrackup-rackserver-rackhandlerand--racklobster-were-moved-to-a-separate-gem)

----
bringing back a previously inadvertently closed [PR](https://github.com/hanami/cli/pull/283)