### PR TITLE
Allow source control of public/404,500.html via gitignore

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gitignore.erb
+++ b/lib/hanami/cli/generators/gem/app/gitignore.erb
@@ -1,7 +1,9 @@
 .env*.local
 log/*
 <%- if generate_assets? -%>
-public/
+public/*
+!public/404.html
+!public/500.html
 node_modules/
 <%- end -%>
 <%- if generate_sqlite? -%>

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -108,7 +108,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       gitignore = <<~EXPECTED
         .env*.local
         log/*
-        public/
+        public/*
+        !public/404.html
+        !public/500.html
         node_modules/
         db/*.sqlite
       EXPECTED
@@ -586,7 +588,9 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gitignore = <<~EXPECTED
           .env*.local
           log/*
-          public/
+          public/*
+          !public/404.html
+          !public/500.html
           node_modules/
           db/*.sqlite
         EXPECTED


### PR DESCRIPTION
Closes [#285](https://github.com/hanami/cli/issues/285)

When generating the .gitignore file on `hanami new`, allow the `public/404.html` and `public/500.html` files, while keeping the rest of `public/` ignored.

please let me know if you'd like to see any changes. thanks!


-----
reopening after unintentionally closing [#286](https://github.com/hanami/cli/pull/286)