### PR TITLE
Clarify customizability of config/assets.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Hanami Command Line Interface
 
+## Unreleased
+
+### Changed
+
+- Expand on comments `config/assets.js` and enable customization function by default (@robyurkowski in #293)
+
 ## v2.2.1 - 2024-11-12
 
 ### Changed

--- a/lib/hanami/cli/generators/gem/app/assets.js
+++ b/lib/hanami/cli/generators/gem/app/assets.js
@@ -1,19 +1,17 @@
 import * as assets from "hanami-assets";
 
-/*
-  Front-end builds are powered by esbuild (https://esbuild.github.io)
-  and can be customized below. Read more at: 
-  https://guides.hanamirb.org/assets/customization/
-*/
+// Assets are managed by esbuild (https://esbuild.github.io), and can be
+// customized below.
+//
+// Learn more at https://guides.hanamirb.org/assets/customization/.
 
 await assets.run({
   esbuildOptionsFn: (args, esbuildOptions) => {
-    /* 
-      You can modify or add to Hanami's preset esbuild options here.
-      Use `args.watch` as a condition for different options for 
-      `hanami assets compile` vs `hanami assets watch`.
-    */
+    // Customize your `esbuildOptions` here.
+    //
+    // Use the `args.watch` boolean as a condition to apply diffierent options
+    // when running `hanami assets watch` vs `hanami assets compile`.
 
     return esbuildOptions;
-  }
+  },
 });

--- a/lib/hanami/cli/generators/gem/app/assets.js
+++ b/lib/hanami/cli/generators/gem/app/assets.js
@@ -1,16 +1,19 @@
 import * as assets from "hanami-assets";
 
-await assets.run();
+/*
+  Front-end builds are powered by esbuild (https://esbuild.github.io)
+  and can be customized below. Read more at: 
+  https://guides.hanamirb.org/assets/customization/
+*/
 
-// To provide additional esbuild (https://esbuild.github.io) options, use the following:
-//
-// Read more at: https://guides.hanamirb.org/assets/customization/
-//
-// await assets.run({
-//   esbuildOptionsFn: (args, esbuildOptions) => {
-//     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
-//     // compile vs watch.
-//
-//     return esbuildOptions;
-//   }
-// });
+await assets.run({
+  esbuildOptionsFn: (args, esbuildOptions) => {
+    /* 
+      You can modify or add to Hanami's preset esbuild options here.
+      Use `args.watch` as a condition for different options for 
+      `hanami assets compile` vs `hanami assets watch`.
+    */
+
+    return esbuildOptions;
+  }
+});

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -260,20 +260,21 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       assets = <<~EXPECTED
         import * as assets from "hanami-assets";
 
-        await assets.run();
+        // Assets are managed by esbuild (https://esbuild.github.io), and can be
+        // customized below.
+        //
+        // Learn more at https://guides.hanamirb.org/assets/customization/.
 
-        // To provide additional esbuild (https://esbuild.github.io) options, use the following:
-        //
-        // Read more at: https://guides.hanamirb.org/assets/customization/
-        //
-        // await assets.run({
-        //   esbuildOptionsFn: (args, esbuildOptions) => {
-        //     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
-        //     // compile vs watch.
-        //
-        //     return esbuildOptions;
-        //   }
-        // });
+        await assets.run({
+          esbuildOptionsFn: (args, esbuildOptions) => {
+            // Customize your `esbuildOptions` here.
+            //
+            // Use the `args.watch` boolean as a condition to apply diffierent options
+            // when running `hanami assets watch` vs `hanami assets compile`.
+
+            return esbuildOptions;
+          },
+        });
       EXPECTED
       expect(fs.read("config/assets.js")).to eq(assets)
       expect(output).to include("Created config/assets.js")
@@ -606,15 +607,15 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           # #{inflector.camelize(app)}
 
           Welcome to your Hanami app!
-  
+
           ## Getting Started
-  
+
           - Run the server with `bin/dev`
           - View the app at [http://localhost:2300](http://localhost:2300)
           - Run the tests with `bundle exec rake`
-  
+
           ## Useful Links
-  
+
           - [Hanami Home](http://hanamirb.org)
           - [Hanami Guides](https://guides.hanamirb.org/)
           - [Hanami API Doc](https://gemdocs.org/gems/hanami/latest)
@@ -738,20 +739,21 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         assets = <<~EXPECTED
           import * as assets from "hanami-assets";
 
-          await assets.run();
+          // Assets are managed by esbuild (https://esbuild.github.io), and can be
+          // customized below.
+          //
+          // Learn more at https://guides.hanamirb.org/assets/customization/.
 
-          // To provide additional esbuild (https://esbuild.github.io) options, use the following:
-          //
-          // Read more at: https://guides.hanamirb.org/assets/customization/
-          //
-          // await assets.run({
-          //   esbuildOptionsFn: (args, esbuildOptions) => {
-          //     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
-          //     // compile vs watch.
-          //
-          //     return esbuildOptions;
-          //   }
-          // });
+          await assets.run({
+            esbuildOptionsFn: (args, esbuildOptions) => {
+              // Customize your `esbuildOptions` here.
+              //
+              // Use the `args.watch` boolean as a condition to apply diffierent options
+              // when running `hanami assets watch` vs `hanami assets compile`.
+
+              return esbuildOptions;
+            },
+          });
         EXPECTED
         expect(fs.read("config/assets.js")).to eq(assets)
         expect(output).to include("Created config/assets.js")


### PR DESCRIPTION
Previously, there was a line that was just `await assets.run()` that was not commented, and a commented block that was suggested for customization. As a result, it was possible that the initial line would be left when enabling the block, which causes a double-build and can also cause a lot of confusion once some customization is added. 

Given that the default customization function doesn't do anything, the computational cost of just executing it seems acceptable to simplify the setup and reduce the chance of frustration.

(I know this because I ran into this issue while adding Tailwind and PostCSS, and wound up being confused why builds were failing to find Tailwind. Real PEBKAC, but I hope that this would help save someone else the grief. I also expanded the comments on the file to try and tip people off that Hanami adds some configuration so that they don't also just accidentally clobber it like I did.)