### PR TITLE
Add `irb`gem as a runtime dependency

### DIFF
--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-cli", "~> 1.0", ">= 1.1.0"
   spec.add_dependency "dry-files", "~> 1.0", ">= 1.0.2", "< 2"
   spec.add_dependency "dry-inflector", "~> 1.0", "< 2"
+  spec.add_dependency "irb"
   spec.add_dependency "rake", "~> 13.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
 


### PR DESCRIPTION
`irb` will be a bundled gem from Ruby 3.5.
https://bugs.ruby-lang.org/issues/20309

So if we use `irb` as the standard library, Bundler shows the following warning.

```
lib/ruby/gems/3.4.0/gems/hanami-cli-2.2.1/lib/hanami/cli/repl/irb.rb:3: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

This PR adds the `irb` to a runtime dependency to fix the warning.