### PR TITLE
Add simple git init at the end of new hanami app command

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -162,6 +162,9 @@ module Hanami
 
                   out.puts "Running hanami install..."
                   run_install_command!(head: head)
+
+                  out.puts "Initializing git repository..."
+                  init_git_repository
                 end
               end
             end
@@ -194,6 +197,16 @@ module Hanami
                 bundler.exec("check").successful? || bundler.exec("install")
               else
                 raise HanamiInstallError.new(result.err)
+              end
+            end
+          end
+
+          # @api private
+          def init_git_repository
+            system_call.call("git", ["init"]).tap do |result|
+              unless result.successful?
+                out.puts "WARNING: Failed to initialize git repository"
+                out.puts(result.err.lines.map { |line| line.prepend("    ") })
               end
             end
           end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1350,4 +1350,28 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
       )
     end
   end
+
+  it "initializes a git repository" do
+    expect(bundler).to receive(:install!)
+      .and_return(true)
+
+    expect(bundler).to receive(:exec)
+      .with("hanami install")
+      .and_return(successful_system_call_result)
+
+    expect(bundler).to receive(:exec)
+      .with("check")
+      .at_least(1)
+      .and_return(successful_system_call_result)
+
+    expect(system_call).to receive(:call).with("npm", ["install"])
+
+    expect(system_call).to receive(:call).with("git", ["init"])
+      .and_return(successful_system_call_result)
+
+    subject.call(app: app, **kwargs)
+
+    expect(fs.directory?(app)).to be(true)
+    expect(output).to include("Initializing git repository...")
+  end
 end


### PR DESCRIPTION
Adding simple git repo initialization, with similar code to npm install (as for handling error display). Running it after the main install command