### PR TITLE
Add app level --skip-view flag

### DIFF
--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -32,6 +32,11 @@ module Hanami
 
           # @since 2.2.0
           # @api private
+          SKIP_VIEW_DEFAULT = false
+          private_constant :SKIP_VIEW_DEFAULT
+
+          # @since 2.2.0
+          # @api private
           DATABASE_SQLITE = "sqlite"
 
           # @since 2.2.0
@@ -81,6 +86,12 @@ module Hanami
 
           # @since 2.2.0
           # @api private
+          option :skip_view, type: :flag, required: false,
+                             default: SKIP_VIEW_DEFAULT,
+                             desc: "Skip including hanami-view"
+
+          # @since 2.2.0
+          # @api private
           option :database, type: :string, required: false,
                             default: DATABASE_SQLITE,
                             desc: "Database adapter (supported: sqlite, mysql, postgres)"
@@ -92,6 +103,7 @@ module Hanami
             "bookshelf --skip-install                     # Generate a new Hanami app, but it skips Hanami installation",
             "bookshelf --skip-assets                      # Generate a new Hanami app without hanmai-assets",
             "bookshelf --skip-db                          # Generate a new Hanami app without hanami-db",
+            "bookshelf --skip-view                        # Generate a new Hanami app without hanami-view",
             "bookshelf --database={sqlite|postgres|mysql} # Generate a new Hanami app with a specified database (default: sqlite)",
           ]
           # rubocop:enable Layout/LineLength
@@ -123,6 +135,7 @@ module Hanami
             skip_install: SKIP_INSTALL_DEFAULT,
             skip_assets: SKIP_ASSETS_DEFAULT,
             skip_db: SKIP_DB_DEFAULT,
+            skip_view: SKIP_VIEW_DEFAULT,
             database: nil
           )
             # rubocop:enable Metrics/ParameterLists
@@ -141,6 +154,7 @@ module Hanami
                 head: head,
                 skip_assets: skip_assets,
                 skip_db: skip_db,
+                skip_view: skip_view,
                 database: normalized_database
               )
               generator.call(app, context: context) do

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -88,6 +88,12 @@ module Hanami
 
         # @since 2.2.0
         # @api private
+        def generate_view?
+          !options.fetch(:skip_view, false)
+        end
+
+        # @since 2.2.0
+        # @api private
         def generate_sqlite?
           generate_db? && database_option == Commands::Gem::New::DATABASE_SQLITE
         end

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -61,6 +61,9 @@ module Hanami
               fs.create("app/view.rb", t("view.erb", context))
               fs.create("app/views/helpers.rb", t("helpers.erb", context))
               fs.create("app/templates/layouts/app.html.erb", t("app_layout.erb", context))
+
+              fs.create("public/404.html", file("404.html"))
+              fs.create("public/500.html", file("500.html"))
             end
 
             if context.generate_assets?
@@ -90,9 +93,6 @@ module Hanami
             end
 
             fs.create("app/operation.rb", t("operation.erb", context))
-
-            fs.create("public/404.html", file("404.html"))
-            fs.create("public/500.html", file("500.html"))
           end
 
           def template(path, context)

--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -56,9 +56,12 @@ module Hanami
 
             fs.create("app/actions/.keep", t("keep.erb", context))
             fs.create("app/action.rb", t("action.erb", context))
-            fs.create("app/view.rb", t("view.erb", context))
-            fs.create("app/views/helpers.rb", t("helpers.erb", context))
-            fs.create("app/templates/layouts/app.html.erb", t("app_layout.erb", context))
+
+            if context.generate_view?
+              fs.create("app/view.rb", t("view.erb", context))
+              fs.create("app/views/helpers.rb", t("helpers.erb", context))
+              fs.create("app/templates/layouts/app.html.erb", t("app_layout.erb", context))
+            end
 
             if context.generate_assets?
               fs.create("package.json", t("package.json.erb", context))

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -12,7 +12,9 @@ source "https://rubygems.org"
 <%- end -%>
 <%= hanami_gem("router") %>
 <%= hanami_gem("validations") %>
+<%- if generate_view? -%>
 <%= hanami_gem("view") %>
+<%- end -%>
 
 gem "dry-types", "~> 1.7"
 gem "dry-operation"


### PR DESCRIPTION
closes #301 

This PR adds an optional `--skip-view` flag to the `hanami new` command. including this flag will not bundle the `hanami-view` gem, and will not generate any of the initial view files or directories (e.g. the things in `app/views` and `app/templates`)

however, this _does_ still potentially allow assets files to be created.  the idea being if you wanted to skip views and assets you'd use `hanami new` in api mode (#302)