### PR TITLE
Remove ACTION_SEPARATOR from base app command

### DIFF
--- a/lib/hanami/cli/commands/app/command.rb
+++ b/lib/hanami/cli/commands/app/command.rb
@@ -14,10 +14,6 @@ module Hanami
         # @since 2.0.0
         # @api public
         class Command < Hanami::CLI::Command
-          # @since 2.0.0
-          # @api private
-          ACTION_SEPARATOR = "." # TODO: rename to container key separator
-
           # Overloads {Hanami::CLI::Commands::App::Command#call} to ensure an appropriate
           # `HANAMI_ENV` environment variable is set.
           #

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -94,7 +94,7 @@ module Hanami
             )
               name = Naming.new(inflector:).action_name(name)
 
-              raise InvalidActionNameError.new(name) unless name.include?(ACTION_SEPARATOR)
+              raise InvalidActionNameError.new(name) unless name.include?(".")
 
               super(
                 name:,


### PR DESCRIPTION
The base app command class shouldn’t concern itself with actions. Since this constant was only used once (in the `generate action` command), I’ve simply replaced it with a literal `"."` string for now.