### PR TITLE
Fix ArgumentError for Part generator

### DIFF
--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -22,19 +22,15 @@ module Hanami
             attr_reader :inflector
             private :inflector
 
-            # @since 2.2.0
-            # @api private
-            def initialize(
-              fs:,
-              inflector:,
-              **
-            )
+            def initialize(fs:, inflector:, out:, **)
               super
-              @generator = generator_class.new(fs: fs, inflector: inflector, out: out)
+              @generator = generator_class.new(fs:, inflector:, out:)
             end
 
+            # @since 2.2.0
+            # @api private
             def generator_class
-              # Must be implemented by subclasses, with class that takes:
+              # Must be implemented by subclasses, with initialize method that takes:
               # fs:, inflector:, out:
             end
 

--- a/lib/hanami/cli/generators/app/part.rb
+++ b/lib/hanami/cli/generators/app/part.rb
@@ -2,7 +2,6 @@
 
 require "erb"
 require "dry/files"
-require_relative "../../errors"
 
 module Hanami
   module CLI
@@ -21,7 +20,7 @@ module Hanami
 
           # @since 2.1.0
           # @api private
-          def call(key:, namespace:, base_path:)
+          def call(key:, namespace:, base_path:, **)
             create_app_base_part_if_missing(key:, namespace:, base_path:)
             create_slice_part_if_missing(key:, namespace:, base_path:) unless namespace == Hanami.app.namespace
             create_generated_part(key:, namespace:, base_path:)

--- a/spec/integration/hanami/cli/commands/app/generate/part_spec.rb
+++ b/spec/integration/hanami/cli/commands/app/generate/part_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "tempfile"
+
+RSpec.describe "Hanami generate part integration", :app do
+  let(:fs) { Hanami::CLI::Files.new(memory: false) }
+  let(:inflector) { Dry::Inflector.new }
+  let(:out) { StringIO.new }
+
+  subject(:command) do
+    Hanami::CLI::Commands::App::Generate::Part.new(
+      fs: fs,
+      inflector: inflector,
+      out: out
+    )
+  end
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      original_dir = Dir.pwd
+      Dir.chdir(dir)
+
+      # Create a basic Hanami app structure
+      fs.mkdir("app")
+      fs.mkdir("config")
+
+      routes_content = <<~RUBY
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module TestApp
+          class Routes < Hanami::Routes
+            root { "Hello from Hanami" }
+          end
+        end
+      RUBY
+
+      fs.write("config/routes.rb", routes_content)
+
+      example.run
+    ensure
+      Dir.chdir(original_dir) if original_dir
+    end
+  end
+
+  context "when generating parts" do
+    it "creates part file successfully, with only name" do
+      expect { command.call(name: "user") }.not_to raise_error
+
+      expect(fs.exist?("app/views/parts/user.rb")).to be(true)
+    end
+
+    it "supports skip_tests parameter" do
+      expect {
+        command.call(name: "product", skip_tests: true)
+      }.not_to raise_error
+
+      expect(fs.exist?("app/views/parts/product.rb")).to be(true)
+    end
+
+    it "allows arbitrary keyword arguments" do
+      expect {
+        command.call(name: "book", extra_param: "extra_value", skip_tests: true)
+      }.not_to raise_error
+
+      expect(fs.exist?("app/views/parts/book.rb")).to be(true)
+    end
+  end
+
+  context "error handling" do
+    it "handles file conflicts" do
+      fs.mkdir("app/views/parts")
+      fs.write("app/views/parts/existing.rb", "# existing content")
+
+      expect {
+        command.call(name: "existing")
+      }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+    end
+  end
+end


### PR DESCRIPTION
Clean up for #292. Right now `hanami generate part` (from hanami/cli main) is broken.
 
`skip_tests:` wasn't being accepted, so it was raising an ArgumentError (hanami-rspec looks at that option)

This also adds a regression test for that, plus allowing arbitrary kwargs args


