### PR TITLE
Generate command automatic slice detection (and a working test)

### DIFF
--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -41,14 +41,16 @@ module Hanami
             # @since 2.2.0
             # @api private
             def call(name:, slice: nil, **opts)
+              slice ||= detect_slice_from_cwd
+
               if slice
-                base_path = fs.join("slices", inflector.underscore(slice))
-                raise MissingSliceError.new(slice) unless fs.exist?(base_path)
+                slice_root = slice.root
+                raise MissingSliceError.new(slice) unless fs.exist?(slice_root)
 
                 generator.call(
                   key: name,
                   namespace: slice,
-                  base_path: base_path,
+                  base_path: slice_root,
                   **opts,
                 )
               else
@@ -59,6 +61,13 @@ module Hanami
                   **opts,
                 )
               end
+            end
+
+            private
+
+            def detect_slice_from_cwd
+              slices_by_root = app.slices.with_nested.each.to_h { |slice| [slice.root.to_s, slice] }
+              slices_by_root[fs.pwd]
             end
           end
         end

--- a/lib/hanami/cli/commands/app/generate/command.rb
+++ b/lib/hanami/cli/commands/app/generate/command.rb
@@ -44,7 +44,17 @@ module Hanami
               slice ||= detect_slice_from_cwd
 
               if slice
-                slice_root = slice.root
+                slice_root =
+                  if slice.respond_to?(:root)
+                    slice.root
+                  else
+                    # TODO: later on we could handle nested slices by expecting command arguments
+                    # like `--slice foo/bar/baz`. This would require us to take a different approach
+                    # to determining their root. For the sake of this new feature, though, we can
+                    # just stick with simplistic top-level-only slice support when passing strings.
+                    fs.join("slices", inflector.underscore(slice))
+                  end
+
                 raise MissingSliceError.new(slice) unless fs.exist?(slice_root)
 
                 generator.call(

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -62,6 +62,8 @@ module Hanami
     # @api public
     class MissingSliceError < Error
       def initialize(slice)
+        # FIXME: if `slice` here is an actual Hanami::Slice subclass, this error should be about its
+        # _root_ being nonexistent, rather than the whole slice itself.
         super("slice `#{slice}' is missing, please generate with `hanami generate slice #{slice}'")
       end
     end

--- a/spec/unit/hanami/cli/commands/app/generate/slice_detection_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/slice_detection_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe "Slice detection for generate commands", :app_integration do
+  subject(:command) {
+    Hanami::CLI::Commands::App::Generate::Operation.new(
+      inflector: inflector,
+      out: out
+    )
+  }
+
+  let(:out) { StringIO.new }
+  def output = out.string.chomp
+  let(:inflector) { Dry::Inflector.new }
+
+  before do
+    with_directory(@dir = make_tmp_directory) do
+      write "config/app.rb", <<~RUBY
+        module TestApp
+          class App < Hanami::App
+          end
+        end
+      RUBY
+
+      write "slices/main/.keep", ""
+
+      require "hanami/setup"
+      before_prepare if respond_to?(:before_prepare)
+      require "hanami/prepare"
+    end
+
+    Dir.chdir(@dir)
+  end
+
+  it "detects the slice based on the current working directory" do
+    Dir.chdir("slices/main") do
+      command.call(name: "add_book")
+    end
+
+    expect(File.exist?("slices/main/add_book.rb")).to be true
+  end
+end


### PR DESCRIPTION
Here's a little spike for you, @krzykamil :)

As you discovered, in-memory `fs` object was mostly just getting in the way of writing an effective test. So in this case I avoided it altogether, and let actual files get written to disk.

The result is we don't have any stubbing at all, so we exercise real code from top to bottom.

Let me know what you think :) Happy to chat further, and of course, I'm happy for you to take this code take it in whatever direction you need to finish the feature. At minimum, we're definitely missing some tests.

(Follows on from #298)