### PR TITLE
Ensure MySQL 9.4 compatibility for `db structure load` command

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -48,7 +48,7 @@ module Hanami
               def exec_load_command
                 exec_cli(
                   "mysql",
-                  %(--execute "SET FOREIGN_KEY_CHECKS = 0; SOURCE #{structure_file}; SET FOREIGN_KEY_CHECKS = 1" --database #{escaped_name})
+                  %(--commands --execute "SET FOREIGN_KEY_CHECKS = 0; SOURCE #{structure_file}; SET FOREIGN_KEY_CHECKS = 1" --database #{escaped_name})
                 )
               end
 


### PR DESCRIPTION
As of MySQL 9.4, client commands are disabled by default for the `mysql` CLI (see https://dev.mysql.com/doc/relnotes/mysql/9.4/en/news-9-4-0.html). Pass the `-—commands` CLI arg to allow `db structure load` (which uses the MySQL `SOURCE` client command) to continue to work.