### PR TITLE
Catch FileAlreadyExistsError and exit cleanly

### DIFF
--- a/lib/hanami/cli/commands/app/command.rb
+++ b/lib/hanami/cli/commands/app/command.rb
@@ -40,6 +40,9 @@ module Hanami
               Hanami::Env.load
 
               super
+            rescue FileAlreadyExistsError => error
+              err.puts(error.message)
+              exit(1)
             end
           end
 

--- a/lib/hanami/cli/errors.rb
+++ b/lib/hanami/cli/errors.rb
@@ -46,8 +46,12 @@ module Hanami
 
     # @api public
     class FileAlreadyExistsError < Error
-      def initialize(path)
-        super("Cannot overwrite existing file: `#{path}`")
+      ERROR_MESSAGE = <<~ERROR.chomp
+        The file `%{file_path}` could not be generated because it already exists.
+      ERROR
+
+      def initialize(file_path)
+        super(ERROR_MESSAGE % {file_path:})
       end
     end
 

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -4,9 +4,10 @@ require "hanami"
 require "ostruct"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
-  subject { described_class.new(fs: fs, out: out) }
+  subject { described_class.new(fs: fs, out: out, err: err) }
 
   let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
   let(:app) { Hanami.app.namespace }
@@ -18,6 +19,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
   def output
     out.rewind && out.read.chomp
   end
+
+  def error_output = err.string.chomp
 
   shared_context "with existing files" do
     before do
@@ -39,53 +42,61 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
     end
 
     context "with existing action file" do
+      let(:file_path) { "app/actions/#{controller}/#{action}.rb" }
+
       before do
         within_application_directory do
-          fs.write("app/actions/#{controller}/#{action}.rb", "")
+          fs.write(file_path, "")
         end
       end
 
-      it "raises error" do
-        expect {
-          within_application_directory do
-            generate_action
-          end
-        }.to raise_error(Hanami::CLI::FileAlreadyExistsError, "Cannot overwrite existing file: `app/actions/#{controller}/#{action}.rb`")
+      it "exits with error message" do
+        expect do
+          within_application_directory { generate_action }
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
       end
     end
 
     context "with existing view file" do
+      let(:file_path) { "app/views/#{controller}/#{action}.rb" }
+
       before do
         within_application_directory do
-          fs.write("app/views/#{controller}/#{action}.rb", "")
+          fs.write(file_path, "")
         end
       end
 
-      it "raises error" do
-        expect {
-          within_application_directory do
-            generate_action
-          end
-        }.to raise_error(Hanami::CLI::FileAlreadyExistsError, "Cannot overwrite existing file: `app/views/#{controller}/#{action}.rb`")
+      it "exits with error message" do
+        expect do
+          within_application_directory { generate_action }
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
       end
     end
 
     context "with existing template file" do
+      let(:file_path) { "app/templates/#{controller}/#{action}.html.erb" }
+
       before do
         within_application_directory do
-          fs.write("app/templates/#{controller}/#{action}.html.erb", "")
+          fs.write(file_path, "")
         end
       end
 
-      it "raises error" do
-        expect {
+      it "exits with error message" do
+        expect do
           within_application_directory do
             generate_action
           end
-        }.to raise_error(
-          Hanami::CLI::FileAlreadyExistsError,
-          "Cannot overwrite existing file: `app/templates/#{controller}/#{action}.html.erb`",
-        )
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
@@ -4,9 +4,10 @@ require "hanami"
 require "ostruct"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
-  subject { described_class.new(fs: fs, out: out) }
+  subject { described_class.new(fs: fs, out: out, err: err) }
 
   let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
   let(:app) { Hanami.app.namespace }
@@ -17,6 +18,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
   def output
     out.rewind && out.read.chomp
   end
+
+  def error_output = err.string.chomp
 
   context "generating for app" do
     context "shallowly nested" do
@@ -39,14 +42,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       end
 
       context "with existing file" do
+        let(:file_path) { "app/operations/send_welcome_email.rb" }
+
         before do
-          fs.write("app/operations/send_welcome_email.rb", "existing content")
+          fs.write(file_path, "existing content")
         end
 
-        it "raises error" do
-          expect {
+        it "exits with error message" do
+          expect do
             subject.call(name: "operations.send_welcome_email")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+          end.to raise_error SystemExit do |exception|
+            expect(exception.status).to eq 1
+            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+          end
         end
       end
     end
@@ -75,14 +83,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       end
 
       context "with existing file" do
+        let(:file_path) { "app/operations/user/mailing/send_welcome_email.rb" }
+
         before do
-          fs.write("app/operations/user/mailing/send_welcome_email.rb", "existing content")
+          fs.write(file_path, "existing content")
         end
 
-        it "raises error" do
-          expect {
+        it "exits with error message" do
+          expect do
             subject.call(name: "operations.user.mailing.send_welcome_email")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+          end.to raise_error SystemExit do |exception|
+            expect(exception.status).to eq 1
+            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+          end
         end
       end
     end
@@ -110,14 +123,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       end
 
       context "with existing file" do
+        let(:file_path) { "slices/main/renderers/welcome_email.rb" }
+
         before do
-          fs.write("slices/main/renderers/welcome_email.rb", "existing content")
+          fs.write(file_path, "existing content")
         end
 
-        it "raises error" do
-          expect {
+        it "exits with error message" do
+          expect do
             subject.call(name: "renderers.welcome_email", slice: "main")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+          end.to raise_error SystemExit do |exception|
+            expect(exception.status).to eq 1
+            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+          end
         end
       end
     end
@@ -147,14 +165,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
       end
 
       context "with existing file" do
+        let(:file_path) { "slices/main/renderers/user/mailing/welcome_email.rb" }
+
         before do
-          fs.write("slices/main/renderers/user/mailing/welcome_email.rb", "existing content")
+          fs.write(file_path, "existing content")
         end
 
-        it "raises error" do
-          expect {
+        it "exits with error message" do
+          expect do
             subject.call(name: "renderers.user.mailing.welcome_email", slice: "main")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+          end.to raise_error SystemExit do |exception|
+            expect(exception.status).to eq 1
+            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+          end
         end
       end
     end

--- a/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_integration do
-  subject { described_class.new(out: out) }
+  subject { described_class.new(out: out, err: err) }
 
   let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
+
   def output = out.string
+
+  def error_output = err.string.chomp
 
   before do
     with_directory(@dir = make_tmp_directory) do
@@ -114,13 +118,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
     end
 
     context "with existing file" do
+      let(:file_path) { "app/relations/books.rb" }
+
       before do
-        write "app/relations/books.rb", "existing content"
+        write file_path, "existing content"
       end
 
-      it "raises error" do
-        expect { subject.call(name: "books") }
-          .to raise_error(Hanami::CLI::FileAlreadyExistsError)
+      it "exits with error message" do
+        expect do
+          subject.call(name: "books")
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
       end
     end
   end
@@ -189,13 +199,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
     end
 
     context "with existing file" do
+      let(:file_path) { "slices/main/relations/books.rb" }
+
       before do
-        write "slices/main/relations/books.rb", "existing content"
+        write file_path, "existing content"
       end
 
-      it "raises error" do
-        expect { subject.call(name: "books", slice: "main") }
-          .to raise_error(Hanami::CLI::FileAlreadyExistsError)
+      it "exits with error message" do
+        expect do
+          subject.call(name: "books", slice: "main")
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
-  subject { described_class.new(fs: fs, out: out) }
+  subject { described_class.new(fs: fs, out: out, err: err) }
 
   let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:app) { Hanami.app.namespace }
 
-  def output
-    out.string.chomp
-  end
+  def output = out.string.chomp
+
+  def error_output = err.string.chomp
 
   context "generating for app" do
     it "generates a struct without a namespace" do
@@ -73,14 +74,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
     end
 
     context "with existing file" do
+      let(:file_path) { "app/structs/book/published/hardcover.rb" }
+
       before do
-        fs.write("app/structs/book/published/hardcover.rb", "existing content")
+        fs.write(file_path, "existing content")
       end
 
-      it "raises error" do
-        expect {
+      it "exits with error message" do
+        expect do
           subject.call(name: "book/published/hardcover")
-        }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
       end
     end
   end
@@ -127,14 +133,19 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
     end
 
     context "with existing file" do
+      let(:file_path) { "slices/main/structs/book/draft_book.rb" }
+
       before do
-        fs.write("slices/main/structs/book/draft_book.rb", "existing content")
+        fs.write(file_path, "existing content")
       end
 
-      it "raises error" do
-        expect {
+      it "exits with error message" do
+        expect do
           subject.call(name: "book.draft_book", slice: "main")
-        }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
       end
     end
   end

--- a/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
@@ -4,9 +4,10 @@ require "hanami"
 require "ostruct"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
-  subject { described_class.new(fs: fs, out: out) }
+  subject { described_class.new(fs: fs, out: out, err: err) }
 
   let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
   let(:app) { Hanami.app.namespace }
@@ -15,6 +16,8 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
   def output
     out.rewind && out.read.chomp
   end
+
+  def error_output = err.string.chomp
 
   # it "raises error if action name doesn't respect the convention" do
   #   expect {
@@ -92,33 +95,41 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
     end
 
     context "with existing view file" do
+      let(:file_path) { "app/views/users/index.rb" }
+
       before do
         within_application_directory do
-          fs.write("app/views/users/index.rb", "existing content")
+          fs.write(file_path, "existing content")
         end
       end
 
-      it "raises error" do
-        within_application_directory do
-          expect {
-            subject.call(name: "users.index")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+      it "exits with error message" do
+        expect do
+          within_application_directory { subject.call(name: "users.index") }
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
         end
       end
     end
 
     context "with existing template file" do
+      let(:file_path) { "app/templates/users/index.html.erb" }
+
       before do
         within_application_directory do
-          fs.write("app/templates/users/index.html.erb", "existing content")
+          fs.write(file_path, "existing content")
         end
       end
 
       it "raises error" do
         within_application_directory do
-          expect {
+          expect do
             subject.call(name: "users.index")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+          end.to raise_error SystemExit do |exception|
+            expect(exception.status).to eq 1
+            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+          end
         end
       end
     end
@@ -160,35 +171,43 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
     end
 
     context "with existing view file" do
+      let(:file_path) { "slices/main/views/users/index.rb" }
+
       before do
         within_application_directory do
           fs.mkdir("slices/main")
-          fs.write("slices/main/views/users/index.rb", "existing content")
+          fs.write(file_path, "existing content")
         end
       end
 
-      it "raises error" do
-        within_application_directory do
-          expect {
-            subject.call(name: "users.index", slice: "main")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+      it "exits with error message" do
+        expect do
+          within_application_directory { subject.call(name: "users.index", slice: "main") }
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
         end
       end
     end
 
     context "with existing template file" do
+      let(:file_path) { "slices/main/templates/users/index.html.erb" }
+
       before do
         within_application_directory do
           fs.mkdir("slices/main")
-          fs.write("slices/main/templates/users/index.html.erb", "existing content")
+          fs.write(file_path, "existing content")
         end
       end
 
       it "raises error" do
         within_application_directory do
-          expect {
+          expect do
             subject.call(name: "users.index", slice: "main")
-          }.to raise_error(Hanami::CLI::FileAlreadyExistsError)
+          end.to raise_error SystemExit do |exception|
+            expect(exception.status).to eq 1
+            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+          end
         end
       end
     end


### PR DESCRIPTION
Exits with status 1 when a command tries to generate an already existing file.

Fixes https://github.com/hanami/cli/issues/181

This is a rebased version of https://github.com/hanami/cli/pull/279

