### PR TITLE
Refactor file conflict tests

### DIFF
--- a/spec/integration/hanami/cli/commands/app/generate/part_spec.rb
+++ b/spec/integration/hanami/cli/commands/app/generate/part_spec.rb
@@ -5,13 +5,10 @@ require "hanami"
 RSpec.describe "Hanami generate part integration", :app do
   let(:fs) { Hanami::CLI::Files.new(memory: false, out: out) }
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
 
   subject(:command) do
-    Hanami::CLI::Commands::App::Generate::Part.new(fs: fs, out: out, err: err)
+    Hanami::CLI::Commands::App::Generate::Part.new(fs: fs, out: out)
   end
-
-  def error_output = err.string.chomp
 
   around do |example|
     Dir.mktmpdir do |dir|
@@ -63,22 +60,6 @@ RSpec.describe "Hanami generate part integration", :app do
       }.not_to raise_error
 
       expect(fs.exist?("app/views/parts/book.rb")).to be(true)
-    end
-  end
-
-  context "error handling" do
-    let(:file_path) { "app/views/parts/existing.rb" }
-
-    it "handles file conflicts" do
-      fs.mkdir("app/views/parts")
-      fs.write(file_path, "# existing content")
-
-      expect do
-        command.call(name: "existing")
-      end.to raise_error SystemExit do |exception|
-        expect(exception.status).to eq 1
-        expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-      end
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -3,10 +3,9 @@
 require "hanami"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
-  subject { described_class.new(fs: fs, out: out, err: err) }
+  subject { described_class.new(fs: fs, out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
   let(:app) { Hanami.app.namespace }
@@ -18,8 +17,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
   def output
     out.rewind && out.read.chomp
   end
-
-  def error_output = err.string.chomp
 
   shared_context "with existing files" do
     before do
@@ -36,65 +33,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           expect(output).to include("Created app/actions/#{controller}/#{action}.rb")
           expect(output).to include("Created app/views/#{controller}/#{action}.rb")
           expect(output).to include("Created app/templates/#{controller}/#{action}.html.erb")
-        end
-      end
-    end
-
-    context "with existing action file" do
-      let(:file_path) { "app/actions/#{controller}/#{action}.rb" }
-
-      before do
-        within_application_directory do
-          fs.write(file_path, "")
-        end
-      end
-
-      it "exits with error message" do
-        expect do
-          within_application_directory { generate_action }
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
-
-    context "with existing view file" do
-      let(:file_path) { "app/views/#{controller}/#{action}.rb" }
-
-      before do
-        within_application_directory do
-          fs.write(file_path, "")
-        end
-      end
-
-      it "exits with error message" do
-        expect do
-          within_application_directory { generate_action }
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
-
-    context "with existing template file" do
-      let(:file_path) { "app/templates/#{controller}/#{action}.html.erb" }
-
-      before do
-        within_application_directory do
-          fs.write(file_path, "")
-        end
-      end
-
-      it "exits with error message" do
-        expect do
-          within_application_directory do
-            generate_action
-          end
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
         end
       end
     end

--- a/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/component_spec.rb
@@ -3,10 +3,9 @@
 require "hanami"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
-  subject { described_class.new(fs: fs, out: out, err: err) }
+  subject { described_class.new(fs: fs, out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
   let(:app) { Hanami.app.namespace }
@@ -17,8 +16,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
   def output
     out.rewind && out.read.chomp
   end
-
-  def error_output = err.string.chomp
 
   context "generating for app" do
     context "shallowly nested" do
@@ -38,23 +35,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
 
         expect(fs.read("app/operations/send_welcome_email.rb")).to eq(component)
         expect(output).to include("Created app/operations/send_welcome_email.rb")
-      end
-
-      context "with existing file" do
-        let(:file_path) { "app/operations/send_welcome_email.rb" }
-
-        before do
-          fs.write(file_path, "existing content")
-        end
-
-        it "exits with error message" do
-          expect do
-            subject.call(name: "operations.send_welcome_email")
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
-        end
       end
     end
 
@@ -80,23 +60,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
         expect(fs.read("app/operations/user/mailing/send_welcome_email.rb")).to eq(component)
         expect(output).to include("Created app/operations/user/mailing/send_welcome_email.rb")
       end
-
-      context "with existing file" do
-        let(:file_path) { "app/operations/user/mailing/send_welcome_email.rb" }
-
-        before do
-          fs.write(file_path, "existing content")
-        end
-
-        it "exits with error message" do
-          expect do
-            subject.call(name: "operations.user.mailing.send_welcome_email")
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
-        end
-      end
     end
   end
 
@@ -119,23 +82,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
 
         expect(fs.read("slices/main/renderers/welcome_email.rb")).to eq(component)
         expect(output).to include("Created slices/main/renderers/welcome_email.rb")
-      end
-
-      context "with existing file" do
-        let(:file_path) { "slices/main/renderers/welcome_email.rb" }
-
-        before do
-          fs.write(file_path, "existing content")
-        end
-
-        it "exits with error message" do
-          expect do
-            subject.call(name: "renderers.welcome_email", slice: "main")
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
-        end
       end
     end
 
@@ -161,23 +107,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Component, :app do
 
         expect(fs.read("slices/main/renderers/user/mailing/welcome_email.rb")).to eq(component)
         expect(output).to include("Created slices/main/renderers/user/mailing/welcome_email.rb")
-      end
-
-      context "with existing file" do
-        let(:file_path) { "slices/main/renderers/user/mailing/welcome_email.rb" }
-
-        before do
-          fs.write(file_path, "existing content")
-        end
-
-        it "exits with error message" do
-          expect do
-            subject.call(name: "renderers.user.mailing.welcome_email", slice: "main")
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
-        end
       end
     end
 

--- a/spec/unit/hanami/cli/commands/app/generate/file_conflict_handling_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/file_conflict_handling_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "hanami"
+
+RSpec.describe "file conflict handling", :app do
+  subject(:cmd) { Hanami::CLI::Commands::App::Generate::View.new(fs:, out:, err:) }
+
+  let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+
+  def error_output = err.string.chomp
+
+  context "when file to be generated already exists" do
+    it "exits with error" do
+      subject.call(name: "users.new")
+
+      file_path = "app/views/users/new.rb"
+
+      expect do
+        subject.call(name: "users.new")
+      end.to raise_error SystemExit do |exception|
+        expect(exception.status).to eq 1
+        expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/migration_spec.rb
@@ -3,17 +3,14 @@
 require "hanami"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
-  subject { described_class.new(fs: fs, err: err) }
+  subject { described_class.new(fs: fs) }
 
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
 
   def output
     out.string.strip
   end
-
-  def error_output = err.string.chomp
 
   let(:app) { Hanami.app.namespace }
 
@@ -65,23 +62,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
                          "Name must contain only letters, numbers, and underscores."
                        ))
     end
-
-    context "with existing file" do
-      let(:file_path) { "config/db/migrate/20240713140600_create_posts.rb" }
-
-      before do
-        fs.write(file_path, "existing content")
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "create_posts")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
   end
 
   context "generating for a slice" do
@@ -93,25 +73,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Migration, :app do
 
       expect(fs.read("slices/main/config/db/migrate/20240713140600_create_posts.rb")).to eq migration_file_contents
       expect(output).to eq("Created slices/main/config/db/migrate/20240713140600_create_posts.rb")
-    end
-
-    context "with existing file" do
-      let(:file_path) { "slices/main/config/db/migrate/20240713140600_create_posts.rb" }
-
-      context "with existing file" do
-        before do
-          fs.write(file_path, "existing content")
-        end
-
-        it "exits with error message" do
-          expect do
-            subject.call(name: "create_posts", slice: "main")
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
-        end
-      end
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
-  subject { described_class.new(fs: fs, out: out, err: err) }
+  subject { described_class.new(fs: fs, out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:app) { Hanami.app.namespace }
 
   def output
     out.string.chomp
   end
-
-  def error_output = err.string.chomp
 
   context "generating for app" do
     it "generates an operation without a namespace, with a recommendation" do
@@ -80,23 +77,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       expect(fs.read("app/admin/books/add.rb")).to eq(operation_file)
       expect(output).to include("Created app/admin/books/add.rb")
     end
-
-    context "with existing file" do
-      let(:file_path) { "app/admin/books/add.rb" }
-
-      before do
-        fs.write(file_path, "existing content")
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "admin.books.add")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
   end
 
   context "generating for a slice" do
@@ -144,24 +124,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
 
       expect(fs.read("slices/main/admin/books/add.rb")).to eq(operation_file)
       expect(output).to include("Created slices/main/admin/books/add.rb")
-    end
-
-    context "with existing file" do
-      let(:file_path) { "slices/main/admin/books/add.rb" }
-
-      before do
-        fs.mkdir("slices/main")
-        fs.write(file_path, "existing content")
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "admin.books.add", slice: "main")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/part_spec.rb
@@ -3,10 +3,9 @@
 require "hanami"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
-  subject { described_class.new(fs: fs, out: out, err: err) }
+  subject { described_class.new(fs: fs, out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
   let(:app) { Hanami.app.namespace }
@@ -15,8 +14,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
   def output
     out.rewind && out.read.chomp
   end
-
-  def error_output = err.string.chomp
 
   context "generating for app" do
     context "without base part" do
@@ -57,25 +54,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
 
           expect(fs.read("app/views/parts/user.rb")).to eq(part)
           expect(output).to include("Created app/views/parts/user.rb")
-        end
-      end
-
-      context "with existing file" do
-        let(:file_path) { "app/views/parts/user.rb" }
-
-        before do
-          within_application_directory do
-            fs.write(file_path, "existing content")
-          end
-        end
-
-        it "exits with error message" do
-          expect do
-            within_application_directory { subject.call(name: "user") }
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
         end
       end
     end
@@ -225,26 +203,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Part, :app do
 
           # This is still printed because the fs.write above still prints
           # expect(output).to_not include("Created slices/main/views/part.rb")
-        end
-      end
-    end
-
-    context "with existing file" do
-      let(:file_path) { "slices/main/views/parts/user.rb" }
-
-      before do
-        within_application_directory do
-          fs.mkdir("slices/main")
-          fs.write(file_path, "existing content")
-        end
-      end
-
-      it "exits with error message" do
-        expect do
-          within_application_directory { subject.call(name: "user", slice: "main") }
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
         end
       end
     end

--- a/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/relation_spec.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_integration do
-  subject { described_class.new(out: out, err: err) }
+  subject { described_class.new(out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
 
   def output = out.string
-
-  def error_output = err.string.chomp
 
   before do
     with_directory(@dir = make_tmp_directory) do
@@ -116,23 +113,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
       expect(Hanami.app.root.join("app/relations/books.rb").read).to eq relation_file
       expect(output).to include("Created app/relations/books.rb")
     end
-
-    context "with existing file" do
-      let(:file_path) { "app/relations/books.rb" }
-
-      before do
-        write file_path, "existing content"
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "books")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
   end
 
   context "generating for a slice" do
@@ -196,23 +176,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Relation, "#call", :app_int
 
       expect(Hanami.app.root.join("slices/main/relations/book/drafts.rb").read).to eq(relation_file)
       expect(output).to include("Created slices/main/relations/book/drafts.rb")
-    end
-
-    context "with existing file" do
-      let(:file_path) { "slices/main/relations/books.rb" }
-
-      before do
-        write file_path, "existing content"
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "books", slice: "main")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
     end
   end
 

--- a/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/repo_spec.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
-  subject { described_class.new(fs: fs, out: out, err: err) }
+  subject { described_class.new(fs: fs, out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:app) { Hanami.app.namespace }
 
   def output
     out.string
   end
-
-  def error_output = err.string.chomp
 
   context "generating for app" do
     describe "without namespace" do
@@ -94,23 +91,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
       expect(fs.read("app/repos/books/published/hardcover_repo.rb")).to eq(repo_file)
       expect(output).to include("Created app/repos/books/published/hardcover_repo.rb")
     end
-
-    context "with existing file" do
-      let(:file_path) { "app/repos/book_repo.rb" }
-
-      before do
-        fs.write(file_path, "existing content")
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "books")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
   end
 
   context "generating for a slice" do
@@ -152,23 +132,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Repo, :app do
 
       expect(fs.read("slices/main/repos/book/draft_repo.rb")).to eq(repo_file)
       expect(output).to include("Created slices/main/repos/book/draft_repo.rb")
-    end
-
-    context "with existing file" do
-      let(:file_path) { "slices/main/repos/book_repo.rb" }
-
-      before do
-        fs.write(file_path, "existing content")
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "books", slice: "main")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/struct_spec.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
-  subject { described_class.new(fs: fs, out: out, err: err) }
+  subject { described_class.new(fs: fs, out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:app) { Hanami.app.namespace }
 
   def output = out.string.chomp
-
-  def error_output = err.string.chomp
 
   context "generating for app" do
     it "generates a struct without a namespace" do
@@ -72,23 +69,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
       expect(fs.read("app/structs/book/published/hardcover.rb")).to eq(struct_file)
       expect(output).to include("Created app/structs/book/published/hardcover.rb")
     end
-
-    context "with existing file" do
-      let(:file_path) { "app/structs/book/published/hardcover.rb" }
-
-      before do
-        fs.write(file_path, "existing content")
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "book/published/hardcover")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
   end
 
   context "generating for a slice" do
@@ -130,23 +110,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Struct, :app do
 
       expect(fs.read("slices/main/structs/book/draft_book.rb")).to eq(struct_file)
       expect(output).to include("Created slices/main/structs/book/draft_book.rb")
-    end
-
-    context "with existing file" do
-      let(:file_path) { "slices/main/structs/book/draft_book.rb" }
-
-      before do
-        fs.write(file_path, "existing content")
-      end
-
-      it "exits with error message" do
-        expect do
-          subject.call(name: "book.draft_book", slice: "main")
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
     end
   end
 end

--- a/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/view_spec.rb
@@ -3,10 +3,9 @@
 require "hanami"
 
 RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
-  subject { described_class.new(fs: fs, out: out, err: err) }
+  subject { described_class.new(fs: fs, out: out) }
 
   let(:out) { StringIO.new }
-  let(:err) { StringIO.new }
   let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
   let(:inflector) { Dry::Inflector.new }
   let(:app) { Hanami.app.namespace }
@@ -15,8 +14,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
   def output
     out.rewind && out.read.chomp
   end
-
-  def error_output = err.string.chomp
 
   # it "raises error if action name doesn't respect the convention" do
   #   expect {
@@ -151,46 +148,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         end
       end
     end
-
-    context "with existing view file" do
-      let(:file_path) { "app/views/users/index.rb" }
-
-      before do
-        within_application_directory do
-          fs.write(file_path, "existing content")
-        end
-      end
-
-      it "exits with error message" do
-        expect do
-          within_application_directory { subject.call(name: "users.index") }
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
-
-    context "with existing template file" do
-      let(:file_path) { "app/templates/users/index.html.erb" }
-
-      before do
-        within_application_directory do
-          fs.write(file_path, "existing content")
-        end
-      end
-
-      it "raises error" do
-        within_application_directory do
-          expect do
-            subject.call(name: "users.index")
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
-        end
-      end
-    end
   end
 
   context "generating for a slice" do
@@ -227,6 +184,7 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
         expect(output).to include("Created slices/main/templates/users/index.html.erb")
       end
     end
+
     it "allows to specify slim template engine" do
       within_application_directory do
         fs.mkdir("slices/main")
@@ -248,48 +206,6 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::View, :app do
           %h1 Main::Views::Users::Index
         EXPECTED
         expect(fs.read("slices/main/templates/users/index.html.haml")).to eq(template_file)
-      end
-    end
-
-    context "with existing view file" do
-      let(:file_path) { "slices/main/views/users/index.rb" }
-
-      before do
-        within_application_directory do
-          fs.mkdir("slices/main")
-          fs.write(file_path, "existing content")
-        end
-      end
-
-      it "exits with error message" do
-        expect do
-          within_application_directory { subject.call(name: "users.index", slice: "main") }
-        end.to raise_error SystemExit do |exception|
-          expect(exception.status).to eq 1
-          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-        end
-      end
-    end
-
-    context "with existing template file" do
-      let(:file_path) { "slices/main/templates/users/index.html.erb" }
-
-      before do
-        within_application_directory do
-          fs.mkdir("slices/main")
-          fs.write(file_path, "existing content")
-        end
-      end
-
-      it "raises error" do
-        within_application_directory do
-          expect do
-            subject.call(name: "users.index", slice: "main")
-          end.to raise_error SystemExit do |exception|
-            expect(exception.status).to eq 1
-            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
Follow up https://github.com/hanami/cli/pull/319

As Tim [said](https://github.com/hanami/cli/pull/319#discussion_r2372421674) and I agree:
> All these tests for file conflict handling, spread across each generator, get pretty repetitious. [...] I think my preference would be not to worry about testing for conflicts in every generator spec, instead add e.g. a spec/unit/hanami/cli/commands/app/generate/file_conflict_handling_spec.rb that demonstrates the conflict handling for just one of the generators, which would be sufficient for us to know the code is doing what it needs.