### PR TITLE
When using --head for new apps, include cli from main github

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -3,6 +3,9 @@
 source "https://rubygems.org"
 
 <%= hanami_gem("hanami") %>
+<%- if hanami_head? -%>
+<%= hanami_gem("cli") %>
+<%- end -%>
 <%- if generate_assets? -%>
 <%= hanami_gem("assets") %>
 <%- end -%>
@@ -14,9 +17,6 @@ source "https://rubygems.org"
 <%= hanami_gem("validations") %>
 <%- if generate_view? -%>
 <%= hanami_gem("view") %>
-<%- end -%>
-<%- if hanami_head? -%>
-<%= hanami_gem("cli") %>
 <%- end -%>
 
 gem "dry-types", "~> 1.7"

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -15,6 +15,9 @@ source "https://rubygems.org"
 <%- if generate_view? -%>
 <%= hanami_gem("view") %>
 <%- end -%>
+<%- if hanami_head? -%>
+<%= hanami_gem("cli") %>
+<%- end -%>
 
 gem "dry-types", "~> 1.7"
 gem "dry-operation"

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -528,6 +528,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           source "https://rubygems.org"
 
           gem "hanami", github: "hanami/hanami", branch: "main"
+          gem "hanami-cli", github: "hanami/cli", branch: "main"
           gem "hanami-assets", github: "hanami/assets", branch: "main"
           gem "hanami-controller", github: "hanami/controller", branch: "main"
           gem "hanami-db", github: "hanami/db", branch: "main"


### PR DESCRIPTION
Small bug fix tonight to fix when using `--head` on `hanami new app --head` to automatically include the cli gem to reduce friction if there's a bug fix in CLI from GitHub for the other versions also using GitHub.

Generated an app with the fix:

```
gem "hanami", github: "hanami/hanami", branch: "main"
gem "hanami-cli", github: "hanami/cli", branch: "main"
gem "hanami-assets", github: "hanami/assets", branch: "main"
gem "hanami-controller", github: "hanami/controller", branch: "main"
gem "hanami-db", github: "hanami/db", branch: "main"
gem "hanami-router", github: "hanami/router", branch: "main"
gem "hanami-validations", github: "hanami/validations", branch: "main"
gem "hanami-view", github: "hanami/view", branch: "main"
```