### PR TITLE
More robust way to check postgres db existence

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -32,7 +32,7 @@ module Hanami
               # @api private
               # @since 2.2.0
               def exists?
-                result = system_call.call("psql -t -A -c '\\list #{escaped_name}'", env: cli_env_vars)
+                result = system_call.call("psql -t -A -c '\\list #{escaped_name}' template1", env: cli_env_vars)
                 raise Hanami::CLI::DatabaseExistenceCheckError.new(result.err) unless result.successful?
 
                 result.out.include?("#{name}|") # start_with?


### PR DESCRIPTION
The test for database existence in postgres can fail if the db user and the app database name are the same. By using a database that comes standard with every postgres installation this handles this case as well.

This fixes https://github.com/hanami/cli/issues/310. See also https://github.com/hanami/cli/issues/228.

To reproduce, use docker compose to spin up a postgres image and set POSTGRES_USER to something other than postgres.