### PR TITLE
Add `--skip_tests` flag when generating an action

### DIFF
--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -96,13 +96,13 @@ module Hanami
               raise InvalidActionNameError.new(name) unless name.include?(".")
 
               super(
-                name: name,
-                slice: slice,
-                url_path: url_path,
-                skip_route: skip_route,
-                http_method: http_method,
+                name:,
+                slice:,
+                url_path:,
+                skip_route:,
+                http_method:,
                 skip_view: skip_view || !Hanami.bundled?("hanami-view"),
-                skip_tests: skip_tests
+                skip_tests:
               )
             end
             # rubocop:enable Lint/ParameterLists

--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -41,7 +41,6 @@ module Hanami
               default: DEFAULT_SKIP_VIEW,
               desc: "Skip view and template generation"
 
-            # TODO: Implement this
             option \
               :skip_tests,
               required: false,
@@ -90,19 +89,20 @@ module Hanami
               http_method: nil,
               skip_view: DEFAULT_SKIP_VIEW,
               skip_route: DEFAULT_SKIP_ROUTE,
-              skip_tests: DEFAULT_SKIP_TESTS # rubocop:disable Lint/UnusedMethodArgument
+              skip_tests: DEFAULT_SKIP_TESTS
             )
               name = Naming.new(inflector:).action_name(name)
 
               raise InvalidActionNameError.new(name) unless name.include?(".")
 
               super(
-                name:,
-                slice:,
-                url_path:,
-                skip_route:,
-                http_method:,
+                name: name,
+                slice: slice,
+                url_path: url_path,
+                skip_route: skip_route,
+                http_method: http_method,
                 skip_view: skip_view || !Hanami.bundled?("hanami-view"),
+                skip_tests: skip_tests
               )
             end
             # rubocop:enable Lint/ParameterLists

--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -27,7 +27,7 @@ module Hanami
 
           # @since 2.0.0
           # @api private
-          def call(key:, namespace:, base_path:, url_path:, http_method:, skip_view:, skip_route:)
+          def call(key:, namespace:, base_path:, url_path:, http_method:, skip_view:, skip_route:, skip_tests:)
             insert_route(key:, namespace:, url_path:, http_method:) unless skip_route
 
             generate_action(key:, namespace:, base_path:, include_placeholder_body: skip_view)

--- a/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/action_spec.rb
@@ -297,6 +297,15 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
       end
     end
 
+    it "can skip test creation" do
+      within_application_directory do
+        subject.call(name: "no.test", skip_tests: true)
+
+        expect(fs.exist?("spec/actions/no/test_spec.rb")).to be(false)
+        expect(output).to_not include("Created spec/actions/no/test_spec.rb")
+      end
+    end
+
     include_context "with existing files" do
       let(:generate_action) { subject.call(name: action_name) }
     end
@@ -476,6 +485,15 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
 
         expect(fs.read("app/templates/#{controller}/#{action}.html.erb")).to eq(template_file)
         expect(output).to include("Created app/templates/#{controller}/#{action}.html.erb")
+      end
+    end
+
+    it "can skip test creation" do
+      within_application_directory do
+        subject.call(name: "no.test", skip_tests: true)
+
+        expect(fs.exist?("spec/actions/no/test_spec.rb")).to be(false)
+        expect(output).to_not include("Created spec/actions/no/test_spec.rb")
       end
     end
 
@@ -1163,6 +1181,17 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
           "slice `foo' is missing, please generate with `hanami generate slice foo'",
         )
       end
+
+      it "can skip test creation" do
+        within_application_directory do
+          prepare_slice!
+
+          subject.call(slice: slice, name: "no.test", skip_tests: true)
+
+          expect(fs.exist?("spec/slices/#{slice}/actions/no/test_spec.rb")).to be(false)
+          expect(output).to_not include("Created spec/slices/#{slice}/actions/no/test_spec.rb")
+        end
+      end
     end
 
     context "with hanami view bundled" do
@@ -1353,6 +1382,17 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Action, :app do
             # template
             expect(output).to_not include("Created slices/#{slice}/templates/#{controller}/#{action}.html.erb")
           end
+        end
+      end
+
+      it "can skip test creation" do
+        within_application_directory do
+          prepare_slice!
+
+          subject.call(slice: slice, name: "no.test", skip_tests: true)
+
+          expect(fs.exist?("spec/slices/#{slice}/actions/no/test_spec.rb")).to be(false)
+          expect(output).to_not include("Created spec/slices/#{slice}/actions/no/test_spec.rb")
         end
       end
     end


### PR DESCRIPTION
When spelunking through the code while working on a previous PR, I noticed a `TODO` for implementing the `skip_tests` flag in the action generator.  This PR adds the ability to do so

The `hanami/rspec` hooks [were already respecting](https://github.com/hanami/rspec/blob/7f10b2fab7008678f8b87f5c0686d07b3fb728ed/lib/hanami/rspec/commands.rb#L134) this flag, so this work was just a matter of passing the flag through to the generators `#call` function.

Please let me know if you'd like to see any changes, thanks!