### PR TITLE
Remove restrict and unrestrict from pg dumps

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -44,7 +44,15 @@ module Hanami
                 system_call.call(
                   "pg_dump --schema-only --no-privileges --no-owner --file #{structure_file} #{escaped_name}",
                   env: cli_env_vars
-                )
+                ).tap do
+                  next unless it.successful?
+                  dump_lines = File.readlines(structure_file)
+                  File.open(structure_file, "w") do |f|
+                    dump_lines.each do |line|
+                      f.write(line) unless line =~ /^\\(un)?restrict/
+                    end
+                  end
+                end
               end
 
               # @api private

--- a/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/structure/dump_spec.rb
@@ -251,6 +251,16 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Structure::Dump, :app_integration
       )
     end
 
+    it "does not change the dump if the structure is the same" do
+      command.call
+      dump_1 = File.read(Hanami.app.root.join("config", "db", "structure.sql"))
+
+      command.call
+      dump_2 = File.read(Hanami.app.root.join("config", "db", "structure.sql"))
+
+      expect(dump_1).to eq(dump_2)
+    end
+
     it "dumps the structure for the app db when given --app" do
       command.call(app: true)
 


### PR DESCRIPTION
This change removes the noise introduced in recent postgres versions by adding a new unique key every time the schema gets dumped.