### PR TITLE
Create db dumps in-memory before writing them to disk

### DIFF
--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -23,7 +23,7 @@ module Hanami
 
                   measure("#{database.name} structure dumped to #{relative_structure_path}") do
                     catch :dump_failed do
-                      result = database.exec_dump_command
+                      result = database.structure_sql_dump
                       exit_codes << result.exit_code if result.respond_to?(:exit_code)
 
                       unless result.successful?
@@ -31,9 +31,13 @@ module Hanami
                         throw :dump_failed, false
                       end
 
+                      structure_sql = result.sql
+
                       migrations_sql = database.schema_migrations_sql_dump
-                      if migrations_sql
-                        File.open(database.structure_file, "a") do |f|
+
+                      File.open(database.structure_file, "w") do |f|
+                        f.puts "#{structure_sql}\n"
+                        if migrations_sql
                           f.puts "#{migrations_sql}\n"
                         end
                       end

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -39,7 +39,7 @@ module Hanami
               def exec_dump_command
                 exec_cli(
                   "mysqldump",
-                  "--no-data --routines --skip-comments --result-file=#{structure_file} #{escaped_name}"
+                  "--no-data --routines --skip-comments #{escaped_name}"
                 )
               end
 

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -42,7 +42,7 @@ module Hanami
               # @since 2.2.0
               def exec_dump_command
                 system_call.call(
-                  "pg_dump --schema-only --no-privileges --no-owner --file #{structure_file} #{escaped_name}",
+                  "pg_dump --schema-only --no-privileges --no-owner #{escaped_name}",
                   env: cli_env_vars
                 )
               end

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -55,7 +55,7 @@ module Hanami
               # @api private
               # @since 2.2.0
               def exec_dump_command
-                system_call.call(%(sqlite3 #{file_path} ".schema --indent --nosys" > #{structure_file}))
+                system_call.call(%(sqlite3 #{file_path} ".schema --indent --nosys"))
               end
 
               # @api private


### PR DESCRIPTION
As discussed in #336, creating the dumps in-memory first makes it easier to process the dumps before writing the final version to disk.