### PR TITLE
Appends routes to slice routes file if it exists

### DIFF
--- a/lib/hanami/cli/generators/app/action.rb
+++ b/lib/hanami/cli/generators/app/action.rb
@@ -83,8 +83,14 @@ module Hanami
             if namespace == Hanami.app.namespace
               fs.inject_line_at_class_bottom(routes_location, "class Routes", route)
             else
-              slice_matcher = /slice[[:space:]]*:#{namespace}/
-              fs.inject_line_at_block_bottom(routes_location, slice_matcher, route)
+              slice_routes = fs.join("slices", namespace, "config", "routes.rb")
+
+              if fs.exist?(slice_routes)
+                fs.inject_line_at_class_bottom(slice_routes, "class Routes", route)
+              else
+                slice_matcher = /slice[[:space:]]*:#{namespace}/
+                fs.inject_line_at_block_bottom(routes_location, slice_matcher, route)
+              end
             end
           end
 


### PR DESCRIPTION
Fixes #341.

Check if the slice has a `slices/xyz/config/routes.rb` file. If it exists, append the route there; otherwise, keep the default behavior by adding it to the slice block in `config/routes.rb`.