### PR TITLE
Fix structure dump/load for MySQL 9.5.0

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -39,7 +39,7 @@ module Hanami
               def exec_dump_command
                 exec_cli(
                   "mysqldump",
-                  "--no-data --routines --skip-comments #{escaped_name}"
+                  "--no-data --routines --skip-comments --set-gtid-purged=off #{escaped_name}"
                 )
               end
 


### PR DESCRIPTION
Fixes #347

MySQL 9.5.0 [just came out](https://dev.mysql.com/doc/relnotes/mysql/9.5/en/news-9-5-0.html) and this feature is currently breaking hanami-cli builds:

> To enable enhanced replication capabilities by default, the default values of gtid_mode has been changed to ON. Additionally, the default value of enforce_gtid_consistency has been changed from ON.
>
> For more information, see Replication with Global Transaction Identifiers. (WL #8602)

The error we get is this:

```
ERROR 3546 (HY000) at line 13 in file: 'config/db/structure.sql': @@GLOBAL.GTID_PURGED cannot be changed: the added gtid set must not overlap with @@GLOBAL.GTID_EXECUTED
```

Here's the dump it was trying to import:

```
/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
/*!50503 SET NAMES utf8mb4 */;
/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
/*!40103 SET TIME_ZONE='+00:00' */;
/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
SET @MYSQLDUMP_TEMP_LOG_BIN = @@SESSION.SQL_LOG_BIN;
SET @@SESSION.SQL_LOG_BIN= 0;
SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ 'cc0777f4-b010-11f0-ba2e-5aaaff26ce00:1-16';
DROP TABLE IF EXISTS `posts`;
/*!40101 SET @saved_cs_client     = @@character_set_client */;
/*!50503 SET character_set_client = utf8mb4 */;
CREATE TABLE `posts` (
  `id` int NOT NULL AUTO_INCREMENT,
  `title` text NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
/*!40101 SET character_set_client = @saved_cs_client */;
DROP TABLE IF EXISTS `schema_migrations`;
/*!40101 SET @saved_cs_client     = @@character_set_client */;
/*!50503 SET character_set_client = utf8mb4 */;
CREATE TABLE `schema_migrations` (
  `filename` varchar(255) NOT NULL,
  PRIMARY KEY (`filename`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
/*!40101 SET character_set_client = @saved_cs_client */;
SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;
/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
INSERT INTO schema_migrations (filename) VALUES
('20240602201330_create_posts.rb');
```

The fix is to avoid putting this line in the dump in the first place:

```
SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ 'cc0777f4-b010-11f0-ba2e-5aaaff26ce00:1-16';
```

To do this, we can call mysqldump with `--set-gtid-purged=off`.