### PR TITLE
Print warnings for unbooted slices in console

### DIFF
--- a/lib/hanami/console/context.rb
+++ b/lib/hanami/console/context.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "plugins/slice_readers"
+require_relative "plugins/unbooted_slice_warnings"
 
 module Hanami
   # @since 2.0.0
@@ -21,6 +22,8 @@ module Hanami
 
         define_context_methods
         include Plugins::SliceReaders.new(app)
+
+        Plugins::UnbootedSliceWarnings.activate
       end
 
       private

--- a/lib/hanami/console/plugins/unbooted_slice_warnings.rb
+++ b/lib/hanami/console/plugins/unbooted_slice_warnings.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Console
+    module Plugins
+      # Console plugin that prints a one-time warning when an unbooted slice is asked for its
+      # `.keys`.
+      #
+      # @api private
+      module UnbootedSliceWarnings
+        module SliceExtension
+        end
+
+        def self.activate
+          warning_shown_for_slice = {}
+
+          # Define the wrapper method with access to the context via closure
+          SliceExtension.define_method(:keys) do
+            if !booted? && !warning_shown_for_slice[self]
+              message = <<~TEXT
+                Warning: #{self} is not booted. Run `#{self}.boot` to load all components, or launch the console with `--boot`.
+              TEXT
+              warn message
+
+              warning_shown_for_slice[self] = true
+            end
+
+            super()
+          end
+
+          Hanami::Slice::ClassMethods.prepend(SliceExtension)
+        end
+
+        def self.deactivate
+          SliceExtension.remove_method :keys
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/console/plugins/unbooted_slice_keys_warning_spec.rb
+++ b/spec/unit/hanami/console/plugins/unbooted_slice_keys_warning_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Console::Plugins::UnbootedSliceWarnings, :app do
+  let(:context) { Hanami::Console::Context.new(app) }
+  let(:console_env) { Object.new.extend(context) }
+
+  after do
+    Hanami::Console::Plugins::UnbootedSliceWarnings.deactivate
+  end
+
+  context "when app is not booted" do
+    it "shows a warning the first time a slice's keys method is called" do
+      expect { console_env.instance_eval { app.keys } }
+        .to output(%(Warning: Test::App is not booted. Run `Test::App.boot` to load all components, or launch the console with `--boot`.\n))
+        .to_stderr
+    end
+
+    it "only shows the warning once per console session per slice" do
+      # Create a second slice for testing
+      stub_const("AnotherSlice", Class.new(Hanami::Slice))
+
+      expect { console_env.instance_eval { app.keys } }
+        .to output(/Test::App is not booted/).to_stderr
+      expect { console_env.instance_eval { app.keys } }
+        .not_to output.to_stderr
+
+      expect { console_env.instance_eval { AnotherSlice.keys } }
+        .to output(/AnotherSlice is not booted/).to_stderr
+      expect { console_env.instance_eval { AnotherSlice.keys } }
+        .not_to output.to_stderr
+    end
+
+    it "still returns the keys from the slice" do
+      result = nil
+      original_keys = app.keys
+      expect {
+        result = console_env.instance_eval { app.keys }
+      }.to output(/Test::App is not booted/).to_stderr
+
+      expect(result).to eq(original_keys)
+    end
+  end
+
+  context "when app is booted" do
+    before do
+      app.boot
+    end
+
+    it "does not show a warning" do
+      expect { console_env.instance_eval { app.keys } }
+        .not_to output.to_stderr
+    end
+  end
+end


### PR DESCRIPTION
Add another console “plugin” to overload `Slice.keys` and print a one-time-per-slice warning when accessing keys for an unbooted slice.

This “plugin” is slightly differently-shaped to the `SliceReaders` one we have currently, but it needs to be because its purpose is not actually to enhance the console context, but rather to patch some external code. I think this difference is fine, and in the future we can move to make a more formal definition of what it means to be a console plugin.

This is an alternative take to @kyleplump’s https://github.com/hanami/hanami/pull/1543. @kyleplump, the reason I like this approach better is that it doesn’t add these console-specific behaviours to `Hanami::Slice` that complicate things in all the times that it’s _not_ running within a console (i.e. most of the time!). It also keeps this specific behaviour closer to the thing that needs it in the first place: the console classes themselves.

How does this feel to you?

After I added the code to make this print one-time only, I think we can probably get away without having the config to disable these notices altogether. Let's at least see how we go and learn from user feedback about whether it makes sense to add the config.

Fixes https://github.com/hanami/hanami-cli/issues/325