### PR TITLE
Require dry-operation 1.0.1 in generated Gemfile

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -20,7 +20,7 @@ source "https://rubygems.org"
 <%- end -%>
 
 gem "dry-types", "~> 1.7"
-gem "dry-operation"
+gem "dry-operation", ">= 1.0.1"
 gem "puma"
 gem "rake"
 <%- if generate_sqlite? -%>

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gem "hanami-view", "#{hanami_version}"
 
         gem "dry-types", "~> 1.7"
-        gem "dry-operation"
+        gem "dry-operation", ">= 1.0.1"
         gem "puma"
         gem "rake"
         gem "sqlite3"
@@ -541,7 +541,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "hanami-view", github: "hanami/view", branch: "main"
 
           gem "dry-types", "~> 1.7"
-          gem "dry-operation"
+          gem "dry-operation", ">= 1.0.1"
           gem "puma"
           gem "rake"
           gem "sqlite3"
@@ -652,7 +652,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "hanami-view", "#{hanami_version}"
 
           gem "dry-types", "~> 1.7"
-          gem "dry-operation"
+          gem "dry-operation", ">= 1.0.1"
           gem "puma"
           gem "rake"
           gem "sqlite3"


### PR DESCRIPTION
This version [includes a fix](https://github.com/dry-rb/dry-operation/pull/33) that enables us to overload `#transaction` within operations with helpful error messaging: https://github.com/hanami/hanami/pull/1490