### PR TITLE
Run `db rollback` against the test env database

### DIFF
--- a/lib/hanami/cli/commands/app/db/rollback.rb
+++ b/lib/hanami/cli/commands/app/db/rollback.rb
@@ -55,15 +55,17 @@ module Hanami
                 true
               end
 
-              return unless dump && !re_running_in_test?
+              if dump && !re_running_in_test?
+                run_command(
+                  Structure::Dump,
+                  app: database.slice == self.app,
+                  slice: database.slice == self.app ? nil : database.slice.slice_name.to_s,
+                  gateway: database.gateway_name == :default ? nil : database.gateway_name.to_s,
+                  command_exit: command_exit
+                )
+              end
 
-              run_command(
-                Structure::Dump,
-                app: database.slice == self.app,
-                slice: database.slice == self.app ? nil : database.slice.slice_name.to_s,
-                gateway: database.gateway_name == :default ? nil : database.gateway_name.to_s,
-                command_exit: command_exit
-              )
+              re_run_development_command_in_test
             end
 
             private

--- a/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/migrate_spec.rb
@@ -580,7 +580,7 @@ RSpec.describe Hanami::CLI::Commands::App::DB::Migrate, :app_integration do
       as_hanami_cli_with_args(%w[db migrate]) { example.run }
     end
 
-    it "re-executes the command in test env when run with development env" do
+    it "re-executes the command in test env when run in development env" do
       command.call(env: "development")
 
       expect(test_env_executor).to have_received(:call).with(


### PR DESCRIPTION
https://github.com/hanami/hanami-cli/issues/353 made me realise we hadn't set up `db rollback` to run against the test env database when it is issued in development mode (just like e.g. `db migrate` and many other db commands do). This PR makes it happen.