### PR TITLE
Add --gem-source to "hanami new"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Hanami Command Line Interface
 
 ## Unreleased
 
+### Added
+
+- By default, Ruby gems are sourced from rubygems.org. Add `--gem-source` to use a different server such as gem.coop or your own gem server. (@svooop in #356)
+
 ## v2.3.0.beta2 - 2025-10-17
 
 ### Added

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -10,15 +10,20 @@ module Hanami
         # @since 2.0.0
         # @api private
         class New < Command
-          # @since 2.0.0
-          # @api private
-          SKIP_INSTALL_DEFAULT = false
-          private_constant :SKIP_INSTALL_DEFAULT
-
           # @since 2.1.0
           # @api private
           HEAD_DEFAULT = false
           private_constant :HEAD_DEFAULT
+
+          # @since 2.3.0
+          # @api private
+          GEM_SOURCE_DEFAULT = "rubygems.org"
+          private_constant :GEM_SOURCE_DEFAULT
+
+          # @since 2.0.0
+          # @api private
+          SKIP_INSTALL_DEFAULT = false
+          private_constant :SKIP_INSTALL_DEFAULT
 
           # @since 2.1.0
           # @api private
@@ -60,17 +65,23 @@ module Hanami
           # @api private
           argument :app, required: true, desc: "App name"
 
-          # @since 2.0.0
-          # @api private
-          option :skip_install, type: :flag, required: false,
-                                default: SKIP_INSTALL_DEFAULT,
-                                desc: "Skip app installation (Bundler, third-party Hanami plugins)"
-
           # @since 2.1.0
           # @api private
           option :head, type: :flag, required: false,
                         default: HEAD_DEFAULT,
                         desc: "Use Hanami HEAD version (from GitHub `main` branches)"
+
+          # @since 2.3.0
+          # @api private
+          option :gem_source, required: true,
+                              default: GEM_SOURCE_DEFAULT,
+                              desc: "Where to source Ruby gems from"
+
+          # @since 2.0.0
+          # @api private
+          option :skip_install, type: :flag, required: false,
+                                default: SKIP_INSTALL_DEFAULT,
+                                desc: "Skip app installation (Bundler, third-party Hanami plugins)"
 
           # @since 2.1.0
           # @api private
@@ -100,6 +111,7 @@ module Hanami
           example [
             "bookshelf                                    # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
             "bookshelf --head                             # Generate a new Hanami app, using Hanami HEAD version from GitHub `main' branches",
+            "bookshelf --gem-source=gem.coop              # Generate a new Hanami app, using https://gem.coop as Ruby gem source",
             "bookshelf --skip-install                     # Generate a new Hanami app, but it skips Hanami installation",
             "bookshelf --skip-assets                      # Generate a new Hanami app without hanami-assets",
             "bookshelf --skip-db                          # Generate a new Hanami app without hanami-db",
@@ -132,6 +144,7 @@ module Hanami
           def call(
             app:,
             head: HEAD_DEFAULT,
+            gem_source: GEM_SOURCE_DEFAULT,
             skip_install: SKIP_INSTALL_DEFAULT,
             skip_assets: SKIP_ASSETS_DEFAULT,
             skip_db: SKIP_DB_DEFAULT,
@@ -152,6 +165,7 @@ module Hanami
                 inflector,
                 app,
                 head: head,
+                gem_source: gem_source,
                 skip_assets: skip_assets,
                 skip_db: skip_db,
                 skip_view: skip_view,

--- a/lib/hanami/cli/generators/context.rb
+++ b/lib/hanami/cli/generators/context.rb
@@ -76,6 +76,14 @@ module Hanami
           options.fetch(:head)
         end
 
+        # @since 2.3.0
+        # @api private
+        def gem_source
+          value = options.fetch(:gem_source)
+          return value if value.match? %r(\A\w+://)
+          "https://#{value}"
+        end
+
         # @since 2.1.0
         # @api private
         def generate_assets?

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "<%= gem_source %>"
 
 <%= hanami_gem("hanami") %>
 <%- if hanami_head? -%>

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -568,6 +568,56 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     end
   end
 
+  context "with gem-source" do
+    context "without scheme" do
+      it "generates an app with a custom gem source" do
+        expect(bundler).to receive(:install!)
+          .and_return(true)
+
+        expect(bundler).to receive(:exec)
+          .with("hanami install")
+          .and_return(successful_system_call_result)
+
+        expect(bundler).to receive(:exec)
+          .with("check")
+          .at_least(1)
+          .and_return(successful_system_call_result)
+
+        subject.call(app: app, **kwargs.merge(gem_source: "gem.coop"))
+
+        expect(fs.directory?(app)).to be(true)
+
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to match('source "https://gem.coop"')
+        end
+      end
+    end
+
+    context "with scheme" do
+      it "generates an app with a custom gem source" do
+        expect(bundler).to receive(:install!)
+          .and_return(true)
+
+        expect(bundler).to receive(:exec)
+          .with("hanami install")
+          .and_return(successful_system_call_result)
+
+        expect(bundler).to receive(:exec)
+          .with("check")
+          .at_least(1)
+          .and_return(successful_system_call_result)
+
+        subject.call(app: app, **kwargs.merge(gem_source: "http://gem.local"))
+
+        expect(fs.directory?(app)).to be(true)
+
+        fs.chdir(app) do
+          expect(fs.read("Gemfile")).to match('source "http://gem.local"')
+        end
+      end
+    end
+  end
+
   context "default configuration" do
     it "generates an app with hanami-assets and hanami-db" do
       expect(bundler).to receive(:install!)


### PR DESCRIPTION
This adds `--gem-server` to `hanami new` which facilitates the use of an alternative or private gem server:

```
hanami new --gem-server=https://gem.coop bookshelf
```

Closes #356 