### PR TITLE
Remove version-generated comments from pg dumps

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -13,7 +13,10 @@ module Hanami
             # @api private
             # @since 2.2.0
             class Postgres < Database
-              SCHEMA_DUMP_FILTER = /^\\(un)?restrict/
+              SCHEMA_DUMP_FILTERS = [
+                /^\\(un)?restrict/,
+                /^-- Dumped (from|by) (database version|pg_dump version)/,
+              ]
 
               # @api private
               # @since 2.2.0
@@ -74,7 +77,9 @@ module Hanami
               private
 
               def post_process_dump(sql)
-                sql.lines.reject{ |line| line =~ SCHEMA_DUMP_FILTER}.join("\n")
+                sql.lines.reject do |line|
+                  SCHEMA_DUMP_FILTERS.any? { |filter| line =~ filter }
+                end.join
               end
 
               def escaped_name


### PR DESCRIPTION
This patch follows work done in #336 to further improve the consistency of `structure.sql` dumps when using PostgreSQL. While the previous pull request ensured that the dynamically-generated `\restrict` and `\unrestrict` directives are omitted, these newer versions of `pg_dump` also include header comments that state information about the PostgreSQL installation itself. Unfortunately, even these comments will differ between platforms. For instance, I use Postgresql.app on my machine, and the structure dumps include these comments directly below the `\restrict` directive:

```pgsql
\restrict vFeenDa6qBIt40XTMVhNiGzFooxc9qCv6xoDBjeOatiGxyfEDs0CjsZihzSm54h

-- Dumped from database version 18.0 (Postgres.app)
-- Dumped by pg_dump version 18.0 (Postgres.app)

```

Developers will have different setups on their own machine, so even these comments will lead to conflicts and/or dirty changesets. We should remove them like we do the `\restrict` and `\unrestrict` directives.

This patch also removes an errant `.join("\n")` in favor of just `.join`, as the resulting SQL dumps were including new/additional linebreaks in-between every line, marking that `"\n"` argument as unnecessary.