### PR TITLE
Always return a result from database command methods

### DIFF
--- a/lib/hanami/cli/commands/app/db/create.rb
+++ b/lib/hanami/cli/commands/app/db/create.rb
@@ -16,9 +16,9 @@ module Hanami
 
               databases(app: app, slice: slice, gateway: gateway).each do |database|
                 result = database.exec_create_command
-                exit_codes << result.exit_code if result.respond_to?(:exit_code)
+                exit_codes << result.exit_code
 
-                if result == true || result.successful?
+                if result.successful?
                   out.puts "=> database #{database.name} created"
                 else
                   out.puts "=> failed to create database #{database.name}"

--- a/lib/hanami/cli/commands/app/db/drop.rb
+++ b/lib/hanami/cli/commands/app/db/drop.rb
@@ -16,9 +16,9 @@ module Hanami
 
               databases(app: app, slice: slice, gateway: gateway).each do |database|
                 result = database.exec_drop_command
-                exit_codes << result.exit_code if result.respond_to?(:exit_code)
+                exit_codes << result.exit_code
 
-                if result == true || result.successful?
+                if result.successful?
                   out.puts "=> database #{database.name} dropped"
                 else
                   out.puts "=> failed to drop database #{database.name}"

--- a/lib/hanami/cli/commands/app/db/structure/dump.rb
+++ b/lib/hanami/cli/commands/app/db/structure/dump.rb
@@ -24,7 +24,7 @@ module Hanami
                   measure("#{database.name} structure dumped to #{relative_structure_path}") do
                     catch :dump_failed do
                       result = database.structure_sql_dump
-                      exit_codes << result.exit_code if result.respond_to?(:exit_code)
+                      exit_codes << result.exit_code
 
                       unless result.successful?
                         out.puts result.err

--- a/lib/hanami/cli/commands/app/db/structure/load.rb
+++ b/lib/hanami/cli/commands/app/db/structure/load.rb
@@ -17,7 +17,7 @@ module Hanami
               option :gateway, required: false, desc: "Use database for gateway"
 
               # @api private
-              def call(app: false, slice: nil, gateway: nil, command_exit: method(:exit), **) # rubocop:disable Metrics/AbcSize
+              def call(app: false, slice: nil, gateway: nil, command_exit: method(:exit), **)
                 exit_codes = []
 
                 databases(app: app, slice: slice, gateway: gateway).each do |database|
@@ -29,7 +29,7 @@ module Hanami
                   measure("#{database.name} structure loaded from #{relative_structure_path}") do
                     catch :load_failed do
                       result = database.exec_load_command
-                      exit_codes << result.exit_code if result.respond_to?(:exit_code)
+                      exit_codes << result.exit_code
 
                       unless result.successful?
                         out.puts result.err

--- a/lib/hanami/cli/commands/app/db/utils/mysql.rb
+++ b/lib/hanami/cli/commands/app/db/utils/mysql.rb
@@ -12,7 +12,7 @@ module Hanami
             class Mysql < Database
               # @api private
               def exec_create_command
-                return true if exists?
+                return success_result if exists?
 
                 exec_cli("mysql", %(-e "CREATE DATABASE #{escaped_name}"))
               end
@@ -20,7 +20,7 @@ module Hanami
               # @api private
               # @since 2.2.0
               def exec_drop_command
-                return true unless exists?
+                return success_result unless exists?
 
                 exec_cli("mysql", %(-e "DROP DATABASE #{escaped_name}"))
               end
@@ -55,6 +55,10 @@ module Hanami
               # rubocop:enable Layout/LineLength
 
               private
+
+              def success_result
+                @success_result ||= SystemCall::Result.new(exit_code: 0, out: "", err: "")
+              end
 
               def escaped_name
                 Shellwords.escape(name)

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -21,7 +21,7 @@ module Hanami
               # @api private
               # @since 2.2.0
               def exec_create_command
-                return true if exists?
+                return success_result if exists?
 
                 system_call.call("createdb #{escaped_name}", env: cli_env_vars)
               end
@@ -29,7 +29,7 @@ module Hanami
               # @api private
               # @since 2.2.0
               def exec_drop_command
-                return true unless exists?
+                return success_result unless exists?
 
                 system_call.call("dropdb #{escaped_name}", env: cli_env_vars)
               end
@@ -75,6 +75,10 @@ module Hanami
               end
 
               private
+
+              def success_result
+                @success_result ||= SystemCall::Result.new(exit_code: 0, out: "", err: "")
+              end
 
               def post_process_dump(sql)
                 sql.lines.reject do |line|

--- a/lib/hanami/cli/commands/app/db/utils/sqlite.rb
+++ b/lib/hanami/cli/commands/app/db/utils/sqlite.rb
@@ -13,20 +13,28 @@ module Hanami
             class Sqlite < Database
               # @api private
               # @since 2.2.0
-              Failure = Struct.new(:err) do
-                def successful?
-                  false
+              class Failure
+                def initialize(err)
+                  @err = err
                 end
 
-                def exit_code
-                  1
-                end
+                attr_reader :err
+
+                def successful? = false
+                def exit_code = 1
+              end
+
+              # @api private
+              # @since 2.2.0
+              class Success
+                def successful? = true
+                def exit_code = 0
               end
 
               # @api private
               # @since 2.2.0
               def exec_create_command
-                return true if exists?
+                return Success.new if exists?
 
                 FileUtils.mkdir_p(File.dirname(file_path))
 
@@ -43,7 +51,8 @@ module Hanami
                   return Failure.new(exception.message)
                 end
 
-                true
+                # Mimic a system_call result
+                Success.new
               end
 
               # @api private


### PR DESCRIPTION
### Description

- Return `SystemCall::Result` objects from guard checks at database util class methods instead of primitive `true` values. This removes the need for checking the object of the returned.

- Replace `Failure` Struct with a class to remove warnings at test outputs. `Failure constant redefined`