### PR TITLE
Include patch-level in Gemfile version requirement

### DIFF
--- a/lib/hanami/cli/generators/version.rb
+++ b/lib/hanami/cli/generators/version.rb
@@ -38,27 +38,25 @@ module Hanami
           "^#{result}"
         end
 
-        # @since 2.0.0
         # @api private
         def self.prerelease?
           version.match?(/alpha|beta|rc/)
         end
 
         # @example
-        #   Hanami::VERSION # => 2.0.0
-        #   Hanami::CLI::Generators::Version.stable_version # => "2.0"
+        #   Hanami::VERSION # => 2.3.1
+        #   Hanami::CLI::Generators::Version.stable_version # => "2.3.0"
         #
-        # @since 2.0.0
         # @api private
         def self.stable_version
-          version.scan(/\A\d{1,2}\.\d{1,2}/).first
+          major_minor = version.scan(/\A\d{1,2}\.\d{1,2}/).first
+          "#{major_minor}.0"
         end
 
         # @example
         #   Hanami::VERSION # => 2.0.0.alpha8.1
-        #   Hanami::CLI::Generators::Version.stable_version # => "2.0.0.alpha"
+        #   Hanami::CLI::Generators::Version.prerelease_version # => "2.0.0.alpha"
         #
-        # @since 2.0.0
         # @api private
         def self.prerelease_version
           version.sub(/[[[:digit:]].]*\Z/, "")

--- a/spec/unit/hanami/cli/generators/version_spec.rb
+++ b/spec/unit/hanami/cli/generators/version_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Hanami::CLI::Generators::Version do
 
   describe ".stable_version" do
     it "returns the major and minor version" do
-      allow(described_class).to receive(:version).and_return("2.1.0")
-      expect(described_class.stable_version).to eq("2.1")
+      allow(described_class).to receive(:version).and_return("2.1.1")
+      expect(described_class.stable_version).to eq("2.1.0")
     end
   end
 


### PR DESCRIPTION
This protects users from an accidental upgrade e.g. from 2.3 to 2.4. We prefer this be done intentionally.

Resolves #366 