### PR TITLE
Remove errant "up" from set up instructions

### DIFF
--- a/lib/hanami/cli/generators/gem/app/readme.erb
+++ b/lib/hanami/cli/generators/gem/app/readme.erb
@@ -4,7 +4,7 @@
 
 ## Getting started
 
-- Set up the project up with `bin/setup`
+- Set up the project with `bin/setup`
 - Run the server with `bin/dev`
 - View the app at [http://localhost:2300](http://localhost:2300)
 - Run the tests with `bundle exec rake`

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         ## Getting started
 
-        - Set up the project up with `bin/setup`
+        - Set up the project with `bin/setup`
         - Run the server with `bin/dev`
         - View the app at [http://localhost:2300](http://localhost:2300)
         - Run the tests with `bundle exec rake`
@@ -706,7 +706,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           ## Getting started
 
-          - Set up the project up with `bin/setup`
+          - Set up the project with `bin/setup`
           - Run the server with `bin/dev`
           - View the app at [http://localhost:2300](http://localhost:2300)
           - Run the tests with `bundle exec rake`
@@ -1365,7 +1365,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         ## Getting started
 
-        - Set up the project up with `bin/setup`
+        - Set up the project with `bin/setup`
         - Run the server with `bin/dev`
         - View the app at [http://localhost:2300](http://localhost:2300)
         - Run the tests with `bundle exec rake`


### PR DESCRIPTION
#365 included a few changes to the READMEs that are generated for new apps, but one of which reworded a statement about setting up the application with the intent of moving the "up". Instead, it introduced a second "up" into the statement 😅 This patch corrects the issue, assuming the new one should be favored