### PR TITLE
Fix version for assets node package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Hanami Command Line Interface
 
 ## Unreleased
 
+### Fixed
+
+- Decouple the hanami-assets npm package version from the current Hanami version in generated `package.json`, using the stable minor version (e.g. `^2.3.0`) instead of the exact version (e.g. `^2.3.1`). This allows Hanami patch releases without requiring a corresponding hanami-assets npm package release. (@timriley in #270)
+
 ## v2.3.1 - 2025-11-14
 
 ### Fixed

--- a/lib/hanami/cli/generators/version.rb
+++ b/lib/hanami/cli/generators/version.rb
@@ -18,7 +18,8 @@ module Hanami
         end
 
         def self.npm_package_requirement
-          result = version
+          result = prerelease? ? prerelease_version : stable_version
+
           # Change "2.1.0.beta2.1" to "2.1.0-beta.2" (the only format tolerable by `npm install`)
           if prerelease?
             result = result

--- a/spec/unit/hanami/cli/generators/version_spec.rb
+++ b/spec/unit/hanami/cli/generators/version_spec.rb
@@ -47,31 +47,46 @@ RSpec.describe Hanami::CLI::Generators::Version do
 
   describe ".npm_package_requirement" do
     context "when prerelease version" do
-      it "formats the alpha version string for npm" do
-        allow(described_class).to receive(:version).and_return("2.1.0.alpha8.1")
+      before do
+        allow(described_class).to receive(:prerelease?).and_return(true)
+      end
+
+      it "formats an alpha version string for npm" do
+        allow(described_class).to receive(:prerelease_version).and_return("2.1.0.alpha8")
         expect(described_class.npm_package_requirement).to eq("^2.1.0-alpha.8")
       end
 
-      it "formats the beta version string for npm" do
-        allow(described_class).to receive(:version).and_return("2.1.0.beta2")
+      it "formats a beta version string for npm" do
+        allow(described_class).to receive(:prerelease_version).and_return("2.1.0.beta2")
         expect(described_class.npm_package_requirement).to eq("^2.1.0-beta.2")
       end
 
-      it "formats the rc version string for npm" do
-        allow(described_class).to receive(:version).and_return("2.1.0.rc1")
+      it "formats an rc version string for npm" do
+        allow(described_class).to receive(:prerelease_version).and_return("2.1.0.rc1")
         expect(described_class.npm_package_requirement).to eq("^2.1.0-rc.1")
       end
     end
 
     context "when stable version" do
-      it "formats the stable version string for npm" do
-        allow(described_class).to receive(:version).and_return("2.1.0")
+      before do
+        allow(described_class).to receive(:prerelease?).and_return(false)
+      end
+
+      it "returns the minor version with ^" do
+        allow(described_class).to receive(:stable_version).and_return("2.1.0")
         expect(described_class.npm_package_requirement).to eq("^2.1.0")
       end
 
-      it "formats the stable version string (with tiny patch) for npm" do
+      it "returns the minor version for patch releases (e.g. 2.1.1 returns ^2.1.0)" do
+        allow(described_class).to receive(:version).and_return("2.1.1")
+        allow(described_class).to receive(:stable_version).and_return("2.1.0")
+        expect(described_class.npm_package_requirement).to eq("^2.1.0")
+      end
+
+      it "returns the minor version for tiny patch releases (e.g. 2.1.0.1 returns ^2.1.0)" do
         allow(described_class).to receive(:version).and_return("2.1.0.1")
-        expect(described_class.npm_package_requirement).to eq("^2.1.0.1")
+        allow(described_class).to receive(:stable_version).and_return("2.1.0")
+        expect(described_class.npm_package_requirement).to eq("^2.1.0")
       end
     end
   end


### PR DESCRIPTION
When generating new apps, use the stable minor version (e.g. `^2.2.0`) for the hanami-assets npm package instead of the exact Hanami version (e.g. `^2.2.1`). This allows Hanami patch releases without requiring a corresponding hanami-assets npm package release.

Fixes #270