### PR TITLE
Remove explicit `preload_app!` from Puma config

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -22,7 +22,7 @@ source "<%= gem_source %>"
 
 gem "dry-types", "~> 1.7"
 gem "dry-operation", ">= 1.0.1"
-gem "puma"
+gem "puma", ">= 7.1"
 gem "rake"
 <%- if generate_sqlite? -%>
 gem "sqlite3"

--- a/lib/hanami/cli/generators/gem/app/puma.erb
+++ b/lib/hanami/cli/generators/gem/app/puma.erb
@@ -32,9 +32,6 @@ workers puma_concurrency
 #
 
 if puma_cluster_mode
-  # Preload the application before starting the workers. Only in cluster mode.
-  preload_app!
-
   # Code to run immediately before master process forks workers (once on boot).
   #
   # These hooks can block if necessary to wait for background operations unknown

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         gem "dry-types", "~> 1.7"
         gem "dry-operation", ">= 1.0.1"
-        gem "puma"
+        gem "puma", ">= 7.1"
         gem "rake"
         gem "sqlite3"
 
@@ -385,9 +385,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         #
 
         if puma_cluster_mode
-          # Preload the application before starting the workers. Only in cluster mode.
-          preload_app!
-
           # Code to run immediately before master process forks workers (once on boot).
           #
           # These hooks can block if necessary to wait for background operations unknown
@@ -575,7 +572,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           gem "dry-types", "~> 1.7"
           gem "dry-operation", ">= 1.0.1"
-          gem "puma"
+          gem "puma", ">= 7.1"
           gem "rake"
           gem "sqlite3"
 
@@ -736,7 +733,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           gem "dry-types", "~> 1.7"
           gem "dry-operation", ">= 1.0.1"
-          gem "puma"
+          gem "puma", ">= 7.1"
           gem "rake"
           gem "sqlite3"
 
@@ -953,9 +950,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           #
 
           if puma_cluster_mode
-            # Preload the application before starting the workers. Only in cluster mode.
-            preload_app!
-
             # Code to run immediately before master process forks workers (once on boot).
             #
             # These hooks can block if necessary to wait for background operations unknown


### PR DESCRIPTION
As of [Puma 7.0](https://github.com/puma/puma/blob/main/History.md#700--2025-09-03), preloading is enabled by default in cluster mode, so there's no need to explicitly enable it.

This is a slightly opinionated change to remove the explicit enabling of a config that's now enabled by default, so feel free to close this if not preferred.