### PR TITLE
Remove duplication from help message on generating view and action

### DIFF
--- a/lib/hanami/cli/commands/app/generate/action.rb
+++ b/lib/hanami/cli/commands/app/generate/action.rb
@@ -61,7 +61,7 @@ module Hanami
             option :slice, required: false, desc: "Slice name"
             option :template_engine, required: false, type: :string, default: DEFAULT_TEMPLATE_ENGINE,
                                      values: %w[erb haml slim],
-                                     desc: "Template engine to use (officially supported options: erb, haml, slim)"
+                                     desc: "Template engine to use"
 
             # option :format, required: false, type: :string, default: DEFAULT_FORMAT, desc: "Template format"
 

--- a/lib/hanami/cli/commands/app/generate/view.rb
+++ b/lib/hanami/cli/commands/app/generate/view.rb
@@ -18,7 +18,7 @@ module Hanami
 
             argument :name, required: true, desc: "View name"
             option :template_engine, required: false,
-                                     desc: "Template engine to use (officially supported: erb, haml, slim)",
+                                     desc: "Template engine to use",
                                      values: %w[erb haml slim],
                                      default: "erb"
 


### PR DESCRIPTION
I made a small mess in #280. Listing of the available options is already handled by dry-cli, no need to specify it inside the message.

State from before this PR:

```
Command:
  hanami generate view

Usage:
  hanami generate view NAME

Arguments:
  NAME                              # REQUIRED View name

Options:
  --env=VALUE, -e VALUE             # App environment (development, test, production)
  --slice=VALUE                     # Slice name
  --template-engine=VALUE           # Template engine to use (officially supported: erb, haml, slim): (erb/haml/slim), default: "erb"
  --help, -h                        # Print this help
```

After:

```
Command:
  hanami generate view

Usage:
  hanami generate view NAME

Arguments:
  NAME                              # REQUIRED View name

Options:
  --env=VALUE, -e VALUE             # App environment (development, test, production)
  --slice=VALUE                     # Slice name
  --template-engine=VALUE           # Template engine to use: (erb/haml/slim), default: "erb"
  --help, -h                        # Print this help
```