### PR TITLE
Fix CI run on JRuby

### DIFF
--- a/.github/workflows/repo-sync-extensions/ci-env.yml
+++ b/.github/workflows/repo-sync-extensions/ci-env.yml
@@ -1,1 +1,2 @@
 POSTGRES_BASE_URL: postgres://postgres:password@localhost:5432/hanami_cli_test
+JRUBY_OPTS: "-X+O"

--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,18 @@ if ENV["RACK_MATRIX_VALUE"]
 end
 
 gem "puma"
-gem "mysql2"
-gem "pg"
-gem "sqlite3"
+
+platforms :ruby do
+  gem "mysql2"
+  gem "pg"
+  gem "sqlite3"
+end
+
+platforms :jruby do
+  gem "jdbc-sqlite3"
+  gem "jdbc-mysql"
+  gem "jdbc-postgres"
+end
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 


### PR DESCRIPTION
The tests success for JRuby is optional, but the CI currently fails in setup, which makes the CI red. This just fixes this one issue (plus adds one thing to env vars), but does not make the JRuby tests pass - the latter is a lot of works and probably should be taken in few smaller steps. Meanwhile, the issue with red CI is problematic.