### PR TITLE
Add `--name` option to `hanami new` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- Add `--name` option to `hanami new`, to specify a custom module namespace while using the positional argument as the directory path. For example, `hanami new my_bookshelf --name=bookshelf` creates the app in `my_bookshelf/` with `Bookshelf` as the module name. (@aaronmallen in #387)
 - Add `--template-engine` option to `hanami generate`, to specify which template engine should be used for generated template file. Supports `erb`, `haml` and `slim`. (@katafrakt in #280)
 
 ### Changed

--- a/lib/hanami/cli/commands/gem/new.rb
+++ b/lib/hanami/cli/commands/gem/new.rb
@@ -107,6 +107,10 @@ module Hanami
                             default: DATABASE_SQLITE,
                             desc: "Database adapter (supported: sqlite, mysql, postgres)"
 
+          # @api private
+          option :name, type: :string, required: false,
+                        desc: "App name to use for the module namespace"
+
           # rubocop:disable Layout/LineLength
           example [
             "bookshelf                                    # Generate a new Hanami app in `bookshelf/' directory, using `Bookshelf' namespace",
@@ -116,7 +120,8 @@ module Hanami
             "bookshelf --skip-assets                      # Generate a new Hanami app without hanami-assets",
             "bookshelf --skip-db                          # Generate a new Hanami app without hanami-db",
             "bookshelf --skip-view                        # Generate a new Hanami app without hanami-view",
-            "bookshelf --database={sqlite|postgres|mysql} # Generate a new Hanami app with a specified database (default: sqlite)"
+            "bookshelf --database={sqlite|postgres|mysql} # Generate a new Hanami app with a specified database (default: sqlite)",
+            "my_bookshelf --name=bookshelf                # Generate a new Hanami app in `my_bookshelf/' directory, using `Bookshelf' namespace"
           ]
           # rubocop:enable Layout/LineLength
 
@@ -147,17 +152,19 @@ module Hanami
             skip_assets: SKIP_ASSETS_DEFAULT,
             skip_db: SKIP_DB_DEFAULT,
             skip_view: SKIP_VIEW_DEFAULT,
-            database: nil
+            database: nil,
+            name: nil
           )
-            app = inflector.underscore(app)
+            directory = inflector.underscore(app)
+            app = inflector.underscore(name || app)
 
-            raise PathAlreadyExistsError.new(app) if fs.exist?(app)
+            raise PathAlreadyExistsError.new(directory) if fs.exist?(directory)
             raise ForbiddenAppNameError.new(app) if FORBIDDEN_APP_NAMES.include?(app)
 
             normalized_database ||= normalize_database(database)
 
-            fs.mkdir(app)
-            fs.chdir(app) do
+            fs.mkdir(directory)
+            fs.chdir(directory) do
               context = Generators::Context.new(
                 inflector,
                 app,

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1386,6 +1386,42 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
     end
   end
 
+  context "with --name" do
+    it "creates the app in the positional arg directory with the given name as module" do
+      expect(bundler).to receive(:install!)
+        .and_return(true)
+
+      expect(bundler).to receive(:exec)
+        .with("hanami install")
+        .and_return(successful_system_call_result)
+
+      expect(bundler).to receive(:exec)
+        .with("check")
+        .at_least(1)
+        .and_return(successful_system_call_result)
+
+      subject.call(app: "my_blog", name: "bookshelf")
+
+      expect(fs.directory?("my_blog")).to be(true)
+
+      fs.chdir("my_blog") do
+        expect(fs.read("config/app.rb")).to include("module Bookshelf")
+      end
+    end
+
+    it "raises PathAlreadyExistsError when the directory already exists" do
+      fs.mkdir("my_blog")
+
+      expect(bundler).to_not receive(:install!)
+      expect(bundler).to_not receive(:exec)
+
+      expect { subject.call(app: "my_blog", name: "bookshelf") }.to raise_error(
+        Hanami::CLI::PathAlreadyExistsError,
+        "Cannot create new Hanami app in an existing path: `my_blog'"
+      )
+    end
+  end
+
   it "doesn't create app in existing folder" do
     fs.mkdir("bookshelf")
 


### PR DESCRIPTION
Allows users to specify a custom module namespace for the generated app while using the positional argument as the directory path.

For example, `hanami new my_bookshelf --name=bookshelf` creates the app in `my_bookshelf/` with `Bookshelf` as the module name.