### PR TITLE
Add compose.yml for new apps

### DIFF
--- a/lib/hanami/cli/generators/gem/app.rb
+++ b/lib/hanami/cli/generators/gem/app.rb
@@ -102,6 +102,10 @@ module Hanami
               if context.generate_sqlite?
                 fs.create("db/.keep", t("keep.erb", context))
               end
+
+              if context.generate_postgres? || context.generate_mysql?
+                fs.create("compose.yml", t("compose.yml.erb", context))
+              end
             end
 
             fs.create("app/operation.rb", t("operation.erb", context))

--- a/lib/hanami/cli/generators/gem/app/compose.yml.erb
+++ b/lib/hanami/cli/generators/gem/app/compose.yml.erb
@@ -1,0 +1,28 @@
+services:
+<%- if generate_postgres? -%>
+  postgres:
+    image: postgres:latest
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_DB: <%= app %>
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
+<%- elsif generate_mysql? -%>
+  mysql:
+    image: mysql:latest
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_DATABASE: <%= app %>
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:
+<%- end -%>

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -1211,6 +1211,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         expect(fs.exist?("config/db/")).to be(false)
         expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
         expect(fs.exist?("db/")).to be(false)
+        expect(fs.exist?("compose.yml")).to be(false)
 
         # bin/setup
         bin_setup = <<~EXPECTED
@@ -1491,6 +1492,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read(".env")).to include("DATABASE_URL=sqlite://db/#{app}.sqlite")
           expect(fs.read(".gitignore")).to include("db/*.sqlite")
           expect(fs.exist?("db/.keep")).to be(true)
+          expect(fs.exist?("compose.yml")).to be(false)
         end
       end
 
@@ -1503,6 +1505,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read(".env")).to include("DATABASE_URL=sqlite://db/#{app}.sqlite")
           expect(fs.read(".gitignore")).to include("db/*.sqlite")
           expect(fs.exist?("db/.keep")).to be(true)
+          expect(fs.exist?("compose.yml")).to be(false)
         end
       end
     end
@@ -1517,6 +1520,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read(".env")).to include("DATABASE_URL=postgres://localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
+          expect(fs.read("compose.yml")).to include("postgres:")
+          expect(fs.read("compose.yml")).to include("POSTGRES_DB: #{app}")
         end
       end
 
@@ -1529,6 +1534,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read(".env")).to include("DATABASE_URL=postgres://localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
+          expect(fs.read("compose.yml")).to include("postgres:")
+          expect(fs.read("compose.yml")).to include("POSTGRES_DB: #{app}")
         end
       end
 
@@ -1541,6 +1548,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read(".env")).to include("DATABASE_URL=postgres://localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
+          expect(fs.read("compose.yml")).to include("postgres:")
+          expect(fs.read("compose.yml")).to include("POSTGRES_DB: #{app}")
         end
       end
     end
@@ -1555,6 +1564,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read(".env")).to include("DATABASE_URL=mysql2://root@localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
+          expect(fs.read("compose.yml")).to include("mysql:")
+          expect(fs.read("compose.yml")).to include("MYSQL_DATABASE: #{app}")
         end
       end
 
@@ -1567,6 +1578,8 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           expect(fs.read(".env")).to include("DATABASE_URL=mysql2://root@localhost/#{app}")
           expect(fs.read(".gitignore")).to_not include("db/*.sqlite")
           expect(fs.exist?("db/")).to be(false)
+          expect(fs.read("compose.yml")).to include("mysql:")
+          expect(fs.read("compose.yml")).to include("MYSQL_DATABASE: #{app}")
         end
       end
     end


### PR DESCRIPTION
## Summary

Generates a `compose.yml` file when a new app is created with either the `postgres` or `mysql` database adapter, so users can spin up a local database with `docker compose up` without any extra setup.

## Design choices

### Why `compose.yml` instead of `docker-compose.yml`

The Compose Specification (which Docker Compose v2 implements) treats `compose.yaml` / `compose.yml` as the canonical filename. `docker-compose.yml` is still supported, but only for backwards compatibility with v1.

From the [Docker documentation](https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file):

> The default path for a Compose file is `compose.yaml` (preferred) or `compose.yml`... Compose also supports `docker-compose.yaml` and `docker-compose.yml` for backwards compatibility.

Generating new projects with the modern name avoids steering users toward a legacy convention they would eventually need to migrate away from.

### Why the database has no password

The generated `compose.yml` uses `POSTGRES_HOST_AUTH_METHOD: trust` for Postgres and `MYSQL_ALLOW_EMPTY_PASSWORD: "yes"` for MySQL. A few reasons:

1. **It is a local development starter, not a production artifact.** Anyone deploying this stack to a real environment is expected to replace the file (or its credentials), which is the same assumption every framework starter makes.
2. **Zero credential plumbing.** A generated password would need to be threaded through `.env`, `config/db.rb`, and the compose `environment` block, and kept in sync across all three. Any drift produces a confusing connection error on first run, which is a bad first experience for a brand new app.
3. **Not network reachable in a meaningful way.** The container only binds to `localhost`, so the unauthenticated socket is not exposed beyond the developer's machine.
4. **Matches the expectations of `hanami db create` out of the box.** Users can run `hanami new`, `docker compose up`, and `hanami db create` in sequence with no further configuration.

closes hanami/roadmap/issues/27