### PR TITLE
Use threads instead of forking to compile slices assets

### DIFF
--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -11,8 +11,8 @@ module Hanami
         module Assets
           # Base class for assets commands.
           #
-          # Finds slices with assets present (anything in an `assets/` dir), then forks a child
-          # process for each slice to run the assets command (`config/assets.js`) for the slice.
+          # Finds slices with assets present (anything in an `assets/` dir), then spawns a thread
+          # for each slice to run the assets command (`config/assets.js`) for the slice.
           #
           # Prefers the slice's own `config/assets.js` if present, otherwise falls back to the
           # app-level file.
@@ -58,15 +58,13 @@ module Hanami
                 end
               end
 
-              pids = slices_with_assets.map { |slice| fork_child_assets_command(slice) }
+              threads = slices_with_assets.map { |slice| spawn_assets_thread(slice) }
 
               Signal.trap("INT") do
-                pids.each do |pid|
-                  Process.kill("INT", pid)
-                end
+                threads.each(&:kill)
               end
 
-              Process.waitall
+              threads.each(&:join)
             end
 
             private
@@ -81,8 +79,8 @@ module Hanami
 
             # @since 2.1.0
             # @api private
-            def fork_child_assets_command(slice)
-              Process.fork do
+            def spawn_assets_thread(slice)
+              Thread.new do
                 cmd, *args = assets_command(slice)
                 system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
               rescue Interrupt

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -33,11 +33,14 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
     end
   end
 
+  let(:thread_double) { double("Thread", kill: nil, join: nil) }
+
   before do
-    # Instead of forking a process per slice, run that code directly. This is is necessary becuase
-    # RSpec method expectations won't work on objects in a forked process.
-    allow(Process).to receive(:fork).and_wrap_original do |_original_method, &block|
+    # Instead of spawning a thread per slice, run that code directly. This is necessary because
+    # RSpec method expectations won't work on objects in a different thread.
+    allow(Thread).to receive(:new).and_wrap_original do |_original_method, &block|
       block.call
+      thread_double
     end
   end
 

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -32,11 +32,14 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
     end
   end
 
+  let(:thread_double) { double("Thread", kill: nil, join: nil) }
+
   before do
-    # Instead of forking a process per slice, run that code directly. This is is necessary becuase
-    # RSpec method expectations won't work on objects in a forked process.
-    allow(Process).to receive(:fork).and_wrap_original do |_original_method, &block|
+    # Instead of spawning a thread per slice, run that code directly. This is necessary because
+    # RSpec method expectations won't work on objects in a different thread.
+    allow(Thread).to receive(:new).and_wrap_original do |_original_method, &block|
       block.call
+      thread_double
     end
   end
 


### PR DESCRIPTION
One of the main blockers for JRuby adoption in Hanami is that Hanami CLI uses `fork` to spawn assets compilation for slices in parallel. I was trying to find a reason why it was done like that for a while, but could not find any. I also recently found https://github.com/hanami/hanami/pull/1524#issuecomment-2977063644 which asks about the same and no conclusion was made.

This PR replaces `Process.fork` with `Thread.new`. In my tests everything still works and assets are being compiled in parallel.