### PR TITLE
Include `rouge` gem in `Gemfile` for new apps

### DIFF
--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -37,9 +37,6 @@ gem "haml"
 <%- if generate_view? && template_engine == "slim" -%>
 gem "slim"
 <%- end -%>
-<%- if generate_db? -%>
-gem "rouge"
-<%- end -%>
 
 group :development do
   <%= hanami_gem("webconsole") %>
@@ -47,6 +44,9 @@ end
 
 group :development, :test do
   gem "dotenv"
+  <%- if generate_db? -%>
+  gem "rouge"
+  <%- end -%>
 end
 
 group :cli, :development do

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -37,6 +37,9 @@ gem "haml"
 <%- if generate_view? && template_engine == "slim" -%>
 gem "slim"
 <%- end -%>
+<%- if generate_db? -%>
+gem "rouge"
+<%- end -%>
 
 group :development do
   <%= hanami_gem("webconsole") %>

--- a/lib/hanami/cli/generators/gem/app/gemfile.erb
+++ b/lib/hanami/cli/generators/gem/app/gemfile.erb
@@ -45,6 +45,7 @@ end
 group :development, :test do
   gem "dotenv"
   <%- if generate_db? -%>
+  # Syntax highlighting SQL logs
   gem "rouge"
   <%- end -%>
 end

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gem "puma", ">= 7.1"
         gem "rake"
         gem "sqlite3"
+        gem "rouge"
 
         group :development do
           gem "hanami-webconsole", "#{hanami_version}"
@@ -575,6 +576,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "puma", ">= 7.1"
           gem "rake"
           gem "sqlite3"
+          gem "rouge"
 
           group :development do
             gem "hanami-webconsole", github: "hanami/hanami-webconsole", branch: "main"
@@ -736,6 +738,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "puma", ">= 7.1"
           gem "rake"
           gem "sqlite3"
+          gem "rouge"
 
           group :development do
             gem "hanami-webconsole", "#{hanami_version}"
@@ -1204,6 +1207,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
       fs.chdir(app) do
         expect(fs.read("Gemfile")).to_not match(/hanami-db/)
+        expect(fs.read("Gemfile")).to_not match(/rouge/)
         expect(fs.read(".env")).to_not include("DATABASE_URL")
         expect(fs.exist?("app/db/repo.rb")).to be(false)
         expect(fs.exist?("app/db/struct.rb")).to be(false)

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         group :development, :test do
           gem "dotenv"
+          # Syntax highlighting SQL logs
           gem "rouge"
         end
 
@@ -583,6 +584,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           group :development, :test do
             gem "dotenv"
+            # Syntax highlighting SQL logs
             gem "rouge"
           end
 
@@ -745,6 +747,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           group :development, :test do
             gem "dotenv"
+            # Syntax highlighting SQL logs
             gem "rouge"
           end
 

--- a/spec/unit/hanami/cli/commands/gem/new_spec.rb
+++ b/spec/unit/hanami/cli/commands/gem/new_spec.rb
@@ -171,7 +171,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
         gem "puma", ">= 7.1"
         gem "rake"
         gem "sqlite3"
-        gem "rouge"
 
         group :development do
           gem "hanami-webconsole", "#{hanami_version}"
@@ -179,6 +178,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
         group :development, :test do
           gem "dotenv"
+          gem "rouge"
         end
 
         group :cli, :development do
@@ -576,7 +576,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "puma", ">= 7.1"
           gem "rake"
           gem "sqlite3"
-          gem "rouge"
 
           group :development do
             gem "hanami-webconsole", github: "hanami/hanami-webconsole", branch: "main"
@@ -584,6 +583,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           group :development, :test do
             gem "dotenv"
+            gem "rouge"
           end
 
           group :cli, :development do
@@ -738,7 +738,6 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
           gem "puma", ">= 7.1"
           gem "rake"
           gem "sqlite3"
-          gem "rouge"
 
           group :development do
             gem "hanami-webconsole", "#{hanami_version}"
@@ -746,6 +745,7 @@ RSpec.describe Hanami::CLI::Commands::Gem::New do
 
           group :development, :test do
             gem "dotenv"
+            gem "rouge"
           end
 
           group :cli, :development do


### PR DESCRIPTION
This PR includes the `rouge` gem in the default `Gemfile` for new apps.  It will not include the gem if `skip-db` flag is passed

Closes [#394](https://github.com/hanami/hanami-cli/issues/394)