### PR TITLE
Fix examples for middleware and routes help

### DIFF
--- a/lib/hanami/cli/commands/app/middleware.rb
+++ b/lib/hanami/cli/commands/app/middleware.rb
@@ -37,8 +37,8 @@ module Hanami
                                   desc: "Include inspected arguments", type: :flag
 
           example [
-            "middleware                  # Print app Rack middleware stack",
-            "middleware --with-arguments # Print app Rack middleware stack, including initialize arguments"
+            "                 # Print app Rack middleware stack",
+            "--with-arguments # Print app Rack middleware stack, including initialize arguments"
           ]
 
           # @since 2.0.0

--- a/lib/hanami/cli/commands/app/routes.rb
+++ b/lib/hanami/cli/commands/app/routes.rb
@@ -45,8 +45,8 @@ module Hanami
                  desc: "Output format"
 
           example [
-            "routes              # Print app routes",
-            "routes --format=csv # Print app routes, using CSV format"
+            "             # Print app routes",
+            "--format=csv # Print app routes, using CSV format"
           ]
 
           # @since 2.0.0


### PR DESCRIPTION
They were showing action name twice, i.e.

```
Examples:
  hanami middleware middleware                  # Print app Rack middleware stack
  hanami middleware middleware --with-arguments # Print app Rack middleware stack, including initialize arguments
```