### PR TITLE
Require dry-cli 1.4 or later

### DIFF
--- a/hanami-cli.gemspec
+++ b/hanami-cli.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.3"
 
   spec.add_runtime_dependency "bundler", ">= 2.1"
-  spec.add_runtime_dependency "dry-cli", "~> 1.0", ">= 1.1.0"
+  spec.add_runtime_dependency "dry-cli", "~> 1.0", ">= 1.4.0"
   spec.add_runtime_dependency "dry-files", "~> 1.0", ">= 1.0.2"
   spec.add_runtime_dependency "dry-inflector", "~> 1.0"
   spec.add_runtime_dependency "irb"

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -14,7 +14,7 @@ gemspec:
   homepage: "https://hanamirb.org"
   runtime_dependencies:
     - ["bundler", ">= 2.1"]
-    - ["dry-cli", "~> 1.0", ">= 1.1.0"]
+    - ["dry-cli", "~> 1.0", ">= 1.4.0"]
     - ["dry-files", "~> 1.0", ">= 1.0.2"]
     - ["dry-inflector", "~> 1.0"]
     - ["irb"]


### PR DESCRIPTION
This will allow us to remove some hacky keyword argument workarounds from hanami-rspec.