### PR TITLE
Fix blank Postgres CLI env values

### DIFF
--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -87,19 +87,10 @@ module Hanami
               end
 
               def cli_env_vars
-                @cli_env_vars ||= {}.tap do |vars|
-                  add_cli_env_var(vars, "PGHOST", database_uri.host)
-                  add_cli_env_var(vars, "PGPORT", database_uri.port)
-                  add_cli_env_var(vars, "PGUSER", database_uri.user)
-                  add_cli_env_var(vars, "PGPASSWORD", database_uri.password)
+                @cli_env_vars ||= %i[host port user password].each_with_object({}) do |field, vars|
+                  value = database_uri.public_send(field).to_s
+                  vars["PG#{field}".upcase] = value unless value.empty?
                 end
-              end
-
-              def add_cli_env_var(vars, name, value)
-                value = value.to_s
-                return if value.empty?
-
-                vars[name] = value
               end
             end
           end

--- a/lib/hanami/cli/commands/app/db/utils/postgres.rb
+++ b/lib/hanami/cli/commands/app/db/utils/postgres.rb
@@ -86,13 +86,20 @@ module Hanami
                 Shellwords.escape(name)
               end
 
-              def cli_env_vars # rubocop:disable Metrics/AbcSize
+              def cli_env_vars
                 @cli_env_vars ||= {}.tap do |vars|
-                  vars["PGHOST"] = database_uri.host.to_s if database_uri.host
-                  vars["PGPORT"] = database_uri.port.to_s if database_uri.port
-                  vars["PGUSER"] = database_uri.user.to_s if database_uri.user
-                  vars["PGPASSWORD"] = database_uri.password.to_s if database_uri.password
+                  add_cli_env_var(vars, "PGHOST", database_uri.host)
+                  add_cli_env_var(vars, "PGPORT", database_uri.port)
+                  add_cli_env_var(vars, "PGUSER", database_uri.user)
+                  add_cli_env_var(vars, "PGPASSWORD", database_uri.password)
                 end
+              end
+
+              def add_cli_env_var(vars, name, value)
+                value = value.to_s
+                return if value.empty?
+
+                vars[name] = value
               end
             end
           end

--- a/spec/unit/hanami/cli/commands/app/db/utils/postgres_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/db/utils/postgres_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "hanami/cli/commands/app/db/utils/postgres"
+
+RSpec.describe Hanami::CLI::Commands::App::DB::Utils::Postgres do
+  subject(:database) {
+    described_class.new(
+      slice: Object.new,
+      gateway_name: :default,
+      system_call: Object.new
+    )
+  }
+
+  let(:database_uri) {
+    Struct.new(:host, :port, :user, :password).new(host, port, user, password)
+  }
+
+  before do
+    allow(database).to receive(:database_uri).and_return(database_uri)
+  end
+
+  describe "#cli_env_vars" do
+    let(:host) { "localhost" }
+    let(:port) { 5433 }
+    let(:user) { "hanami" }
+    let(:password) { "secret" }
+
+    it "uses connection values from the database URL" do
+      expect(database.send(:cli_env_vars)).to eq(
+        "PGHOST" => "localhost",
+        "PGPORT" => "5433",
+        "PGUSER" => "hanami",
+        "PGPASSWORD" => "secret"
+      )
+    end
+
+    context "when the database URL has blank values" do
+      let(:host) { "" }
+      let(:port) { nil }
+      let(:user) { "" }
+      let(:password) { "" }
+
+      it "does not override libpq environment variables" do
+        expect(database.send(:cli_env_vars)).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #412.

`postgres:///db_name` socket-style URLs can leave URI connection fields blank. The db CLI currently turns those blank fields into `PG*` env values, which means `PGHOST=""` can override a caller-provided socket directory and make the Postgres tools fall back to the default socket path.

This keeps the existing behavior for non-empty host/port/user/password values, but skips blank URI fields so libpq can use the surrounding environment. I also added a small Postgres utility spec covering both non-empty values and blank values.

I checked the focused Postgres utility spec, RuboCop on the touched files, Ruby syntax for the touched files, and whitespace before opening this.