### PR TITLE
Add `generate mailer` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 ### Added
 
 - Include `hanami-mailer` in the default `Gemfile`, include sample mailer env vars in `.env`, and generate a base `Mailer` class for the app and each slice (`app/mailer.rb` and `mailer.rb` in slices). Use `hanami new --skip-mailer` to opt out. (@timriley in #420, #425)
+- Add `generate mailer` command. (@timriley in #426)
 - Add `i18n` gem to the default `Gemfile`, and generate a placeholder `config/i18n/en.yml` for the app and each generated slice. (@timriley in #409)
 - Add `--name` option to `hanami new`, to specify a custom module namespace while using the positional argument as the directory path. For example, `hanami new my_bookshelf --name=bookshelf` creates the app in `my_bookshelf/` with `Bookshelf` as the module name. (@aaronmallen in #387)
 - Add `--test` option to `hanami new` to specify which test framework to use. Supports `rspec` (default) and `minitest`. (@timriley in #399)

--- a/lib/hanami/cli/commands/app.rb
+++ b/lib/hanami/cli/commands/app.rb
@@ -60,6 +60,10 @@ module Hanami
                 prefix.register "part", Generate::Part
               end
 
+              if Hanami.bundled?("hanami-mailer")
+                prefix.register "mailer", Generate::Mailer
+              end
+
               if Hanami.bundled?("hanami-db")
                 prefix.register "migration", Generate::Migration
                 prefix.register "relation", Generate::Relation

--- a/lib/hanami/cli/commands/app/generate/mailer.rb
+++ b/lib/hanami/cli/commands/app/generate/mailer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Hanami
+  module CLI
+    module Commands
+      module App
+        module Generate
+          # @api private
+          class Mailer < Command
+            DEFAULT_TEMPLATE_ENGINE = "erb"
+
+            argument :name, required: true, desc: "Mailer name"
+            option :template_engine, required: false,
+              values: %w[erb haml slim],
+              desc: "Template engine to use (default: set in app config or erb)"
+            option :force, required: false, type: :flag, default: false,
+              desc: "Overwrite existing files during generation"
+
+            example [
+              %(welcome               (MyApp::Mailers::Welcome)),
+              %(welcome --slice=admin (Admin::Mailers::Welcome))
+            ]
+
+            def generator_class
+              Generators::App::Mailer
+            end
+
+            def call(name:, slice: nil, template_engine: nil, force: false, **opts)
+              super(name:, slice:, template_engine: template_engine || default_template_engine, force: force)
+            end
+
+            private
+
+            def default_template_engine
+              if Hanami.bundled?("hanami-view") && app.config.views.respond_to?(:default_template_engine)
+                app.config.views.default_template_engine
+              else
+                DEFAULT_TEMPLATE_ENGINE
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/cli/generators/app/mailer.rb
+++ b/lib/hanami/cli/generators/app/mailer.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "dry/files"
+require_relative "../constants"
+require_relative "../../errors"
+
+module Hanami
+  module CLI
+    module Generators
+      module App
+        # @api private
+        class Mailer
+          TEMPLATES_FOLDER = "templates/mailers"
+          DEFAULT_TEMPLATE_ENGINE = "erb"
+
+          def initialize(fs:, inflector:, out: $stdout)
+            @fs = fs
+            @inflector = inflector
+            @out = out
+          end
+
+          def call(key:, namespace:, base_path:, template_engine: DEFAULT_TEMPLATE_ENGINE, force: false)
+            mailer_class_file(key:, namespace:, base_path:).then do |mailer_class|
+              mailer_class.create(force:)
+              mailer_class_name = mailer_class.fully_qualified_name
+              create_template_files(key:, base_path:, mailer_class_name:, template_engine:, force:)
+            end
+          end
+
+          private
+
+          attr_reader :fs, :inflector, :out
+
+          def mailer_class_file(key:, namespace:, base_path:)
+            RubyClassFile.new(
+              fs:, inflector:,
+              namespace:,
+              key:,
+              base_path:,
+              parent_class_name: "#{inflector.camelize(namespace)}::Mailer",
+              extra_namespace: "Mailers"
+            )
+          end
+
+          def create_template_files(key:, base_path:, mailer_class_name:, template_engine:, force:)
+            key_parts = key.split(KEY_SEPARATOR)
+            class_name_from_key = key_parts.pop # takes last segment as the class name
+            module_names_from_key = key_parts # the rest of the segments are the module names
+
+            html_path = template_path(base_path, module_names_from_key, class_name_from_key, "html", template_engine)
+            fs.create(html_path, html_body(mailer_class_name, template_engine), force:)
+
+            text_path = template_path(base_path, module_names_from_key, class_name_from_key, "text", "erb")
+            fs.create(text_path, text_body(mailer_class_name), force:)
+          end
+
+          def template_path(base_path, module_names, name, format, engine)
+            fs.join(
+              base_path,
+              TEMPLATES_FOLDER,
+              module_names,
+              "#{name}.#{format}.#{engine}"
+            )
+          end
+
+          def html_body(mailer_class_name, engine)
+            case engine
+            when "erb" then "<h1>#{mailer_class_name}</h1>\n"
+            when "haml" then "%h1 #{mailer_class_name}\n"
+            when "slim" then "h1 #{mailer_class_name}\n"
+            end
+          end
+
+          def text_body(mailer_class_name)
+            "#{mailer_class_name}\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/cli/commands/app/generate/mailer_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/mailer_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require "hanami"
+
+RSpec.describe Hanami::CLI::Commands::App::Generate::Mailer, :app do
+  subject { described_class.new(fs: fs, out: out, err: err) }
+
+  let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
+  let(:fs) { Hanami::CLI::Files.new(memory: true, out: out) }
+  let(:inflector) { Dry::Inflector.new }
+  let(:app) { Hanami.app.namespace }
+  let(:dir) { inflector.underscore(app) }
+
+  def output
+    out.rewind && out.read.chomp
+  end
+
+  def error_output = err.string.chomp
+
+  context "generating for app" do
+    it "generates a mailer in a top-level namespace" do
+      within_application_directory do
+        subject.call(name: "welcome")
+
+        mailer_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Mailers
+              class Welcome < Test::Mailer
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/mailers/welcome.rb")).to eq(mailer_file)
+        expect(output).to include("Created app/mailers/welcome.rb")
+
+        expect(fs.read("app/templates/mailers/welcome.html.erb")).to eq("<h1>Test::Mailers::Welcome</h1>\n")
+        expect(output).to include("Created app/templates/mailers/welcome.html.erb")
+
+        expect(fs.read("app/templates/mailers/welcome.text.erb")).to eq("Test::Mailers::Welcome\n")
+        expect(output).to include("Created app/templates/mailers/welcome.text.erb")
+      end
+    end
+
+    it "generates a mailer in a deeper namespace" do
+      within_application_directory do
+        subject.call(name: "notifications.welcome")
+
+        mailer_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Test
+            module Mailers
+              module Notifications
+                class Welcome < Test::Mailer
+                end
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("app/mailers/notifications/welcome.rb")).to eq(mailer_file)
+        expect(output).to include("Created app/mailers/notifications/welcome.rb")
+
+        expect(fs.directory?("app/templates/mailers/notifications")).to be(true)
+        expect(fs.read("app/templates/mailers/notifications/welcome.html.erb"))
+          .to eq("<h1>Test::Mailers::Notifications::Welcome</h1>\n")
+        expect(fs.read("app/templates/mailers/notifications/welcome.text.erb"))
+          .to eq("Test::Mailers::Notifications::Welcome\n")
+      end
+    end
+
+    it "allows specifying Slim template engine for the HTML template" do
+      within_application_directory do
+        subject.call(name: "welcome", template_engine: "slim")
+
+        expect(fs.read("app/templates/mailers/welcome.html.slim")).to eq("h1 Test::Mailers::Welcome\n")
+
+        # Text templates remain plain ERB
+        expect(fs.read("app/templates/mailers/welcome.text.erb")).to eq("Test::Mailers::Welcome\n")
+      end
+    end
+
+    it "allows specifying HAML template engine for the HTML template" do
+      within_application_directory do
+        subject.call(name: "welcome", template_engine: "haml")
+
+        expect(fs.read("app/templates/mailers/welcome.html.haml")).to eq("%h1 Test::Mailers::Welcome\n")
+        expect(fs.read("app/templates/mailers/welcome.text.erb")).to eq("Test::Mailers::Welcome\n")
+      end
+    end
+
+    context "with default_template_engine configured" do
+      before do
+        allow(Hanami).to receive(:bundled?).and_call_original
+        allow(Hanami).to receive(:bundled?).with("hanami-view").and_return(true)
+        allow(Hanami).to receive(:prepare)
+
+        views_config = double(default_template_engine: "slim")
+        allow(Hanami.app.config).to receive(:views).and_return(views_config)
+      end
+
+      it "uses the configured template engine for the HTML template" do
+        within_application_directory do
+          subject.call(name: "welcome")
+
+          expect(fs.read("app/templates/mailers/welcome.html.slim")).to eq("h1 Test::Mailers::Welcome\n")
+          expect(output).to include("Created app/templates/mailers/welcome.html.slim")
+        end
+      end
+
+      it "allows overriding the configured template engine" do
+        within_application_directory do
+          subject.call(name: "welcome", template_engine: "haml")
+
+          expect(fs.read("app/templates/mailers/welcome.html.haml")).to eq("%h1 Test::Mailers::Welcome\n")
+          expect(output).to include("Created app/templates/mailers/welcome.html.haml")
+        end
+      end
+    end
+
+    context "with existing mailer file" do
+      let(:file_path) { "app/mailers/welcome.rb" }
+
+      before do
+        within_application_directory do
+          fs.write(file_path, "existing content")
+        end
+      end
+
+      it "exits with error message" do
+        expect do
+          within_application_directory { subject.call(name: "welcome") }
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
+      end
+    end
+
+    context "with existing template file" do
+      let(:file_path) { "app/templates/mailers/welcome.html.erb" }
+
+      before do
+        within_application_directory do
+          fs.write(file_path, "existing content")
+        end
+      end
+
+      it "raises error" do
+        within_application_directory do
+          expect do
+            subject.call(name: "welcome")
+          end.to raise_error SystemExit do |exception|
+            expect(exception.status).to eq 1
+            expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+          end
+        end
+      end
+    end
+
+    context "with existing files and force flag" do
+      let(:mailer_file_path) { "app/mailers/welcome.rb" }
+      let(:template_file_path) { "app/templates/mailers/welcome.html.erb" }
+
+      before do
+        within_application_directory do
+          fs.write(mailer_file_path, "existing mailer content")
+          fs.write(template_file_path, "existing template content")
+        end
+      end
+
+      it "overwrites the mailer file" do
+        within_application_directory do
+          subject.call(name: "welcome", force: true)
+          expect(output).to include("Created #{mailer_file_path}")
+          expect(fs.read(mailer_file_path)).to include("class Welcome < Test::Mailer")
+        end
+      end
+
+      it "overwrites the template file" do
+        within_application_directory do
+          subject.call(name: "welcome", force: true)
+          expect(output).to include("Created #{template_file_path}")
+          expect(fs.read(template_file_path)).to eq("<h1>Test::Mailers::Welcome</h1>\n")
+        end
+      end
+    end
+  end
+
+  context "generating for a slice" do
+    it "generates a mailer in a top-level namespace" do
+      within_application_directory do
+        fs.mkdir("slices/main")
+        subject.call(name: "welcome", slice: "main")
+
+        mailer_file = <<~EXPECTED
+          # frozen_string_literal: true
+
+          module Main
+            module Mailers
+              class Welcome < Main::Mailer
+              end
+            end
+          end
+        EXPECTED
+
+        expect(fs.read("slices/main/mailers/welcome.rb")).to eq(mailer_file)
+        expect(output).to include("Created slices/main/mailers/welcome.rb")
+
+        expect(fs.read("slices/main/templates/mailers/welcome.html.erb")).to eq("<h1>Main::Mailers::Welcome</h1>\n")
+        expect(fs.read("slices/main/templates/mailers/welcome.text.erb")).to eq("Main::Mailers::Welcome\n")
+      end
+    end
+
+    context "with existing mailer file" do
+      let(:file_path) { "slices/main/mailers/welcome.rb" }
+
+      before do
+        within_application_directory do
+          fs.mkdir("slices/main")
+          fs.write(file_path, "existing content")
+        end
+      end
+
+      it "exits with error message" do
+        expect do
+          within_application_directory { subject.call(name: "welcome", slice: "main") }
+        end.to raise_error SystemExit do |exception|
+          expect(exception.status).to eq 1
+          expect(error_output).to eq Hanami::CLI::FileAlreadyExistsError::ERROR_MESSAGE % {file_path:}
+        end
+      end
+    end
+  end
+
+  private
+
+  def within_application_directory
+    fs.mkdir(dir)
+    fs.chdir(dir) do
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            root { "Hello from Hanami" }
+          end
+        end
+      CODE
+
+      fs.write("config/routes.rb", routes)
+
+      yield
+    end
+  end
+end


### PR DESCRIPTION
Like `generate view` this allows preferred HTL template engine to be specified, as well as respecting `config.views.default_template_engine`.

Resolves #421