### PR TITLE
Add skip_tests option to generate mailer/operation

### DIFF
--- a/lib/hanami/cli/commands/app/generate/mailer.rb
+++ b/lib/hanami/cli/commands/app/generate/mailer.rb
@@ -10,9 +10,14 @@ module Hanami
             DEFAULT_TEMPLATE_ENGINE = "erb"
 
             argument :name, required: true, desc: "Mailer name"
+
             option :template_engine, required: false,
               values: %w[erb haml slim],
               desc: "Template engine to use (default: set in app config or erb)"
+
+            option :skip_tests, required: false, type: :flag, default: false,
+              desc: "Skip test generation"
+
             option :force, required: false, type: :flag, default: false,
               desc: "Overwrite existing files during generation"
 
@@ -25,8 +30,9 @@ module Hanami
               Generators::App::Mailer
             end
 
-            def call(name:, slice: nil, template_engine: nil, force: false, **opts)
-              super(name:, slice:, template_engine: template_engine || default_template_engine, force: force)
+            def call(template_engine: nil, **opts)
+              template_engine ||= default_template_engine
+              super(template_engine:, **opts)
             end
 
             private

--- a/lib/hanami/cli/commands/app/generate/operation.rb
+++ b/lib/hanami/cli/commands/app/generate/operation.rb
@@ -9,6 +9,10 @@ module Hanami
           # @api private
           class Operation < Command
             argument :name, required: true, desc: "Operation name"
+
+            option :skip_tests, required: false, type: :flag, default: false,
+              desc: "Skip test generation"
+
             option :force, required: false, type: :flag, default: false,
               desc: "Overwrite existing files during generation"
 

--- a/lib/hanami/cli/commands/app/generate/part.rb
+++ b/lib/hanami/cli/commands/app/generate/part.rb
@@ -12,16 +12,9 @@ module Hanami
           # @since 2.1.0
           # @api private
           class Part < Command
-            DEFAULT_SKIP_TESTS = false
-            private_constant :DEFAULT_SKIP_TESTS
-
             argument :name, required: true, desc: "Part name"
 
-            option \
-              :skip_tests,
-              required: false,
-              type: :flag,
-              default: DEFAULT_SKIP_TESTS,
+            option :skip_tests, required: false, type: :flag, default: false,
               desc: "Skip test generation"
 
             option :force, required: false, type: :flag, default: false,

--- a/lib/hanami/cli/generators/app/mailer.rb
+++ b/lib/hanami/cli/generators/app/mailer.rb
@@ -19,7 +19,7 @@ module Hanami
             @out = out
           end
 
-          def call(key:, namespace:, base_path:, template_engine: DEFAULT_TEMPLATE_ENGINE, force: false)
+          def call(key:, namespace:, base_path:, template_engine: DEFAULT_TEMPLATE_ENGINE, force: false, **)
             mailer_class_file(key:, namespace:, base_path:).then do |mailer_class|
               mailer_class.create(force:)
               mailer_class_name = mailer_class.fully_qualified_name

--- a/lib/hanami/cli/generators/app/operation.rb
+++ b/lib/hanami/cli/generators/app/operation.rb
@@ -19,7 +19,7 @@ module Hanami
 
           # @since 2.2.0
           # @api private
-          def call(key:, namespace:, base_path:, force: false)
+          def call(key:, namespace:, base_path:, force: false, **)
             RubyClassFile.new(
               fs: fs,
               inflector: inflector,

--- a/spec/unit/hanami/cli/commands/app/generate/mailer_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/mailer_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Mailer, :app do
       end
     end
 
+    it "accepts a skip_tests option" do
+      within_application_directory do
+        subject.call(name: "welcome", skip_tests: true)
+
+        expect(fs.exist?("app/mailers/welcome.rb")).to be(true)
+      end
+    end
+
     it "generates a mailer in a deeper namespace" do
       within_application_directory do
         subject.call(name: "notifications.welcome")

--- a/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/generate/operation_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe Hanami::CLI::Commands::App::Generate::Operation, :app do
       expect(output).to include("Created app/admin/books/add.rb")
     end
 
+    it "accepts a skip_tests option" do
+      subject.call(name: "add_book", skip_tests: true)
+
+      expect(fs.exist?("app/add_book.rb")).to be(true)
+    end
+
     context "with existing file" do
       let(:file_path) { "app/admin/books/add.rb" }
 


### PR DESCRIPTION
This will allow our testing gems (hanami-minitest and hanami-rspec) to generate tests as well as skip them if directed.

Resolves #396