### PR TITLE
Provide a way to prevent db command re-runs for test

### DIFF
--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -179,6 +179,9 @@ module Hanami
               # Re-runs in test are for development-env commands only.
               return unless Hanami.env == :development
 
+              # Re-runs have been intentionally switched off
+              return if ENV.fetch("HANAMI_CLI_DB_COMMAND_RE_RUN_IN_TEST", "true") != "true"
+
               cmd = $0
               cmd = "bundle exec #{cmd}" if ENV.key?("BUNDLE_BIN_PATH")
 
@@ -192,7 +195,7 @@ module Hanami
             end
 
             def re_running_in_test?
-              ENV.key?("HANAMI_CLI_DB_COMMAND_RE_RUN_IN_TEST")
+              ENV["HANAMI_CLI_DB_COMMAND_RE_RUN_IN_TEST"] == "true"
             end
 
             # Returns the `ARGV` with every option argument included, but the `-e` or `--env` args


### PR DESCRIPTION
At my workplace, we have a remote development environment named "development" that allows for free-form experimentation with our service infrastructure (yes, this is dumb. No, I can't do anything about it). This environment is isolated from any test systems, so we would like a way to explicitly switch off re-runs when performing `hanami db` commands.

Since we are using this ENV var anyway, there shouldn't be any harm in testing the value explicitly.