### PR TITLE
Add --skip-test-db flag to DB Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 [Unreleased]: https://github.com/hanami/cli/compare/v3.0.0.rc1...HEAD
 
+## [3.0.0] - 2026-06-30
+
+### Added
+
+- Add a `--skip-test-db` flag to `hanami db` commands. By default, running a `db` command in development also re-runs against the test database to keep the two in sync; passing `--skip-test-db` operates on the development database only. (@adamlassek in #430)
+
+[3.0.0]: https://github.com/hanami/cli/compare/v2.3.5...v3.0.0
+
 ## [3.0.0.rc1] - 2026-06-16
 
 ### Added

--- a/lib/hanami/cli/commands/app/db/command.rb
+++ b/lib/hanami/cli/commands/app/db/command.rb
@@ -14,6 +14,42 @@ module Hanami
           # @since 2.2.0
           # @api private
           class Command < App::Command
+            # Overloads {Hanami::CLI::Commands::App::DB::Command#call} to allow skipping test
+            # database operations
+            #
+            # Adds `--skip-test-db` option flag
+            #
+            # @since 3.0.0
+            # @api private
+            module SkipTestDB
+              # @since 3.0.0
+              # @api private
+              def self.prepended(klass)
+                # This module is included each time the class is inherited
+                # Without this check, the --skip-test-db option is duplicated each time
+                unless klass.options.map(&:name).include?(:skip_test_db)
+                  klass.option :skip_test_db, type: :flag, default: false, desc: "Skip test database operations"
+                end
+              end
+
+              # @since 3.0.0
+              # @api private
+              def call(*args, **opts)
+                if opts[:skip_test_db]
+                  ENV["HANAMI_CLI_DB_COMMAND_RE_RUN_IN_TEST"] = "false"
+                end
+
+                super
+              end
+            end
+
+            # @since 3.0.0
+            # @api private
+            def self.inherited(klass)
+              super
+              klass.prepend(SkipTestDB)
+            end
+
             option :app, required: false, type: :flag, default: false, desc: "Use app database"
             option :slice, required: false, desc: "Use database for slice"
 


### PR DESCRIPTION
This is based on the `--env` implementation.