### PR TITLE
 Run per-slice asset commands in threads instead of forking, for JRuby support

### DIFF
--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -91,7 +91,7 @@ module Hanami
             # itself backed by `Open3.popen3`) rather than `Process.fork`, since JRuby's JVM cannot
             # support `fork`.
             #
-            # @since 2.1.0
+            # @since 3.0.1
             # @api private
             def run_assets_command(slice, pids, pids_mutex)
               Thread.new do

--- a/lib/hanami/cli/commands/app/assets/command.rb
+++ b/lib/hanami/cli/commands/app/assets/command.rb
@@ -11,8 +11,8 @@ module Hanami
         module Assets
           # Base class for assets commands.
           #
-          # Finds slices with assets present (anything in an `assets/` dir), then forks a child
-          # process for each slice to run the assets command (`config/assets.js`) for the slice.
+          # Finds slices with assets present (anything in an `assets/` dir), then runs the assets
+          # command (`config/assets.js`) for each slice concurrently, each in its own thread.
           #
           # Prefers the slice's own `config/assets.js` if present, otherwise falls back to the
           # app-level file.
@@ -58,15 +58,22 @@ module Hanami
                 end
               end
 
-              pids = slices_with_assets.map { |slice| fork_child_assets_command(slice) }
+              pids = []
+              pids_mutex = Mutex.new
+
+              threads = slices.map { |slice| run_assets_command(slice, pids, pids_mutex) }
 
               Signal.trap("INT") do
-                pids.each do |pid|
-                  Process.kill("INT", pid)
+                pids_mutex.synchronize do
+                  pids.each do |pid|
+                    Process.kill("INT", pid)
+                  rescue Errno::ESRCH
+                    # Already exited
+                  end
                 end
               end
 
-              Process.waitall
+              threads.each(&:join)
             end
 
             private
@@ -79,15 +86,19 @@ module Hanami
             # @api private
             attr_reader :system_call
 
+            # Runs the assets command for the given slice in its own thread, so that all slices'
+            # assets commands run concurrently. Uses a real OS process (via {InteractiveSystemCall},
+            # itself backed by `Open3.popen3`) rather than `Process.fork`, since JRuby's JVM cannot
+            # support `fork`.
+            #
             # @since 2.1.0
             # @api private
-            def fork_child_assets_command(slice)
-              Process.fork do
+            def run_assets_command(slice, pids, pids_mutex)
+              Thread.new do
                 cmd, *args = assets_command(slice)
-                system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ")
-              rescue Interrupt
-                # When this has been interrupted (by the Signal.trap handler in #call), catch the
-                # interrupt and exit cleanly, without showing the default full backtrace.
+                system_call.call(cmd, *args, out_prefix: "[#{slice.slice_name}] ") { |pid|
+                  pids_mutex.synchronize { pids << pid }
+                }
               end
             end
 

--- a/lib/hanami/cli/interactive_system_call.rb
+++ b/lib/hanami/cli/interactive_system_call.rb
@@ -17,13 +17,15 @@ module Hanami
 
       # @api private
       # @since 2.1.0
-      def call(cmd, *args, env: {}, out_prefix: "")
+      def call(cmd, *args, env: {}, out_prefix: "", &pid_callback)
         ::Bundler.with_original_env do
           threads = []
           exit_status = 0
 
           # rubocop:disable Lint/SuppressedException
           Open3.popen3(env, command(cmd, *args)) do |_stdin, stdout, stderr, wait_thr|
+            pid_callback&.call(wait_thr.pid)
+
             threads << Thread.new do
               stdout.each_line do |line|
                 out.puts("#{out_prefix}#{line}")

--- a/spec/support/app_integration.rb
+++ b/spec/support/app_integration.rb
@@ -27,8 +27,12 @@ RSpec.shared_context "App integration" do
   let(:app_modules) { %i[Test TestApp Admin Main] }
 end
 
+def slice_autoloaders(klass)
+  klass.subclasses.flat_map { |subclass| [subclass.autoloader] + slice_autoloaders(subclass) }
+end
+
 def autoloaders_teardown!
-  ObjectSpace.each_object(Zeitwerk::Loader) do |loader|
+  slice_autoloaders(Hanami::Slice).each do |loader|
     loader.unregister if loader.dirs.any? { |dir|
       dir.include?("/spec/") || dir.include?(Dir.tmpdir) ||
       dir.include?("/slices/") || dir.include?("/app")

--- a/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/compile_spec.rb
@@ -33,14 +33,6 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Compile, "#call", :app_integr
     end
   end
 
-  before do
-    # Instead of forking a process per slice, run that code directly. This is is necessary becuase
-    # RSpec method expectations won't work on objects in a forked process.
-    allow(Process).to receive(:fork).and_wrap_original do |_original_method, &block|
-      block.call
-    end
-  end
-
   describe "assets in app" do
     describe "assets dir present" do
       def before_prepare

--- a/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
+++ b/spec/unit/hanami/cli/commands/app/assets/watch_spec.rb
@@ -32,13 +32,6 @@ RSpec.describe Hanami::CLI::Commands::App::Assets::Watch, "#call", :app_integrat
     end
   end
 
-  before do
-    # Instead of forking a process per slice, run that code directly. This is is necessary becuase
-    # RSpec method expectations won't work on objects in a forked process.
-    allow(Process).to receive(:fork).and_wrap_original do |_original_method, &block|
-      block.call
-    end
-  end
 
   describe "assets in app" do
     describe "assets dir present" do


### PR DESCRIPTION
`Process.fork` has no JVM equivalent, but each forked child only ran
already-subprocess-spawning code (`InteractiveSystemCall`, backed by
Open3.popen3), so a Thread works identically and is portable. Interrupt
handling now signals the real subprocess pid directly rather than an
intermediate forked Ruby process.

Also avoids ObjectSpace.each_object in the `app_integration` spec
support, which JRuby disables by default, mirroring the same fix in
`hanami/hanami`.