### PR TITLE
Fix psqlrc test issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Changed
 
+- Print clearer errors when Postgres CLI commands fail. (@mddelk in #437)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Avoid loading user config when running Postgres CLI commands, to ensure command output is in the expected format. (@mddelk in #437)
 
 ### Security
 

--- a/spec/support/postgres.rb
+++ b/spec/support/postgres.rb
@@ -18,11 +18,11 @@ RSpec.configure do |config|
     }
 
     db_prefix = POSTGRES_BASE_URI.path.sub(%r{^/}, "")
-    psql_list, _status = Open3.capture2(cmd_env, "psql -t -A -c '\\l #{db_prefix}*'")
+    psql_list, _status = Open3.capture2(cmd_env, "psql -t -X -A -c '\\l #{db_prefix}*'")
 
     test_databases = psql_list.split("\n").map { _1.split("|").first }
     test_databases.each do |database|
-      system(cmd_env, "dropdb --force #{database}")
+      system(cmd_env, "dropdb --force #{database}", exception: true)
     end
   end
 end


### PR DESCRIPTION
Add some postgres test support cleanup.

1. Pass `-X` when calling `psql`, to avoid loading user configuration.

We're using `psql` here to list databases, so we need clean output to parse.

This lets us avoid  issues when `.psqlrc` files are present that result in additional stdout, such as:

```
\pset null '(null)'
```

2. Pass `exception: true` when running postgres `system` commands.

This makes errors here more obvious, e.g:

```
Failures:

  1) Hanami::CLI::Commands::App::DB::Create single db in app postgres creates the database
     Failure/Error: system(cmd_env, "dropdb --force #{database}", exception: true)

     RuntimeError:
       Command failed with exit 1: dropdb --force Null display is "(null)".
     # ./spec/support/postgres.rb:25:in 'Kernel#system'
     # ./spec/support/postgres.rb:25:in 'block (3 levels) in <top (required)>'
     # ./spec/support/postgres.rb:24:in 'Array#each'
     # ./spec/support/postgres.rb:24:in 'block (2 levels) in <top (required)>'
```